### PR TITLE
Add declarative event tracking via data attributes

### DIFF
--- a/.claude/skills/waniwani-sdk/mcp/react.md
+++ b/.claude/skills/waniwani-sdk/mcp/react.md
@@ -180,6 +180,24 @@ to context metadata when available.
 | `widget_scroll` | Throttled scroll depth tracking |
 | `widget_form_field` | focusin/focusout on inputs — time in field |
 | `widget_form_submit` | Form submit — time to submit, validation errors |
+| `conversion` | Click on element with `data-ww-conversion` attribute |
+| `step` | Click on element with `data-ww-step` attribute |
+
+### Declarative Data Attributes
+
+Track conversions and funnel steps without calling methods — add data attributes to any clickable element:
+
+```html
+<!-- Conversion: "name key:value key:value ..." -->
+<button data-ww-conversion="purchase value:49.99 currency:EUR">Buy Now</button>
+<button data-ww-conversion="signup">Sign Up Free</button>
+
+<!-- Funnel step: "name key:value key:value ..." (auto-incrementing sequence) -->
+<button data-ww-step="pricing">View Pricing</button>
+<button data-ww-step="select-plan plan:premium">Select Plan</button>
+```
+
+First token is the event name, remaining `key:value` pairs become metadata. Numeric values are auto-coerced. `data-ww-conversion` defaults to `value:0 currency:USD` when omitted. Both use `closest()` so child clicks bubble up.
 
 Requires `WidgetProvider` wrapper (for auto-resolving the JWT token from tool response metadata).
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,40 @@ Flushes and stops transport. Returns:
 - `link.clicked`
 - `purchase.completed`
 
+## Declarative Event Tracking
+
+Track conversions and funnel steps without writing JavaScript — just add data attributes to your HTML elements.
+
+### `data-ww-conversion`
+
+Fires a conversion event on click. Format: `name key:value key:value ...`
+
+```html
+<button data-ww-conversion="purchase value:49.99 currency:EUR">Buy Now</button>
+<button data-ww-conversion="signup">Sign Up Free</button>
+```
+
+| Token | Description |
+|-------|-------------|
+| First token | Conversion name (required) |
+| `value:N` | Numeric conversion value (defaults to `0`) |
+| `currency:X` | Currency code (defaults to `USD`) |
+| Any `key:value` | Included as event metadata |
+
+### `data-ww-step`
+
+Fires a funnel step event on click with an auto-incrementing sequence number. Format: `name key:value key:value ...`
+
+```html
+<button data-ww-step="pricing">View Pricing</button>
+<button data-ww-step="select-plan plan:premium">Select Plan</button>
+<button data-ww-step="checkout">Checkout</button>
+```
+
+Clicking these in order produces steps with `step_sequence` 1, 2, 3. Extra `key:value` pairs are included as event metadata.
+
+Both attributes use `closest()` to walk up the DOM tree, so clicking a child element (e.g. an icon inside a button) works automatically.
+
 ## Quality Gates
 
 Run from repo root:

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@types/react-dom": "^19.2.3",
         "ai": "^6.0.71",
         "clsx": "^2.1.1",
+        "happy-dom": "^20.7.0",
         "lucide-react": "^0.563.0",
         "postcss": "^8.5.6",
         "react": "^19.0.0",
@@ -344,6 +345,10 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
@@ -430,7 +435,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -487,6 +492,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.7.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -912,9 +919,13 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -945,6 +956,8 @@
     "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "@ai-sdk/react/@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@3.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw=="],
   }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@types/react-dom": "^19.2.3",
     "ai": "^6.0.71",
     "clsx": "^2.1.1",
+    "happy-dom": "^20.7.0",
     "lucide-react": "^0.563.0",
     "postcss": "^8.5.6",
     "react": "^19.0.0",

