### PR TITLE
Simplify conversion tracking interface and auto-track on element interaction

### DIFF
--- a/.claude/skills/waniwani-sdk/SKILL.md
+++ b/.claude/skills/waniwani-sdk/SKILL.md
@@ -194,7 +194,7 @@ Returns `WaniwaniWidget`:
 | `identify(userId, traits?)` | Tie subsequent events to a user |
 | `step(name, meta?)` | Record a funnel step (auto-incrementing sequence) |
 | `track(event, properties?)` | Record a custom event |
-| `conversion(name, { value, currency, meta? })` | Record a revenue attribution event |
+| `conversion(name, data?)` | Record a conversion event |
 
 Auto-captured events: `widget_render`, `widget_click`, `widget_link_click`, `widget_error`, `widget_scroll`, `widget_form_field`, `widget_form_submit`.
 

--- a/.claude/skills/waniwani-sdk/mcp/react.md
+++ b/.claude/skills/waniwani-sdk/mcp/react.md
@@ -167,7 +167,7 @@ to context metadata when available.
 | `identify(userId, traits?)` | Tie subsequent events to a user |
 | `step(name, meta?)` | Record a funnel step (auto-incrementing sequence) |
 | `track(event, properties?)` | Record a custom event |
-| `conversion(name, { value, currency, meta? })` | Record a revenue attribution event |
+| `conversion(name, data?)` | Record a conversion event |
 
 **Auto-captured events:**
 
