### PR TITLE
feat: extract generic KV store from flow store

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@waniwani/cli",
@@ -8,7 +9,7 @@
       },
       "devDependencies": {
         "@ai-sdk/mcp": "^1.0.0",
-        "@ai-sdk/react": "^3.0.73",
+        "@ai-sdk/react": "^3.0.134",
         "@biomejs/biome": "^2.3.13",
         "@modelcontextprotocol/ext-apps": "1.0.1",
         "@modelcontextprotocol/sdk": "1.25.2",
@@ -19,7 +20,7 @@
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.2.3",
-        "ai": "^6.0.71",
+        "ai": "^6.0.134",
         "autoevals": "^0.0.132",
         "clsx": "^2.1.1",
         "happy-dom": "^20.7.0",
@@ -64,7 +65,7 @@
     "zod": "^4.0.0",
   },
   "packages": {
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.34", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZS1dWai5DINQOv3bpNi3ua9+yt3jnRaux3CwEr/ai9qETp6T+2wcpZyw+0jUHo1He/Lznw//AQh4zhdwHnTWrg=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.83", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ=="],
 
     "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-dRX2X6GDadZNpiylNnw0HP7zJC8ggVOOJV/JtxuF6CgtP8CKnc7a/wEzpUw1m/4AGdD3mTDhKnKFwC4y10a8FQ=="],
 