--- a/playground/src/features/playground/index.tsx
+++ b/playground/src/features/playground/index.tsx
@@ -118,6 +118,8 @@ export function Playground({
 
       <button
         type="button"
+        data-ww-step="request-demo"
+        data-ww-conversion="demo-request"
         onClick={() => chatRef.current?.sendMessage("I want to request a demo")}
         style={{
           position: "fixed",
@@ -140,6 +142,7 @@ export function Playground({
 
       <button
         type="button"
+        data-ww-step="emit-event"
         onClick={emitV2TrackingSample}
         disabled={isEmitting}
         style={{

--- a/src/mcp/react/hooks/__tests__/auto-capture.test.ts
+++ b/src/mcp/react/hooks/__tests__/auto-capture.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+import { initAutoCapture } from "../auto-capture";
+import type { WidgetEvent } from "../widget-transport";
+
+let win: InstanceType<typeof GlobalWindow>;
+
+beforeEach(() => {
+	win = new GlobalWindow();
+	globalThis.window = win as unknown as typeof globalThis.window;
+	globalThis.document = win.document as unknown as typeof globalThis.document;
+	globalThis.navigator =
+		win.navigator as unknown as typeof globalThis.navigator;
+});
+
+afterEach(() => {
+	win.close();
+});
+
+function byType(enqueued: WidgetEvent[][], type: string) {
+	return enqueued.filter((batch) => batch[0]?.event_type === type);
+}
+
+describe("data-ww-conversion", () => {
+	let enqueued: WidgetEvent[][];
+	let cleanup: () => void;
+
+	beforeEach(() => {
+		enqueued = [];
+	});
+
+	test("parses name, value, and currency from single attribute", () => {
+		const btn = document.createElement("button");
+		btn.setAttribute("data-ww-conversion", "purchase value:49.99 currency:EUR");
+		document.body.appendChild(btn);
+
+		cleanup = initAutoCapture(
+			{ sessionId: "sess-1", traceId: "trace-1" },
+			(events) => enqueued.push(events),
+		);
+		btn.click();
+
+		const events = byType(enqueued, "conversion");
+		expect(events).toHaveLength(1);
+
+		const event = events[0][0];
+		expect(event.event_type).toBe("conversion");
+		expect(event.event_name).toBe("purchase");
+		expect(event.conversion_value).toBe(49.99);
+		expect(event.conversion_currency).toBe("EUR");
+		expect(event.session_id).toBe("sess-1");
+		expect(event.trace_id).toBe("trace-1");
+
+		cleanup();
+	});
+
+	test("defaults to value=0 and currency=USD when only name given", () => {
+		const btn = document.createElement("button");
+		btn.setAttribute("data-ww-conversion", "signup");
+		document.body.appendChild(btn);
+
+		cleanup = initAutoCapture(
+			{ sessionId: "sess-1", traceId: "trace-1" },
+			(events) => enqueued.push(events),
+		);
+		btn.click();
+
+		const events = byType(enqueued, "conversion");
+		expect(events).toHaveLength(1);
+
+		const event = events[0][0];
+		expect(event.event_name).toBe("signup");
+		expect(event.conversion_value).toBe(0);
+		expect(event.conversion_currency).toBe("USD");
+
+		cleanup();
+	});
+
+	test("click on child bubbles up to find data attribute", () => {
+		const btn = document.createElement("button");
+		btn.setAttribute("data-ww-conversion", "upgrade value:9.99");
+		const span = document.createElement("span");
+		span.textContent = "Upgrade";
+		btn.appendChild(span);
+		document.body.appendChild(btn);
+
+		cleanup = initAutoCapture(
+			{ sessionId: "sess-1", traceId: "trace-1" },
+			(events) => enqueued.push(events),
+		);
+		span.click();
+
+		const events = byType(enqueued, "conversion");
+		expect(events).toHaveLength(1);
+		expect(events[0][0].event_name).toBe("upgrade");
+		expect(events[0][0].conversion_value).toBe(9.99);
+
+		cleanup();
+	});
+
+	test("does not fire without the attribute", () => {
+		const btn = document.createElement("button");
+		btn.textContent = "No tracking";
+		document.body.appendChild(btn);
+
+		cleanup = initAutoCapture(
+			{ sessionId: "sess-1", traceId: "trace-1" },
+			(events) => enqueued.push(events),
+		);
+		btn.click();
+
+		expect(byType(enqueued, "conversion")).toHaveLength(0);
+
+		cleanup();
+	});
+});
+
+describe("data-ww-step", () => {
+	let enqueued: WidgetEvent[][];
+	let cleanup: () => void;
+
+	beforeEach(() => {
+		enqueued = [];
+	});
+
+	test("fires step event with name and auto-incrementing sequence", () => {
+		const btn1 = document.createElement("button");
+		btn1.setAttribute("data-ww-step", "pricing");
+		const btn2 = document.createElement("button");
+		btn2.setAttribute("data-ww-step", "checkout");
+		document.body.appendChild(btn1);
+		document.body.appendChild(btn2);
+
+		cleanup = initAutoCapture(
+			{ sessionId: "sess-1", traceId: "trace-1" },
+			(events) => enqueued.push(events),
+		);
+		btn1.click();
+		btn2.click();
+
+		const events = byType(enqueued, "step");
+		expect(events).toHaveLength(2);
+
+		expect(events[0][0].event_name).toBe("pricing");
+		expect(events[0][0].step_sequence).toBe(1);
+
+		expect(events[1][0].event_name).toBe("checkout");
+		expect(events[1][0].step_sequence).toBe(2);
+
+		cleanup();
+	});
+
+	test("includes extra properties as metadata", () => {
+		const btn = document.createElement("button");
+		btn.setAttribute("data-ww-step", "select-plan plan:premium tier:3");
+		document.body.appendChild(btn);
+
+		cleanup = initAutoCapture(
+			{ sessionId: "sess-1", traceId: "trace-1" },
+			(events) => enqueued.push(events),
+		);
+		btn.click();
+
+		const events = byType(enqueued, "step");
+		expect(events).toHaveLength(1);
+
+		const event = events[0][0];
+		expect(event.event_name).toBe("select-plan");
+		expect(event.step_sequence).toBe(1);
+		expect((event.metadata as Record<string, unknown>)?.plan).toBe("premium");
+		expect((event.metadata as Record<string, unknown>)?.tier).toBe(3);
+
+		cleanup();
+	});
+
+	test("click on child bubbles up to find data attribute", () => {
+		const btn = document.createElement("button");
+		btn.setAttribute("data-ww-step", "confirm");
+		const span = document.createElement("span");
+		span.textContent = "Confirm";
+		btn.appendChild(span);
+		document.body.appendChild(btn);
+
+		cleanup = initAutoCapture(
+			{ sessionId: "sess-1", traceId: "trace-1" },
+			(events) => enqueued.push(events),
+		);
+		span.click();
+
+		const events = byType(enqueued, "step");
+		expect(events).toHaveLength(1);
+		expect(events[0][0].event_name).toBe("confirm");
+
+		cleanup();
+	});
+
+	test("does not fire without the attribute", () => {
+		const btn = document.createElement("button");
+		btn.textContent = "No tracking";
+		document.body.appendChild(btn);
+
+		cleanup = initAutoCapture(
+			{ sessionId: "sess-1", traceId: "trace-1" },
+			(events) => enqueued.push(events),
+		);
+		btn.click();
+
+		expect(byType(enqueued, "step")).toHaveLength(0);
+
+		cleanup();
+	});
+});

--- a/src/mcp/react/hooks/auto-capture.ts
+++ b/src/mcp/react/hooks/auto-capture.ts
@@ -30,6 +30,29 @@ function baseFields(
 	};
 }
 
+/**
+ * Parse a data attribute value into a name and key-value properties.
+ * Format: "name key:value key:value ..."
+ * Values that look numeric are coerced to numbers.
+ */
+function parseAttr(raw: string): {
+	name: string;
+	props: Record<string, string | number>;
+} {
+	const tokens = raw.trim().split(/\s+/);
+	const name = tokens[0] || "";
+	const props: Record<string, string | number> = {};
+	for (let i = 1; i < tokens.length; i++) {
+		const idx = tokens[i].indexOf(":");
+		if (idx === -1) continue;
+		const key = tokens[i].slice(0, idx);
+		const val = tokens[i].slice(idx + 1);
+		const num = Number(val);
+		props[key] = Number.isFinite(num) && val !== "" ? num : val;
+	}
+	return { name, props };
+}
+
 function isFormField(el: HTMLElement): boolean {
 	const tag = el.tagName.toLowerCase();
 	return tag === "input" || tag === "textarea" || tag === "select";
@@ -121,6 +144,60 @@ export function initAutoCapture(
 	document.addEventListener("click", onClick, { capture: true });
 	cleanups.push(() =>
 		document.removeEventListener("click", onClick, { capture: true }),
+	);
+
+	// ── data-ww-conversion ────────────────────────────────────────────
+	// Format: "name value:49.99 currency:EUR"
+	const onConversionClick = (ev: MouseEvent) => {
+		const target = ev.target as HTMLElement | null;
+		const el = target?.closest?.("[data-ww-conversion]") as HTMLElement | null;
+		if (!el) return;
+
+		const { name, props } = parseAttr(
+			el.getAttribute("data-ww-conversion") || "",
+		);
+		if (!name) return;
+
+		enqueue([
+			baseFields(config, "conversion", {
+				event_name: name,
+				conversion_value: typeof props.value === "number" ? props.value : 0,
+				conversion_currency:
+					typeof props.currency === "string" ? props.currency : "USD",
+				metadata: Object.keys(props).length > 0 ? props : undefined,
+			}),
+		]);
+	};
+	document.addEventListener("click", onConversionClick, { capture: true });
+	cleanups.push(() =>
+		document.removeEventListener("click", onConversionClick, {
+			capture: true,
+		}),
+	);
+
+	// ── data-ww-step ─────────────────────────────────────────────────
+	// Format: "name key:value key:value ..."
+	let stepSequence = 0;
+	const onStepClick = (ev: MouseEvent) => {
+		const target = ev.target as HTMLElement | null;
+		const el = target?.closest?.("[data-ww-step]") as HTMLElement | null;
+		if (!el) return;
+
+		const { name, props } = parseAttr(el.getAttribute("data-ww-step") || "");
+		if (!name) return;
+
+		stepSequence++;
+		enqueue([
+			baseFields(config, "step", {
+				event_name: name,
+				step_sequence: stepSequence,
+				metadata: Object.keys(props).length > 0 ? props : undefined,
+			}),
+		]);
+	};
+	document.addEventListener("click", onStepClick, { capture: true });
+	cleanups.push(() =>
+		document.removeEventListener("click", onStepClick, { capture: true }),
 	);
 
 	// ── widget_link_click ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Adds zero-JavaScript event tracking through HTML data attributes: `data-ww-conversion` and `data-ww-step`. Developers can now annotate clickable elements instead of writing tracking code, with automatic event capture via capture-phase listeners.

## Changes
- New `parseAttr()` helper for parsing data attribute values into structured objects
- `data-ww-conversion` listener for tracking conversions with optional value and currency
- `data-ww-step` listener for tracking funnel steps with auto-incrementing sequence numbers
- Comprehensive test coverage using `happy-dom` for DOM simulation
- Updated skill docs and README with examples and token format documentation
- Playground buttons annotated as live usage examples

## Quality
- No CLAUDE.md violations
- No runtime dependency additions (happy-dom is devDependency only)
- All edge cases handled: numeric coercion, empty strings, NaN/Infinity
- Listeners properly registered and cleaned up with capture-phase event handling

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>