### PR TITLE
Fix widget tool-call session propagation

### DIFF
--- a/src/chat/server/handle-tool.ts
+++ b/src/chat/server/handle-tool.ts
@@ -17,13 +17,21 @@ export function createToolHandler(deps: ResourceHandlerDeps) {
 				name: string;
 				arguments: Record<string, unknown>;
 			};
+			const requestSessionId = request.headers.get("x-session-id")?.trim();
 
 			if (!name || typeof name !== "string") {
 				log("← 400 missing tool name");
 				return Response.json({ error: "Missing tool name" }, { status: 400 });
 			}
 
-			log("tool:", name, "args:", JSON.stringify(args));
+			log(
+				"tool:",
+				name,
+				"args:",
+				JSON.stringify(args),
+				"sessionId:",
+				requestSessionId || "(none)",
+			);
 
 			const mcpServerUrl =
 				mcpServerUrlOverride ?? (await resolveConfig()).mcpServerUrl;
@@ -65,6 +73,17 @@ export function createToolHandler(deps: ResourceHandlerDeps) {
 				const result = await client.callTool({
 					name,
 					arguments: args ?? {},
+					...(requestSessionId
+						? {
+								_meta: {
+									"waniwani/sessionId": requestSessionId,
+								},
+							}
+						: {}),
+				} as {
+					name: string;
+					arguments: Record<string, unknown>;
+					_meta?: Record<string, unknown>;
 				});
 				log("tool result received");
 

--- a/src/chat/web/hooks/use-call-tool.ts
+++ b/src/chat/web/hooks/use-call-tool.ts
@@ -15,22 +15,33 @@ export function useCallTool(props: {
 	api?: string;
 	headers?: Record<string, string>;
 	onCallTool?: CallToolFn;
+	sessionId?: string;
 }): CallToolFn {
 	const propsRef = useRef(props);
 	propsRef.current = props;
 
 	return useCallback(
 		async (params: CallToolParams): Promise<CallToolResult> => {
-			const { api, headers, onCallTool } = propsRef.current;
+			const { api, headers, onCallTool, sessionId } = propsRef.current;
 
 			if (onCallTool) {
 				return onCallTool(params);
 			}
 
 			const endpoint = `${api ?? "/api/waniwani"}/tool`;
+			const normalizedSessionId =
+				typeof sessionId === "string" && sessionId.trim().length > 0
+					? sessionId.trim()
+					: undefined;
 			const res = await fetch(endpoint, {
 				method: "POST",
-				headers: { "Content-Type": "application/json", ...headers },
+				headers: {
+					"Content-Type": "application/json",
+					...(normalizedSessionId
+						? { "X-Session-Id": normalizedSessionId }
+						: {}),
+					...headers,
+				},
 				body: JSON.stringify(params),
 			});
 

--- a/src/chat/web/layouts/chat-bar.tsx
+++ b/src/chat/web/layouts/chat-bar.tsx
@@ -59,7 +59,10 @@ export const ChatBar = forwardRef<ChatHandle, ChatBarProps>(
 		const isDark = isDarkTheme(resolvedTheme);
 
 		const engine = useChatEngine(props);
-		const handleCallTool = useCallTool(props);
+		const handleCallTool = useCallTool({
+			...props,
+			sessionId: engine.sessionId,
+		});
 
 		const suggestionsState = useSuggestions({
 			messages: engine.messages,

--- a/src/chat/web/layouts/chat-card.tsx
+++ b/src/chat/web/layouts/chat-card.tsx
@@ -73,7 +73,11 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 		}, [effectiveApi]);
 
 		const engine = useChatEngine({ ...props, api: effectiveApi });
-		const handleCallTool = useCallTool({ ...props, api: effectiveApi });
+		const handleCallTool = useCallTool({
+			...props,
+			api: effectiveApi,
+			sessionId: engine.sessionId,
+		});
 
 		const animatedPlaceholder = useTypingPlaceholder(placeholder, !engine.text);
 


### PR DESCRIPTION
## Summary
- pass the active chat session ID into widget `/api/waniwani/tool` requests
- inject that session ID into MCP `tools/call` `_meta` on the server side
- keep widget tool calls correlated with the same session as the parent chat

## Verification
- bun x tsc --noEmit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the tool-call request/response path end-to-end (client headers → server MCP metadata), so mistakes could break tool invocation or correlate calls to the wrong session, but the change is small and additive.
> 
> **Overview**
> Ensures widget tool calls stay correlated to the active chat session by propagating a `sessionId` through the tool-call pipeline.
> 
> The web widgets (`ChatBar`, `ChatCard`) now pass `engine.sessionId` into `useCallTool`, which conditionally adds an `X-Session-Id` header on `/tool` POSTs. The server tool handler reads this header, logs it, and forwards it to MCP `tools/call` via `_meta["waniwani/sessionId"]` when present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c86cfac2a67980f03e3bc66ecdf051de11b8e87f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->