### PR TITLE
fix: reset chat session ID on page reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.4.3",
+  "version": "0.4.3-beta.0",
   "description": "WaniWani SDK - MCP event tracking, widget framework, and tools",
   "type": "module",
   "exports": {

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -12,7 +12,6 @@ import type { PromptInputMessage } from "../ai-elements/prompt-input";
 import type { VisitorContext } from "../lib/visitor-context";
 import { collectVisitorContext } from "../lib/visitor-context";
 
-const SESSION_STORAGE_KEY = "waniwani-chat-session-id";
 const SESSION_HEADER_NAME = "x-session-id";
 
 function normalizeSessionId(value: unknown): string | undefined {
@@ -21,30 +20,6 @@ function normalizeSessionId(value: unknown): string | undefined {
 	}
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function writeSessionIdToStorage(sessionId: string): void {
-	if (typeof window === "undefined") {
-		return;
-	}
-
-	try {
-		window.sessionStorage.setItem(SESSION_STORAGE_KEY, sessionId);
-	} catch {
-		// Ignore storage failures (private mode, security policy, etc.)
-	}
-}
-
-function removeSessionIdFromStorage(): void {
-	if (typeof window === "undefined") {
-		return;
-	}
-
-	try {
-		window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
-	} catch {
-		// Ignore storage failures (private mode, security policy, etc.)
-	}
 }
 
 export interface QueuedMessage {
@@ -93,13 +68,11 @@ export function useChatEngine(props: ChatBaseProps) {
 
 		sessionIdRef.current = sessionId;
 		setSessionIdState(sessionId);
-		writeSessionIdToStorage(sessionId);
 	}, []);
 
 	const clearSessionId = useCallback(() => {
 		sessionIdRef.current = undefined;
 		setSessionIdState(undefined);
-		removeSessionIdFromStorage();
 	}, []);
 
 	useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to client-side session handling and a version bump; no auth or persistent data migrations involved.
> 
> **Overview**
> Chat session IDs are no longer written to/cleared from `sessionStorage`; `useChatEngine` now keeps the session ID purely in-memory so a reload starts a fresh session.
> 
> The package version is bumped from `0.4.3` to `0.4.3-beta.0` for a beta prerelease.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edde4fd8d64d810893bc8d104de788849d02561b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->