### PR TITLE
fix: add missing permissions to gitleaks CI workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
+      security-events: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Adds explicit permissions to the gitleaks workflow job: `contents: read`, `pull-requests: write`, `security-events: write`
- `pull-requests: write` is needed for the action to post review comments on PRs
- `security-events: write` is needed for SARIF upload to the code scanning dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)