### PR TITLE
fix: use body.scrollHeight for widget auto-resize

### DIFF
--- a/src/mcp/react/widgets/mcp-apps-client.ts
+++ b/src/mcp/react/widgets/mcp-apps-client.ts
@@ -118,17 +118,13 @@ export class MCPAppsWidgetClient implements UnifiedWidgetClient {
 				const scrollbarGap = window.innerWidth - el.clientWidth;
 				const width = Math.ceil(fitRect.width + scrollbarGap);
 
-				// --- Height: collapse root and read scrollHeight ---
-				// fit-content on <html> can under-report when children use
-				// percentage heights or viewport units. Collapsing to 0 and
-				// reading scrollHeight gives the true content height.
-				const savedHeight = el.style.height;
-				const savedMinHeight = el.style.minHeight;
-				el.style.height = "0";
-				el.style.minHeight = "0";
-				const height = el.scrollHeight;
-				el.style.height = savedHeight;
-				el.style.minHeight = savedMinHeight;
+				// --- Height: read body.scrollHeight ---
+				// We use document.body.scrollHeight rather than collapsing
+				// <html> and reading its scrollHeight, because in an iframe
+				// document.documentElement.scrollHeight never drops below
+				// the viewport height (set by the parent iframe element),
+				// causing a ratchet effect where the iframe only ever grows.
+				const height = document.body.scrollHeight;
 
 				if (width !== lastWidth || height !== lastHeight) {
 					lastWidth = width;

--- a/src/mcp/react/widgets/mcp-apps-client.ts
+++ b/src/mcp/react/widgets/mcp-apps-client.ts
@@ -129,7 +129,7 @@ export class MCPAppsWidgetClient implements UnifiedWidgetClient {
 				const bodyStyle = getComputedStyle(document.body);
 				const bodyMargins =
 					parseFloat(bodyStyle.marginTop) + parseFloat(bodyStyle.marginBottom);
-				const height = document.body.scrollHeight + bodyMargins;
+				const height = Math.ceil(document.body.scrollHeight + bodyMargins);
 
 				if (width !== lastWidth || height !== lastHeight) {
 					lastWidth = width;

--- a/src/mcp/react/widgets/mcp-apps-client.ts
+++ b/src/mcp/react/widgets/mcp-apps-client.ts
@@ -118,13 +118,18 @@ export class MCPAppsWidgetClient implements UnifiedWidgetClient {
 				const scrollbarGap = window.innerWidth - el.clientWidth;
 				const width = Math.ceil(fitRect.width + scrollbarGap);
 
-				// --- Height: read body.scrollHeight ---
+				// --- Height: read body.scrollHeight + body margins ---
 				// We use document.body.scrollHeight rather than collapsing
 				// <html> and reading its scrollHeight, because in an iframe
 				// document.documentElement.scrollHeight never drops below
 				// the viewport height (set by the parent iframe element),
 				// causing a ratchet effect where the iframe only ever grows.
-				const height = document.body.scrollHeight;
+				// scrollHeight excludes the body's own margins, so we add
+				// them back to avoid clipping.
+				const bodyStyle = getComputedStyle(document.body);
+				const bodyMargins =
+					parseFloat(bodyStyle.marginTop) + parseFloat(bodyStyle.marginBottom);
+				const height = document.body.scrollHeight + bodyMargins;
 
 				if (width !== lastWidth || height !== lastHeight) {
 					lastWidth = width;


### PR DESCRIPTION
## Summary

- Fixes widget auto-resize ratchet effect where the iframe height only ever grows but never shrinks
- Replaces the collapse-and-measure approach on `<html>` with `document.body.scrollHeight`, which correctly reports content height in iframes without being clamped to the viewport height

## Test plan

- [ ] Verify widget resizes correctly when content grows
- [ ] Verify widget shrinks when content is removed
- [ ] Test across Claude and ChatGPT hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the widget iframe height measurement logic, which could affect layout/scrolling behavior across hosts and CSS setups (e.g., body margins). Scope is limited to auto-resize sizing calculations.
> 
> **Overview**
> Fixes widget auto-resize so the iframe can *shrink as well as grow* by changing how height is measured.
> 
> The height calculation in `MCPAppsWidgetClient.setupAutoResize` now uses `document.body.scrollHeight` plus computed body top/bottom margins instead of collapsing `<html>` and reading `documentElement.scrollHeight`, avoiding iframe viewport clamping that caused a “ratchet” growth effect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f56cb8bbd6a40257cc9f09723c51ded89747aa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->