### PR TITLE
Limit gitleaks push trigger to main branch

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -2,6 +2,7 @@ name: gitleaks
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Scopes the gitleaks push trigger to `main` only to avoid duplicate workflow runs when pushing to branches with open PRs

## Test plan
- [ ] Verify workflow runs once per PR, not twice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only alters when the gitleaks workflow runs; no product/runtime code is affected.
> 
> **Overview**
> The `gitleaks` workflow now triggers on `push` events **only for `main`**, while keeping the `pull_request` trigger unchanged, reducing duplicate secret-scan runs when working on branches with open PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cac5397a7b6adc7474e4d731351ee6194f962684. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->