### PR TITLE
fix: preserve first-turn request metadata in withWaniwani

### DIFF
--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -192,4 +192,83 @@ describe("withWaniwani", () => {
 		);
 		expect(waniwani.token).toBe(undefined);
 	});
+
+	test("injects session and geo metadata into the first widget result", async () => {
+		const { client } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, { client });
+
+		mock.registerTool("search", { description: "Search" }, async () => ({
+			text: "ok",
+		}));
+
+		const handler = mock.registered[0]?.[2];
+		const result = (await handler?.(
+			{},
+			{
+				_meta: {
+					"waniwani/sessionId": "session-1",
+					"waniwani/geoLocation": {
+						country: "SK",
+						city: "Bratislava",
+					},
+				},
+			},
+		)) as Record<string, unknown>;
+		const meta = result._meta as Record<string, unknown>;
+		const waniwani = meta.waniwani as Record<string, unknown>;
+
+		expect(waniwani.sessionId).toBe("session-1");
+		expect(waniwani.geoLocation).toEqual({
+			country: "SK",
+			city: "Bratislava",
+		});
+		expect(meta["waniwani/sessionId"]).toBe("session-1");
+		expect(meta["waniwani/geoLocation"]).toEqual({
+			country: "SK",
+			city: "Bratislava",
+		});
+		expect(meta["waniwani/userLocation"]).toEqual({
+			country: "SK",
+			city: "Bratislava",
+		});
+	});
+
+	test("injects request metadata even when widget token injection is disabled", async () => {
+		const { client } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, {
+			client,
+			injectWidgetToken: false,
+		});
+
+		mock.registerTool("search", { description: "Search" }, async () => ({
+			text: "ok",
+		}));
+
+		const handler = mock.registered[0]?.[2];
+		const result = (await handler?.(
+			{},
+			{
+				_meta: {
+					"waniwani/sessionId": "session-1",
+					"waniwani/geoLocation": {
+						country: "SK",
+					},
+				},
+			},
+		)) as Record<string, unknown>;
+		const meta = result._meta as Record<string, unknown>;
+
+		expect(meta["waniwani/sessionId"]).toBe("session-1");
+		expect(meta["waniwani/geoLocation"]).toEqual({
+			country: "SK",
+		});
+		expect(meta["waniwani/userLocation"]).toEqual({
+			country: "SK",
+		});
+		expect(meta.waniwani).toBe(undefined);
+	});
 });

--- a/src/mcp/server/with-waniwani/helpers.ts
+++ b/src/mcp/server/with-waniwani/helpers.ts
@@ -3,6 +3,7 @@ import type {
 	TrackInput,
 } from "../../../tracking/index.js";
 import type { WaniWaniClient } from "../../../types.js";
+import { extractSessionId } from "../utils.js";
 import type { WidgetTokenCache } from "../widget-token.js";
 
 type UnknownRecord = Record<string, unknown>;
@@ -12,7 +13,9 @@ export type WaniwaniTracker = Pick<
 	"flush" | "track" | "_config"
 >;
 
-const USER_LOCATION_KEY = "waniwani/userLocation";
+const SESSION_ID_KEY = "waniwani/sessionId";
+const GEO_LOCATION_KEY = "waniwani/geoLocation";
+const LEGACY_USER_LOCATION_KEY = "waniwani/userLocation";
 
 export function isRecord(value: unknown): value is UnknownRecord {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -123,8 +126,14 @@ export async function injectWidgetConfig(
 	}
 
 	const meta = (result as UnknownRecord)._meta as UnknownRecord;
+	const existingWaniwaniConfig = isRecord(meta.waniwani)
+		? (meta.waniwani as UnknownRecord)
+		: undefined;
 	const waniwaniConfig: UnknownRecord = {
-		endpoint: `${baseUrl.replace(/\/$/, "")}/api/mcp/events/v2/batch`,
+		...(existingWaniwaniConfig ?? {}),
+		endpoint:
+			existingWaniwaniConfig?.endpoint ??
+			`${baseUrl.replace(/\/$/, "")}/api/mcp/events/v2/batch`,
 	};
 
 	if (cache) {
@@ -138,17 +147,26 @@ export async function injectWidgetConfig(
 		}
 	}
 
+	const sessionId = extractSessionId(meta);
+	if (sessionId) {
+		if (!waniwaniConfig.sessionId) {
+			waniwaniConfig.sessionId = sessionId;
+		}
+	}
+
+	const geoLocation = extractGeoLocation(meta);
+	if (geoLocation !== undefined) {
+		if (!waniwaniConfig.geoLocation) {
+			waniwaniConfig.geoLocation = geoLocation;
+		}
+	}
+
 	meta.waniwani = waniwaniConfig;
 }
 
