### PR TITLE
fix: skip empty URI keys in buildToolMeta

### DIFF
--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -464,16 +464,13 @@ export function compileFlow<TState extends Record<string, unknown>>(
 	// fixed `openai/outputTemplate` at registration causes hosts (e.g.
 	// ChatGPT) to render the widget on first invocation, before the flow
 	// has progressed to the widget step.
-	const firstResource = resources[0];
-	const toolMeta = firstResource
-		? buildToolMeta({
-				openaiTemplateUri: "",
-				mcpTemplateUri: "",
-				invoking: "Loading...",
-				invoked: "Loaded",
-				autoHeight: firstResource.autoHeight,
-			})
-		: undefined;
+	const toolMeta =
+		resources.length > 0
+			? buildToolMeta({
+					invoking: "Loading...",
+					invoked: "Loaded",
+				})
+			: undefined;
 	async function handleToolCall(
 		args: FlowToolInput,
 		meta?: Record<string, unknown>,

--- a/src/mcp/server/resources/meta.ts
+++ b/src/mcp/server/resources/meta.ts
@@ -88,23 +88,27 @@ export function buildMcpAppsResourceMeta(config: {
 // ---- Tool metadata (references resource URIs) ----
 
 export function buildToolMeta(config: {
-	openaiTemplateUri: string;
-	mcpTemplateUri: string;
+	openaiTemplateUri?: string;
+	mcpTemplateUri?: string;
 	invoking: string;
 	invoked: string;
 	autoHeight?: boolean;
 }) {
 	return {
 		// OpenAI metadata
-		"openai/outputTemplate": config.openaiTemplateUri,
+		...(config.openaiTemplateUri && {
+			"openai/outputTemplate": config.openaiTemplateUri,
+		}),
 		"openai/toolInvocation/invoking": config.invoking,
 		"openai/toolInvocation/invoked": config.invoked,
 		"openai/widgetAccessible": true,
 		"openai/resultCanProduceWidget": true,
 		// MCP Apps metadata
-		ui: {
-			resourceUri: config.mcpTemplateUri,
-			...(config.autoHeight && { autoHeight: true }),
-		},
-	} as const;
+		...(config.mcpTemplateUri && {
+			ui: {
+				resourceUri: config.mcpTemplateUri,
+				...(config.autoHeight && { autoHeight: true }),
+			},
+		}),
+	};
 }


### PR DESCRIPTION
Fixes buildToolMeta unconditionally setting `openai/outputTemplate` and `ui.resourceUri` even when empty. ChatGPT sees the key and prematurely associates a widget.

- Made `openaiTemplateUri` and `mcpTemplateUri` optional in `buildToolMeta`
- Only spread the URI keys when non-empty
- Removed empty string args from flow compilation call site

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that alters which `_meta` keys are included when template URIs are missing. Main risk is subtle host/client behavior differences if anything depended on those keys always being present.
> 
> **Overview**
> Prevents tools from advertising widget templates at registration time when no real template URI is available, avoiding premature widget rendering (e.g. in ChatGPT) for multi-step flows.
> 
> `buildToolMeta` now treats `openaiTemplateUri`/`mcpTemplateUri` as optional and only includes `openai/outputTemplate` and `ui.resourceUri` when non-empty, and `compileFlow` stops passing empty-string URIs when setting tool-level metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8004e3b9cd6f7915ac3274eba07e5ea7871473cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->