### PR TITLE
feat: inject browser and MCP client metadata into tracking

### DIFF
--- a/src/chat/server/handle-chat.ts
+++ b/src/chat/server/handle-chat.ts
@@ -104,11 +104,16 @@ export function createChatRequestHandler(deps: ApiHandlerDeps) {
 			// 4. Forward to WaniWani API
 			const upstreamUrl = `${baseUrl}/api/mcp/chat`;
 			log("forwarding to", upstreamUrl);
+			const clientUserAgent = request.headers.get("user-agent");
+
 			const response = await fetch(upstreamUrl, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
 					...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+					...(clientUserAgent
+						? { "X-Client-User-Agent": clientUserAgent }
+						: {}),
 				},
 				body: JSON.stringify({
 					messages,

--- a/src/mcp/server/with-waniwani.ts
+++ b/src/mcp/server/with-waniwani.ts
@@ -120,16 +120,31 @@ export function withWaniwani(
 
 		const wrappedHandler = async (input: unknown, extra: unknown) => {
 			const startTime = performance.now();
+			const clientInfo = (
+				server as {
+					server?: {
+						getClientVersion?: () =>
+							| { name: string; version: string }
+							| undefined;
+					};
+				}
+			).server?.getClientVersion?.();
 			try {
 				const result = await handler(input, extra);
 				const durationMs = Math.round(performance.now() - startTime);
 
 				await safeTrack(
 					tracker,
-					buildTrackInput(toolName, extra, options, {
-						durationMs,
-						status: "ok",
-					}),
+					buildTrackInput(
+						toolName,
+						extra,
+						options,
+						{
+							durationMs,
+							status: "ok",
+						},
+						clientInfo,
+					),
 					options.onError,
 				);
 
@@ -154,12 +169,18 @@ export function withWaniwani(
 
 				await safeTrack(
 					tracker,
-					buildTrackInput(toolName, extra, options, {
-						durationMs,
-						status: "error",
-						errorMessage:
-							error instanceof Error ? error.message : String(error),
-					}),
+					buildTrackInput(
+						toolName,
+						extra,
+						options,
+						{
+							durationMs,
+							status: "error",
+							errorMessage:
+								error instanceof Error ? error.message : String(error),
+						},
+						clientInfo,
+					),
 					options.onError,
 				);
 
@@ -215,6 +236,7 @@ function buildTrackInput(
 	extra: unknown,
 	options: WithWaniwaniOptions,
 	timing?: { durationMs: number; status: string; errorMessage?: string },
+	clientInfo?: { name: string; version: string },
 ): TrackInput {
 	const toolType = resolveToolType(toolName, options.toolType);
 	const meta = extractMeta(extra);
@@ -230,6 +252,7 @@ function buildTrackInput(
 		metadata: {
 			source: "withWaniwani",
 			...(options.metadata ?? {}),
+			...(clientInfo && { clientInfo }),
 		},
 	};
 }


### PR DESCRIPTION
Forward the browser's User-Agent header from client requests to the upstream API as X-Client-User-Agent, and capture MCP client version information in tool tracking metadata. This enables downstream services to correlate events with specific client types and versions for better observability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds propagation of client-identifying metadata (browser User-Agent and MCP client name/version) into upstream requests and tracking payloads, which can affect privacy/compliance expectations and downstream analytics behavior. Logic changes are small and localized but touch request headers and event metadata.
> 
> **Overview**
> For chat proxy requests, forwards the incoming `User-Agent` to the upstream WaniWani API as `X-Client-User-Agent`.
> 
> For MCP tool tracking via `withWaniwani`, captures MCP client `{name, version}` (when available) and attaches it to `tool.called` event `metadata.clientInfo` for both success and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f7ca792f965bc111bd242001ffd527221ca57de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->