-export function injectUserLocation(result: unknown, extra: unknown): void {
+export function injectRequestMetadata(result: unknown, extra: unknown): void {
 	const requestMeta = extractMeta(extra);
 	if (!requestMeta) {
-		return;
-	}
-
-	const userLocation = requestMeta[USER_LOCATION_KEY];
-	if (!userLocation) {
 		return;
 	}
 
@@ -161,10 +179,38 @@ export function injectUserLocation(result: unknown, extra: unknown): void {
 	}
 
 	const resultMeta = (result as UnknownRecord)._meta as UnknownRecord;
-
-	if (!resultMeta[USER_LOCATION_KEY]) {
-		resultMeta[USER_LOCATION_KEY] = userLocation;
+	const sessionId = extractSessionId(requestMeta);
+	if (sessionId && !resultMeta[SESSION_ID_KEY]) {
+		resultMeta[SESSION_ID_KEY] = sessionId;
 	}
+
+	const geoLocation = extractGeoLocation(requestMeta);
+	if (!geoLocation) {
+		return;
+	}
+
+	if (!resultMeta[GEO_LOCATION_KEY]) {
+		resultMeta[GEO_LOCATION_KEY] = geoLocation;
+	}
+
+	if (!resultMeta[LEGACY_USER_LOCATION_KEY]) {
+		resultMeta[LEGACY_USER_LOCATION_KEY] = geoLocation;
+	}
+}
+
+function extractGeoLocation(
+	meta: UnknownRecord | undefined,
+): UnknownRecord | string | undefined {
+	if (!meta) {
+		return undefined;
+	}
+
+	const geoLocation = meta[GEO_LOCATION_KEY] ?? meta[LEGACY_USER_LOCATION_KEY];
+	if (isRecord(geoLocation) || typeof geoLocation === "string") {
+		return geoLocation;
+	}
+
+	return undefined;
 }
 
 function toError(error: unknown): Error {

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -6,7 +6,7 @@ import {
 	buildTrackInput,
 	extractErrorText,
 	extractMeta,
-	injectUserLocation,
+	injectRequestMetadata,
 	injectWidgetConfig,
 	isRecord,
 	safeFlush,
@@ -173,6 +173,8 @@ export function withWaniwani(
 						await safeFlush(tracker, options.onError);
 					}
 
+					injectRequestMetadata(result, extra);
+
 					if (injectToken) {
 						await injectWidgetConfig(
 							result,
@@ -181,8 +183,6 @@ export function withWaniwani(
 							options.onError,
 						);
 					}
-
-					injectUserLocation(result, extra);
 
 					return result;
 				} catch (error) {


### PR DESCRIPTION
## Summary
- inject request metadata into the tool result `_meta` independently of widget token injection
- keep widget config enrichment separate from request metadata propagation
- add regression coverage for the default path and `injectWidgetToken: false`

## Testing
- bun test src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
- bun run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to post-tool-call metadata enrichment in `withWaniwani` and related helper logic, with added tests covering the new behavior and the `injectWidgetToken: false` path.
> 
> **Overview**
> Ensures first-turn request metadata is preserved in `withWaniwani` tool responses by always copying session/geo fields from `extra._meta` into the returned result’s `_meta`, even when widget token injection is disabled.
> 
> Separates request metadata propagation from widget config enrichment: `injectWidgetConfig` now preserves any existing `_meta.waniwani` fields and can additionally include `sessionId` and `geoLocation`, while `injectRequestMetadata` also backfills legacy `waniwani/userLocation` from geo data.
> 
> Adds regression tests to verify session/geo injection into `_meta` and that disabling `injectWidgetToken` stops `_meta.waniwani` injection without losing request metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29db03bc230117f350d30c4901f4b5c79de355e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->