@@ -72,7 +73,7 @@
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.15", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@3.0.73", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.13", "ai": "6.0.71", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-k7KnGZuTn5HKZWUh2OLxij5Erhedo/6faiO3eb+pD3fIVXwt8sr4V1tU60pBG349Kzrj2EUzg5mn1TYZf1Y2pw=="],
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.143", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.21", "ai": "6.0.141", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-yYXrrscpF3MiCycGizgw1rukbhXBnoYpisC9vt12UU4i0tkyBMBCtBrsqLTJFrItax6ZR9TjTcGdNTqKqJhyow=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -350,7 +351,7 @@
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
-    "ai": ["ai@6.0.71", "", { "dependencies": { "@ai-sdk/gateway": "3.0.34", "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-33/Qq0BhEG+SabYeE7ZlLL3DCubUQo04C8E9UdEHqh2DJuGdtxMXG/TSMkO2uF+ZmlGJpD4UY5Wij9/qal298w=="],
+    "ai": ["ai@6.0.141", "", { "dependencies": { "@ai-sdk/gateway": "3.0.83", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-+GomGQWaId3xN0wcugUW/H7xMMaFkID2PiS7K/Wugj45G3efv0BXhQ3psRZoQVoRbOpdNoUqcK/KTB+FR4h6qg=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -970,11 +971,9 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@3.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw=="],
+    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
-    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og=="],
-
-    "@ai-sdk/react/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og=="],
+    "@ai-sdk/react/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -988,14 +987,10 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw=="],
-
-    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og=="],
+    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "@ai-sdk/react/@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@3.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "devDependencies": {
     "@ai-sdk/mcp": "^1.0.0",
-    "@ai-sdk/react": "^3.0.73",
+    "@ai-sdk/react": "^3.0.134",
     "@biomejs/biome": "^2.3.13",
     "@modelcontextprotocol/ext-apps": "1.0.1",
     "@modelcontextprotocol/sdk": "1.25.2",
@@ -116,7 +116,7 @@
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.2.3",
-    "ai": "^6.0.71",
+    "ai": "^6.0.134",
     "autoevals": "^0.0.132",
     "clsx": "^2.1.1",
     "happy-dom": "^20.7.0",

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -31,6 +31,9 @@ export {
 	START,
 	StateGraph,
 } from "./server/flows";
+// Generic key-value store
+export type { KvStore, KvStoreOptions } from "./server/kv";
+export { WaniwaniKvStore } from "./server/kv";
 export type {
 	RegisteredResource,
 	ResourceConfig,

--- a/src/mcp/server/flows/flow-store.ts
+++ b/src/mcp/server/flows/flow-store.ts
@@ -10,6 +10,7 @@
  * The `FlowStore` interface is exported for custom implementations.
  */
 
+import { type KvStoreOptions, WaniwaniKvStore } from "../kv";
 import type { FlowTokenContent } from "./@types";
 
 // ============================================================================
@@ -26,77 +27,22 @@ export interface FlowStore {
 // WaniWani API implementation
 // ============================================================================
 
-const SDK_NAME = "@waniwani/sdk";
-const DEFAULT_BASE_URL = "https://app.waniwani.ai";
-
 export class WaniwaniFlowStore implements FlowStore {
-	private readonly baseUrl: string;
-	private readonly apiKey: string | undefined;
+	private readonly store: WaniwaniKvStore<FlowTokenContent>;
 
-	constructor(options?: { baseUrl?: string; apiKey?: string }) {
-		this.baseUrl = (
-			options?.baseUrl ??
-			process.env.WANIWANI_BASE_URL ??
-			DEFAULT_BASE_URL
-		).replace(/\/$/, "");
-		this.apiKey = options?.apiKey ?? process.env.WANIWANI_API_KEY;
+	constructor(options?: KvStoreOptions) {
+		this.store = new WaniwaniKvStore<FlowTokenContent>(options);
 	}
 
-	async get(key: string): Promise<FlowTokenContent | null> {
-		if (!this.apiKey) {
-			return null;
-		}
-		try {
-			const data = await this.request<FlowTokenContent | null>(
-				"/api/mcp/redis/get",
-				{ key },
-			);
-			return data ?? null;
-		} catch {
-			return null;
-		}
+	get(key: string): Promise<FlowTokenContent | null> {
+		return this.store.get(key);
 	}
 
-	async set(key: string, value: FlowTokenContent): Promise<void> {
-		if (!this.apiKey) {
-			return;
-		}
-		try {
-			await this.request("/api/mcp/redis/set", { key, value });
-		} catch {
-			// Non-fatal
-		}
+	set(key: string, value: FlowTokenContent): Promise<void> {
+		return this.store.set(key, value);
 	}
 
-	async delete(key: string): Promise<void> {
-		if (!this.apiKey) {
-			return;
-		}
-		try {
-			await this.request("/api/mcp/redis/delete", { key });
-		} catch {
-			// Non-fatal
-		}
-	}
-
-	private async request<T>(path: string, body: unknown): Promise<T> {
-		const url = `${this.baseUrl}${path}`;
-		const response = await fetch(url, {
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${this.apiKey}`,
-				"Content-Type": "application/json",
-				"X-WaniWani-SDK": SDK_NAME,
-			},
-			body: JSON.stringify(body),
-		});
-
-		if (!response.ok) {
-			const text = await response.text().catch(() => "");
-			throw new Error(text || `Flow state API error: HTTP ${response.status}`);
-		}
-
-		const json = (await response.json()) as { data: T };
-		return json.data;
+	delete(key: string): Promise<void> {
+		return this.store.delete(key);
 	}
 }

--- a/src/mcp/server/kv/index.ts
+++ b/src/mcp/server/kv/index.ts
@@ -1,0 +1,4 @@
+// Generic key-value store
+
+export type { KvStore, KvStoreOptions } from "./kv-store";
+export { WaniwaniKvStore } from "./kv-store";

--- a/src/mcp/server/kv/kv-store.ts
+++ b/src/mcp/server/kv/kv-store.ts
@@ -1,0 +1,104 @@
+/**
+ * Generic key-value store backed by the WaniWani API.
+ *
+ * Values are stored as JSON objects (`Record<string, unknown>`) in the
+ * `/api/mcp/redis/*` endpoints. Tenant isolation is handled by the API key.
+ *
+ * This is the generic version — `WaniwaniFlowStore` uses this under the hood
+ * with `FlowTokenContent` as the value type.
+ */
+
+// ============================================================================
+// Interface
+// ============================================================================
+
+export interface KvStore<T = Record<string, unknown>> {
+	get(key: string): Promise<T | null>;
+	set(key: string, value: T): Promise<void>;
+	delete(key: string): Promise<void>;
+}
+
+// ============================================================================
+// WaniWani API implementation
+// ============================================================================
+
+const SDK_NAME = "@waniwani/sdk";
+const DEFAULT_BASE_URL = "https://app.waniwani.ai";
+
+export interface KvStoreOptions {
+	baseUrl?: string;
+	apiKey?: string;
+}
+
+export class WaniwaniKvStore<T = Record<string, unknown>>
+	implements KvStore<T>
+{
+	private readonly baseUrl: string;
+	private readonly apiKey: string | undefined;
+
+	constructor(options?: KvStoreOptions) {
+		this.baseUrl = (
+			options?.baseUrl ??
+			process.env.WANIWANI_BASE_URL ??
+			DEFAULT_BASE_URL
+		).replace(/\/$/, "");
+		this.apiKey = options?.apiKey ?? process.env.WANIWANI_API_KEY;
+	}
+
+	async get(key: string): Promise<T | null> {
+		if (!this.apiKey) {
+			return null;
+		}
+		try {
+			const data = await this.request<T | null>("/api/mcp/redis/get", {
+				key,
+			});
+			return data ?? null;
+		} catch {
+			return null;
+		}
+	}
+
+	async set(key: string, value: T): Promise<void> {
+		if (!this.apiKey) {
+			return;
+		}
+		try {
+			await this.request("/api/mcp/redis/set", { key, value });
+		} catch {
+			// Non-fatal
+		}
+	}
+
+	async delete(key: string): Promise<void> {
+		if (!this.apiKey) {
+			return;
+		}
+		try {
+			await this.request("/api/mcp/redis/delete", { key });
+		} catch {
+			// Non-fatal
+		}
+	}
+
+	private async request<R>(path: string, body: unknown): Promise<R> {
+		const url = `${this.baseUrl}${path}`;
+		const response = await fetch(url, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${this.apiKey}`,
+				"Content-Type": "application/json",
+				"X-WaniWani-SDK": SDK_NAME,
+			},
+			body: JSON.stringify(body),
+		});
+
+		if (!response.ok) {
+			const text = await response.text().catch(() => "");
+			throw new Error(text || `KV store API error: HTTP ${response.status}`);
+		}
+
+		const json = (await response.json()) as { data: R };
+		return json.data;
+	}
+}


### PR DESCRIPTION
## Summary
- Extracts the WaniWani API-backed key-value logic from `WaniwaniFlowStore` into a reusable, generic `WaniwaniKvStore<T>` class in `src/mcp/server/kv/`
- `WaniwaniFlowStore` now delegates to `WaniwaniKvStore<FlowTokenContent>` instead of duplicating the HTTP/auth logic
- Exports `KvStore`, `KvStoreOptions`, and `WaniwaniKvStore` from the SDK's public API
- Bumps `ai` and `@ai-sdk/react` dev dependencies

## Test plan
- [ ] Verify `bun run build` succeeds
- [ ] Verify existing flow store behavior is unchanged (delegation is transparent)
- [ ] Verify `WaniwaniKvStore` can be imported and used independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors flow state persistence to delegate to a new generic KV store wrapper around the WaniWani API; behavior should be equivalent but regressions could affect flow continuation/state retrieval. Also bumps `ai`/`@ai-sdk/react`, which may introduce unrelated runtime or build changes.
> 
> **Overview**
> **Extracts a reusable, API-backed key/value store.** Adds `KvStore`/`WaniwaniKvStore<T>` (with `KvStoreOptions`) under `src/mcp/server/kv`, encapsulating the `/api/mcp/redis/*` fetch/auth logic.
> 
> **Refactors flow state storage to delegate.** `WaniwaniFlowStore` now wraps `WaniwaniKvStore<FlowTokenContent>` instead of duplicating HTTP request code, and the new KV types are exported from the public `src/mcp` entrypoint.
> 
> **Dependency maintenance.** Updates dev dependencies `ai` and `@ai-sdk/react` (and corresponding lockfile entries).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 483cbeed38665734efeff950f8a8753ab8e07c78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->