@@ -197,7 +197,7 @@ Track conversions and funnel steps without calling methods — add data attribut
 <button data-ww-step="select-plan plan:premium">Select Plan</button>
 ```
 
-First token is the event name, remaining `key:value` pairs become metadata. Numeric values are auto-coerced. `data-ww-conversion` defaults to `value:0 currency:USD` when omitted. Both use `closest()` so child clicks bubble up.
+First token is the event name, remaining `key:value` pairs become metadata. Numeric values are auto-coerced. Both use `closest()` so child clicks bubble up.
 
 Requires `WidgetProvider` wrapper (for auto-resolving the JWT token from tool response metadata).
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ Fires a conversion event on click. Format: `name key:value key:value ...`
 | Token | Description |
 |-------|-------------|
 | First token | Conversion name (required) |
-| `value:N` | Numeric conversion value (defaults to `0`) |
-| `currency:X` | Currency code (defaults to `USD`) |
 | Any `key:value` | Included as event metadata |
 
 ### `data-ww-step`

--- a/src/mcp/react/hooks/__tests__/auto-capture.test.ts
+++ b/src/mcp/react/hooks/__tests__/auto-capture.test.ts
@@ -29,7 +29,7 @@ describe("data-ww-conversion", () => {
 		enqueued = [];
 	});
 
-	test("parses name, value, and currency from single attribute", () => {
+	test("parses name and properties from single attribute", () => {
 		const btn = document.createElement("button");
 		btn.setAttribute("data-ww-conversion", "purchase value:49.99 currency:EUR");
 		document.body.appendChild(btn);
@@ -46,15 +46,15 @@ describe("data-ww-conversion", () => {
 		const event = events[0][0];
 		expect(event.event_type).toBe("conversion");
 		expect(event.event_name).toBe("purchase");
-		expect(event.conversion_value).toBe(49.99);
-		expect(event.conversion_currency).toBe("EUR");
+		expect((event.metadata as Record<string, unknown>)?.value).toBe(49.99);
+		expect((event.metadata as Record<string, unknown>)?.currency).toBe("EUR");
 		expect(event.session_id).toBe("sess-1");
 		expect(event.trace_id).toBe("trace-1");
 
 		cleanup();
 	});
 
-	test("defaults to value=0 and currency=USD when only name given", () => {
+	test("sends no metadata when only name given", () => {
 		const btn = document.createElement("button");
 		btn.setAttribute("data-ww-conversion", "signup");
 		document.body.appendChild(btn);
@@ -70,8 +70,7 @@ describe("data-ww-conversion", () => {
 
 		const event = events[0][0];
 		expect(event.event_name).toBe("signup");
-		expect(event.conversion_value).toBe(0);
-		expect(event.conversion_currency).toBe("USD");
+		expect(event.metadata).toBe(undefined);
 
 		cleanup();
 	});
@@ -93,7 +92,9 @@ describe("data-ww-conversion", () => {
 		const events = byType(enqueued, "conversion");
 		expect(events).toHaveLength(1);
 		expect(events[0][0].event_name).toBe("upgrade");
-		expect(events[0][0].conversion_value).toBe(9.99);
+		expect((events[0][0].metadata as Record<string, unknown>)?.value).toBe(
+			9.99,
+		);
 
 		cleanup();
 	});

--- a/src/mcp/react/hooks/auto-capture.ts
+++ b/src/mcp/react/hooks/auto-capture.ts
@@ -147,7 +147,7 @@ export function initAutoCapture(
 	);
 
 	// ── data-ww-conversion ────────────────────────────────────────────
-	// Format: "name value:49.99 currency:EUR"
+	// Format: "name key:value key:value ..."
 	const onConversionClick = (ev: MouseEvent) => {
 		const target = ev.target as HTMLElement | null;
 		const el = target?.closest?.("[data-ww-conversion]") as HTMLElement | null;
@@ -161,9 +161,6 @@ export function initAutoCapture(
 		enqueue([
 			baseFields(config, "conversion", {
 				event_name: name,
-				conversion_value: typeof props.value === "number" ? props.value : 0,
-				conversion_currency:
-					typeof props.currency === "string" ? props.currency : "USD",
 				metadata: Object.keys(props).length > 0 ? props : undefined,
 			}),
 		]);

--- a/src/mcp/react/hooks/use-waniwani.ts
+++ b/src/mcp/react/hooks/use-waniwani.ts
@@ -60,15 +60,8 @@ export interface WaniwaniWidget {
 	step(name: string, meta?: Record<string, unknown>): void;
 	/** Record a generic custom event. */
 	track(event: string, properties?: Record<string, unknown>): void;
-	/** Record a revenue attribution event. */
-	conversion(
-		name: string,
-		data: {
-			value: number;
-			currency: string;
-			meta?: Record<string, unknown>;
-		},
-	): void;
+	/** Record a conversion event. */
+	conversion(name: string, data?: Record<string, unknown>): void;
 }
 
 /** No-op widget that silently discards all calls. */
@@ -243,20 +236,11 @@ function createState(
 				]);
 			},
 
-			conversion(
-				name: string,
-				data: {
-					value: number;
-					currency: string;
-					meta?: Record<string, unknown>;
-				},
-			) {
+			conversion(name: string, data?: Record<string, unknown>) {
 				enqueue([
 					baseFields("conversion", {
 						event_name: name,
-						conversion_value: data.value,
-						conversion_currency: data.currency,
-						metadata: data.meta,
+						metadata: data,
 					}),
 				]);
 			},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Public widget tracking API/semantics for `conversion` events change (signature and payload fields), which may break consumers or backend expectations around `conversion_value`/`conversion_currency`. The implementation is small and well-covered by updated tests/docs, but affects analytics data shape.
> 
> **Overview**
> Simplifies widget conversion tracking by changing `WaniwaniWidget.conversion` to accept an optional free-form metadata object (`conversion(name, data?)`) instead of a required `{ value, currency, meta }` payload.
> 
> Updates DOM auto-capture for `data-ww-conversion` to emit only parsed `key:value` pairs as `metadata` (no default `value`/`currency`, and no dedicated `conversion_value`/`conversion_currency` fields), with corresponding test and documentation updates in `README.md` and the SDK skill/docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 765b46d5e7318fcfa6d07b2e58f8131325a0b0bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->