### PR TITLE
fix: interrupt unanswered questions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@waniwani/cli",

--- a/src/mcp/server/flows/__tests__/compile.test.ts
+++ b/src/mcp/server/flows/__tests__/compile.test.ts
@@ -376,6 +376,135 @@ describe("compileFlow response contract", () => {
 		expect(p3.status).toBe("complete");
 	});
 
+	test("interrupt loops when AI drops _meta.flow.questions (no cached questions)", async () => {
+		const flow = createFlow({
+			id: "no_cache_flow",
+			title: "No Cache Flow",
+			description: "Test fallback when AI drops questions cache.",
+			state: {
+				name: z.string().describe("User name"),
+				email: z.string().describe("User email"),
+				company: z.string().describe("Company name"),
+				role: z.string().describe("User role"),
+			},
+		})
+			.addNode("ask_details", () =>
+				interrupt({
+					questions: [
+						{ question: "Name?", field: "name" },
+						{ question: "Email?", field: "email" },
+						{ question: "Company?", field: "company" },
+						{ question: "Role?", field: "role" },
+					],
+					context: "Ask all together.",
+				}),
+			)
+			.addEdge(START, "ask_details")
+			.addEdge("ask_details", END)
+			.compile();
+
+		const { server, registered } = mockServer();
+		await flow.register(server);
+		const handler = registered[0]?.[2];
+
+		// Step 1: Start — get all 4 questions
+		const r1 = (await handler?.({ action: "start" }, {})) as Record<
+			string,
+			unknown
+		>;
+		const p1 = JSON.parse(
+			(r1.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		expect(p1.status).toBe("interrupt");
+		expect(p1.questions).toHaveLength(4);
+
+		// Step 2: Continue with NO answers and WITHOUT passing back questions
+		// (simulates AI dropping _meta.flow.questions)
+		const meta1 = (r1._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		const r2 = (await handler?.(
+			{
+				action: "continue",
+				stateUpdates: {},
+				_meta: {
+					flow: {
+						step: meta1.step,
+						state: meta1.state,
+						// intentionally omitting: questions, interruptContext
+					},
+				},
+			},
+			{},
+		)) as Record<string, unknown>;
+		const p2 = JSON.parse(
+			(r2.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		// Should still interrupt with all 4 questions — NOT advance to next node
+		expect(p2.status).toBe("interrupt");
+		expect(p2.questions).toHaveLength(4);
+
+		// Step 3: Answer 2 of 4 without questions cache
+		const meta2 = (r2._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		const r3 = (await handler?.(
+			{
+				action: "continue",
+				stateUpdates: { name: "Alice", email: "alice@test.com" },
+				_meta: {
+					flow: {
+						step: meta2.step,
+						state: meta2.state,
+						// intentionally omitting questions again
+					},
+				},
+			},
+			{},
+		)) as Record<string, unknown>;
+		const p3 = JSON.parse(
+			(r3.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		// Should loop with 2 remaining questions
+		expect(p3.status).toBe("interrupt");
+		expect(p3.questions).toHaveLength(2);
+		const fields3 = (p3.questions as Array<{ field: string }>).map(
+			(q) => q.field,
+		);
+		expect(fields3).toContain("company");
+		expect(fields3).toContain("role");
+
+		// Step 4: Answer all remaining — should complete
+		const meta3 = (r3._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		const r4 = (await handler?.(
+			{
+				action: "continue",
+				stateUpdates: { company: "Acme", role: "Engineer" },
+				_meta: {
+					flow: {
+						step: meta3.step,
+						state: meta3.state,
+						// omitting questions — still works
+					},
+				},
+			},
+			{},
+		)) as Record<string, unknown>;
+		const p4 = JSON.parse(
+			(r4.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		expect(p4.status).toBe("complete");
+	});
+
 	test("returns widget JSON content and _meta.flow for widget steps", async () => {
 		const resource = {
 			id: "plan_picker",

--- a/src/mcp/server/flows/__tests__/compile.test.ts
+++ b/src/mcp/server/flows/__tests__/compile.test.ts
@@ -505,6 +505,79 @@ describe("compileFlow response contract", () => {
 		expect(p4.status).toBe("complete");
 	});
 
+	test("widget continue without field advances to next node (no stuck loop)", async () => {
+		const resource = {
+			id: "info_panel",
+			title: "Info Panel",
+			description: "Display info",
+			openaiUri: "ui://widgets/apps-sdk/info_panel.html",
+			mcpUri: "ui://widgets/ext-apps/info_panel.html",
+			autoHeight: true,
+			register: async () => {},
+		};
+
+		const flow = createFlow({
+			id: "widget_no_field_flow",
+			title: "Widget No Field Flow",
+			description: "Widget without a field should advance on continue.",
+			state: {
+				result: z.string().describe("Final result"),
+			},
+		})
+			.addNode("show_info", {
+				resource,
+				// no field — widget is informational only
+				data: { message: "Hello" },
+				description: "Show info panel",
+			})
+			.addNode("done", () => ({ result: "finished" }))
+			.addEdge(START, "show_info")
+			.addEdge("show_info", "done")
+			.addEdge("done", END)
+			.compile();
+
+		const { server, registered } = mockServer();
+		await flow.register(server);
+		const handler = registered[0]?.[2];
+
+		// Start — should show widget
+		const r1 = (await handler?.({ action: "start" }, {})) as Record<
+			string,
+			unknown
+		>;
+		const p1 = JSON.parse(
+			(r1.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+		expect(p1.status).toBe("widget");
+
+		const meta1 = (r1._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		expect(meta1.widgetId).toBe("info_panel");
+
+		// Continue from widget — should advance to "done" and complete
+		const r2 = (await handler?.(
+			{
+				action: "continue",
+				_meta: {
+					flow: {
+						step: meta1.step,
+						state: meta1.state,
+						widgetId: meta1.widgetId,
+					},
+				},
+			},
+			{},
+		)) as Record<string, unknown>;
+		const p2 = JSON.parse(
+			(r2.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		// Must complete — NOT show the widget again
+		expect(p2.status).toBe("complete");
+	});
+
 	test("returns widget JSON content and _meta.flow for widget steps", async () => {
 		const resource = {
 			id: "plan_picker",

--- a/src/mcp/server/flows/__tests__/compile.test.ts
+++ b/src/mcp/server/flows/__tests__/compile.test.ts
@@ -123,6 +123,259 @@ describe("compileFlow response contract", () => {
 		});
 	});
 
+	test("multi-question interrupt loops with unanswered questions when user answers partially", async () => {
+		const flow = createFlow({
+			id: "multi_q_flow",
+			title: "Multi Question Flow",
+			description: "Collect multiple details.",
+			state: {
+				name: z.string().describe("User name"),
+				email: z.string().describe("User email"),
+				company: z.string().describe("Company name"),
+			},
+		})
+			.addNode("ask_details", () =>
+				interrupt({
+					questions: [
+						{ question: "What's your name?", field: "name" },
+						{ question: "What's your email?", field: "email" },
+						{ question: "What's your company?", field: "company" },
+					],
+					context: "Ask all questions together.",
+				}),
+			)
+			.addEdge(START, "ask_details")
+			.addEdge("ask_details", END)
+			.compile();
+
+		const { server, registered } = mockServer();
+		await flow.register(server);
+		const handler = registered[0]?.[2];
+
+		// Step 1: Start — should get all 3 questions
+		const r1 = (await handler?.({ action: "start" }, {})) as Record<
+			string,
+			unknown
+		>;
+		const p1 = JSON.parse(
+			(r1.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		expect(p1.status).toBe("interrupt");
+		expect(p1.questions).toHaveLength(3);
+
+		// Step 2: User answers only name — should loop with 2 remaining questions
+		const meta1 = (r1._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		const r2 = (await handler?.(
+			{
+				action: "continue",
+				stateUpdates: { name: "Alice" },
+				_meta: { flow: meta1 },
+			},
+			{},
+		)) as Record<string, unknown>;
+		const p2 = JSON.parse(
+			(r2.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		expect(p2.status).toBe("interrupt");
+		expect(p2.questions).toHaveLength(2);
+		const fields2 = (p2.questions as Array<{ field: string }>).map(
+			(q) => q.field,
+		);
+		expect(fields2).toContain("email");
+		expect(fields2).toContain("company");
+		expect(fields2.includes("name")).toBe(false);
+
+		// Step 3: User answers email only — should loop with 1 remaining question (single-question shorthand)
+		const meta2 = (r2._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		const r3 = (await handler?.(
+			{
+				action: "continue",
+				stateUpdates: { email: "alice@example.com" },
+				_meta: { flow: meta2 },
+			},
+			{},
+		)) as Record<string, unknown>;
+		const p3 = JSON.parse(
+			(r3.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		expect(p3.status).toBe("interrupt");
+		// Should be single-question shorthand (unwrapped)
+		expect(p3.question).toBe("What's your company?");
+		expect(p3.field).toBe("company");
+		expect(p3.questions).toBe(undefined);
+
+		// Step 4: User answers company — should complete
+		const meta3 = (r3._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		const r4 = (await handler?.(
+			{
+				action: "continue",
+				stateUpdates: { company: "Acme Inc" },
+				_meta: { flow: meta3 },
+			},
+			{},
+		)) as Record<string, unknown>;
+		const p4 = JSON.parse(
+			(r4.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		expect(p4.status).toBe("complete");
+		// Verify final state has all answers
+		const meta4 = (r4._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		expect(meta4?.state).toMatchObject({
+			name: "Alice",
+			email: "alice@example.com",
+			company: "Acme Inc",
+		});
+	});
+
+	test("multi-question interrupt completes when all questions answered at once", async () => {
+		const flow = createFlow({
+			id: "multi_q_all_at_once",
+			title: "Multi Q All At Once",
+			description: "Collect multiple details.",
+			state: {
+				name: z.string().describe("User name"),
+				email: z.string().describe("User email"),
+			},
+		})
+			.addNode("ask_details", () =>
+				interrupt({
+					questions: [
+						{ question: "What's your name?", field: "name" },
+						{ question: "What's your email?", field: "email" },
+					],
+				}),
+			)
+			.addEdge(START, "ask_details")
+			.addEdge("ask_details", END)
+			.compile();
+
+		const { server, registered } = mockServer();
+		await flow.register(server);
+		const handler = registered[0]?.[2];
+
+		// Start
+		const r1 = (await handler?.({ action: "start" }, {})) as Record<
+			string,
+			unknown
+		>;
+		const meta1 = (r1._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+
+		// Answer both at once — should complete
+		const r2 = (await handler?.(
+			{
+				action: "continue",
+				stateUpdates: { name: "Bob", email: "bob@test.com" },
+				_meta: { flow: meta1 },
+			},
+			{},
+		)) as Record<string, unknown>;
+		const p2 = JSON.parse(
+			(r2.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+
+		expect(p2.status).toBe("complete");
+	});
+
+	test("partial-answer continue does not re-execute the node handler (no side-effect replay)", async () => {
+		let handlerCallCount = 0;
+
+		const flow = createFlow({
+			id: "side_effect_flow",
+			title: "Side Effect Flow",
+			description: "Test handler is not re-called on partial answers.",
+			state: {
+				name: z.string().describe("User name"),
+				email: z.string().describe("User email"),
+			},
+		})
+			.addNode("ask_details", () => {
+				handlerCallCount++;
+				return interrupt({
+					questions: [
+						{ question: "Name?", field: "name" },
+						{ question: "Email?", field: "email" },
+					],
+				});
+			})
+			.addEdge(START, "ask_details")
+			.addEdge("ask_details", END)
+			.compile();
+
+		const { server, registered } = mockServer();
+		await flow.register(server);
+		const handler = registered[0]?.[2];
+
+		// Start — handler called once
+		const r1 = (await handler?.({ action: "start" }, {})) as Record<
+			string,
+			unknown
+		>;
+		expect(handlerCallCount).toBe(1);
+
+		// Partial answer — handler should NOT be called again
+		const meta1 = (r1._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		const r2 = (await handler?.(
+			{
+				action: "continue",
+				stateUpdates: { name: "Alice" },
+				_meta: { flow: meta1 },
+			},
+			{},
+		)) as Record<string, unknown>;
+		expect(handlerCallCount).toBe(1); // Still 1 — no replay
+
+		const p2 = JSON.parse(
+			(r2.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+		expect(p2.status).toBe("interrupt");
+		expect(p2.field).toBe("email");
+
+		// Final answer — handler called once more when advancing past the node
+		const meta2 = (r2._meta as Record<string, unknown>)?.flow as Record<
+			string,
+			unknown
+		>;
+		const r3 = (await handler?.(
+			{
+				action: "continue",
+				stateUpdates: { email: "alice@test.com" },
+				_meta: { flow: meta2 },
+			},
+			{},
+		)) as Record<string, unknown>;
+		// Handler is called once more because we advance to next node (END)
+		// via executeFrom, which doesn't re-execute ask_details since questions
+		// are resolved in handleToolCall before advancing
+		expect(handlerCallCount).toBe(1); // Still 1 — resolved from cache
+
+		const p3 = JSON.parse(
+			(r3.content as Array<{ text: string }>)[0]?.text ?? "",
+		) as Record<string, unknown>;
+		expect(p3.status).toBe("complete");
+	});
+
 	test("returns widget JSON content and _meta.flow for widget steps", async () => {
 		const resource = {
 			id: "plan_picker",

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -532,27 +532,33 @@ export function compileFlow<TState extends Record<string, unknown>>(
 					updatedState,
 				);
 				if (interruptResult) return interruptResult;
-				// All questions answered — fall through to advance
+
+				// All questions answered — advance to the next node
+				const edge = edges.get(step);
+				if (!edge) {
+					return {
+						payload: {
+							status: "error",
+							error: `No edge from step "${step}"`,
+						},
+					};
+				}
+				const nextNode = await resolveNextNode(edge, updatedState);
+				return executeFrom(
+					nextNode,
+					updatedState,
+					nodes,
+					nodeConfigs,
+					edges,
+					meta,
+				);
 			}
 
-			const edge = edges.get(step);
-			if (!edge) {
-				return {
-					payload: {
-						status: "error",
-						error: `No edge from step "${step}"`,
-					},
-				};
-			}
-			const nextNode = await resolveNextNode(edge, updatedState);
-			return executeFrom(
-				nextNode,
-				updatedState,
-				nodes,
-				nodeConfigs,
-				edges,
-				meta,
-			);
+			// No cached questions — the AI may have dropped _meta.flow.questions.
+			// Re-execute from the current step so the handler can re-check
+			// unanswered questions (interrupt nodes) or auto-skip (widget nodes
+			// whose field is already filled).
+			return executeFrom(step, updatedState, nodes, nodeConfigs, edges, meta);
 		}
 
 		return {

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -554,10 +554,33 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				);
 			}
 
-			// No cached questions — the AI may have dropped _meta.flow.questions.
-			// Re-execute from the current step so the handler can re-check
-			// unanswered questions (interrupt nodes) or auto-skip (widget nodes
-			// whose field is already filled).
+			// Widget continues never have cached questions — advance to next node
+			// (same as the old behavior). Re-executing the handler would cause a
+			// stuck loop for widgets without a field.
+			if (inputMeta.widgetId) {
+				const edge = edges.get(step);
+				if (!edge) {
+					return {
+						payload: {
+							status: "error",
+							error: `No edge from step "${step}"`,
+						},
+					};
+				}
+				const nextNode = await resolveNextNode(edge, updatedState);
+				return executeFrom(
+					nextNode,
+					updatedState,
+					nodes,
+					nodeConfigs,
+					edges,
+					meta,
+				);
+			}
+
+			// No cached questions and not a widget — the AI may have dropped
+			// _meta.flow.questions. Re-execute from the current step so the
+			// handler can re-check unanswered questions.
 			return executeFrom(step, updatedState, nodes, nodeConfigs, edges, meta);
 		}
 

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -532,8 +532,15 @@ export function compileFlow<TState extends Record<string, unknown>>(
 					updatedState,
 				);
 				if (interruptResult) return interruptResult;
+				// All questions answered — fall through to advance
+			}
 
-				// All questions answered — advance to the next node
+			// Advance to next node when: all cached questions are answered, or
+			// this is a widget continue (widgets never have cached questions and
+			// re-executing the handler would cause a stuck loop for field-less widgets).
+			// Otherwise the AI may have dropped _meta.flow.questions — re-execute
+			// from the current step so the handler can re-check unanswered questions.
+			if (inputMeta.questions || inputMeta.widgetId) {
 				const edge = edges.get(step);
 				if (!edge) {
 					return {
@@ -554,33 +561,6 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				);
 			}
 
-			// Widget continues never have cached questions — advance to next node
-			// (same as the old behavior). Re-executing the handler would cause a
-			// stuck loop for widgets without a field.
-			if (inputMeta.widgetId) {
-				const edge = edges.get(step);
-				if (!edge) {
-					return {
-						payload: {
-							status: "error",
-							error: `No edge from step "${step}"`,
-						},
-					};
-				}
-				const nextNode = await resolveNextNode(edge, updatedState);
-				return executeFrom(
-					nextNode,
-					updatedState,
-					nodes,
-					nodeConfigs,
-					edges,
-					meta,
-				);
-			}
-
-			// No cached questions and not a widget — the AI may have dropped
-			// _meta.flow.questions. Re-execute from the current step so the
-			// handler can re-check unanswered questions.
 			return executeFrom(step, updatedState, nodes, nodeConfigs, edges, meta);
 		}
 

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -39,6 +39,15 @@ type FlowToolInput = {
 			state?: Record<string, unknown>;
 			field?: string;
 			widgetId?: string;
+			/** Cached interrupt questions from the previous response — used to avoid re-executing the handler */
+			questions?: Array<{
+				question: string;
+				field: string;
+				suggestions?: string[];
+				context?: string;
+			}>;
+			/** Cached overall interrupt context */
+			interruptContext?: string;
 		};
 	};
 };
@@ -57,6 +66,15 @@ type ExecutionResult = {
 		state: Record<string, unknown>;
 		field?: string;
 		widgetId?: string;
+		/** Cached interrupt questions — avoids re-executing the handler on partial answers */
+		questions?: Array<{
+			question: string;
+			field: string;
+			suggestions?: string[];
+			context?: string;
+		}>;
+		/** Cached overall interrupt context */
+		interruptContext?: string;
 	};
 };
 
@@ -126,7 +144,8 @@ function buildFlowProtocol(config: FlowConfig): string {
 		"",
 		"3. ALWAYS pass back the `state` object exactly as received.",
 		"4. Do NOT invent state values. Only use `stateUpdates` for information the user explicitly provided.",
-		"5. Always include answers for all pending fields in `stateUpdates` when resuming.",
+		"5. Include only the fields the user actually answered in `stateUpdates` — do NOT guess missing ones.",
+		"   If the user did not answer all pending questions, the engine will re-prompt for the remaining ones.",
 		"   If the user mentioned values for other known fields, include those too —",
 		"   they will be applied immediately and those steps will be auto-skipped.",
 	);
@@ -139,12 +158,21 @@ function getInputMeta(args: FlowToolInput): {
 	state: Record<string, unknown>;
 	field?: string;
 	widgetId?: string;
+	questions?: Array<{
+		question: string;
+		field: string;
+		suggestions?: string[];
+		context?: string;
+	}>;
+	interruptContext?: string;
 } {
 	const state = args._meta?.flow?.state ?? {};
 	const step = args._meta?.flow?.step;
 	const field = args._meta?.flow?.field;
 	const widgetId = args._meta?.flow?.widgetId;
-	return { step, state, field, widgetId };
+	const questions = args._meta?.flow?.questions;
+	const interruptContext = args._meta?.flow?.interruptContext;
+	return { step, state, field, widgetId, questions, interruptContext };
 }
 
 // ============================================================================
@@ -157,6 +185,81 @@ async function resolveNextNode<TState extends Record<string, unknown>>(
 ): Promise<string> {
 	if (edge.type === "direct") return edge.to;
 	return edge.condition(state);
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Check whether a state value counts as "filled" (not empty/missing). */
+function isFilled(v: unknown): boolean {
+	return v !== undefined && v !== null && v !== "";
+}
+
+// ============================================================================
+// Interrupt result builder
+// ============================================================================
+
+type InterruptQuestionData = {
+	question: string;
+	field: string;
+	suggestions?: string[];
+	context?: string;
+};
+
+/**
+ * Build an interrupt ExecutionResult from a list of questions and current state.
+ * Filters out already-answered questions and caches the full question list in
+ * flowMeta so partial-answer continues can filter without re-executing the handler.
+ *
+ * Returns `null` when all questions are already filled (caller should advance).
+ */
+function buildInterruptResult<TState extends Record<string, unknown>>(
+	questions: InterruptQuestionData[],
+	context: string | undefined,
+	currentNode: string,
+	state: TState,
+): ExecutionResult | null {
+	// All filled — caller should advance to the next node
+	if (questions.every((q) => isFilled(state[q.field as keyof TState]))) {
+		return null;
+	}
+
+	// Filter out questions whose fields are already answered
+	const unanswered = questions.filter(
+		(q) => !isFilled(state[q.field as keyof TState]),
+	);
+
+	// Single-question shorthand: unwrap for cleaner AI payload
+	const isSingle = unanswered.length === 1;
+	const q0 = unanswered[0];
+	const payload =
+		isSingle && q0
+			? {
+					status: "interrupt" as const,
+					question: q0.question,
+					field: q0.field,
+					...(q0.suggestions ? { suggestions: q0.suggestions } : {}),
+					...(q0.context || context ? { context: q0.context ?? context } : {}),
+				}
+			: {
+					status: "interrupt" as const,
+					questions: unanswered,
+					...(context ? { context } : {}),
+				};
+
+	return {
+		payload,
+		flowMeta: {
+			step: currentNode,
+			state,
+			...(isSingle && q0 ? { field: q0.field } : {}),
+			// Cache the full question list so partial-answer continues
+			// can filter without re-executing the node handler.
+			questions,
+			...(context ? { interruptContext: context } : {}),
+		},
+	};
 }
 
 // ============================================================================
@@ -202,53 +305,26 @@ async function executeFrom<TState extends Record<string, unknown>>(
 
 			// Interrupt signal — pause and ask the user one or more questions
 			if (isInterrupt(result)) {
-				// Auto-skip: advance only when ALL question fields are already in state
-				const allFilled = result.questions.every((q) => {
-					const v = state[q.field as keyof TState];
-					return v !== undefined && v !== null && v !== "";
-				});
-				if (allFilled) {
-					const edge = edges.get(currentNode);
-					if (!edge) {
-						return {
-							payload: {
-								status: "error",
-								error: `No outgoing edge from node "${currentNode}"`,
-							},
-						};
-					}
-					currentNode = await resolveNextNode(edge, state);
-					continue;
+				const interruptResult = buildInterruptResult(
+					result.questions,
+					result.context,
+					currentNode,
+					state,
+				);
+				if (interruptResult) return interruptResult;
+
+				// All questions filled — auto-skip to next node
+				const edge = edges.get(currentNode);
+				if (!edge) {
+					return {
+						payload: {
+							status: "error",
+							error: `No outgoing edge from node "${currentNode}"`,
+						},
+					};
 				}
-
-				// Single-question shorthand: unwrap for cleaner AI payload
-				const isSingle = result.questions.length === 1;
-				const q0 = result.questions[0];
-				const payload =
-					isSingle && q0
-						? {
-								status: "interrupt" as const,
-								question: q0.question,
-								field: q0.field,
-								...(q0.suggestions ? { suggestions: q0.suggestions } : {}),
-								...(q0.context || result.context
-									? { context: q0.context ?? result.context }
-									: {}),
-							}
-						: {
-								status: "interrupt" as const,
-								questions: result.questions,
-								...(result.context ? { context: result.context } : {}),
-							};
-
-				return {
-					payload,
-					flowMeta: {
-						step: currentNode,
-						state,
-						...(isSingle && q0 ? { field: q0.field } : {}),
-					},
-				};
+				currentNode = await resolveNextNode(edge, state);
+				continue;
 			}
 
 			// Widget signal — pause and show widget
@@ -256,8 +332,7 @@ async function executeFrom<TState extends Record<string, unknown>>(
 				// Auto-skip: use field from the signal, fall back to nodeConfig
 				const widgetField = result.field ?? nodeConfigs.get(currentNode)?.field;
 				if (widgetField) {
-					const v = state[widgetField as keyof TState];
-					if (v !== undefined && v !== null && v !== "") {
+					if (isFilled(state[widgetField as keyof TState])) {
 						const edge = edges.get(currentNode);
 						if (!edge) {
 							return {
@@ -355,6 +430,17 @@ const inputSchema = {
 						.describe("Flow state — pass back exactly as received"),
 					field: z.string().optional(),
 					widgetId: z.string().optional(),
+					questions: z
+						.array(
+							z.object({
+								question: z.string(),
+								field: z.string(),
+								suggestions: z.array(z.string()).optional(),
+								context: z.string().optional(),
+							}),
+						)
+						.optional(),
+					interruptContext: z.string().optional(),
 				})
 				.optional()
 				.describe("Flow routing data. Pass back exactly as received."),
@@ -435,6 +521,19 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				...state,
 				...(args.stateUpdates ?? {}),
 			} as TState;
+
+			// If cached interrupt questions exist, check for unanswered questions
+			// without re-executing the node handler (avoids side-effect replay).
+			if (inputMeta.questions) {
+				const interruptResult = buildInterruptResult(
+					inputMeta.questions,
+					inputMeta.interruptContext,
+					step,
+					updatedState,
+				);
+				if (interruptResult) return interruptResult;
+				// All questions answered — fall through to advance
+			}
 
 			const edge = edges.get(step);
 			if (!edge) {


### PR DESCRIPTION
Sometimes the interrupt asks multiple questions and needs multiple answers. If it does not get all the answers, we need to repeat the questions which were not answered yet before moving on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flow continuation logic for `interrupt` and `widget` steps, altering when nodes re-run vs advance; regressions could cause stuck loops or skipped steps despite added tests.
> 
> **Overview**
> **Flow continuation now correctly loops on partially-answered multi-question interrupts.** The engine caches interrupt `questions` (and `interruptContext`) in `_meta.flow`, filters out already-answered fields on `continue`, and re-prompts only the remaining questions (including single-question shorthand).
> 
> **Prevents unintended node re-execution and widget loops.** `continue` uses cached questions to avoid re-running interrupt handlers (avoiding side-effect replay); when the cache is missing it re-executes the current step to re-derive questions, and `widget` continues (including field-less widgets) now advance instead of re-showing the widget. Tests were expanded to cover these scenarios, and `bun.lock` was updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ce2c2ff4704943e46cfebafdb72bd18f7629997. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->