### PR TITLE
fix: use MCP ui/message for ChatGPT follow-ups

### DIFF
--- a/src/mcp/react/widgets/openai-client.ts
+++ b/src/mcp/react/widgets/openai-client.ts
@@ -1,3 +1,4 @@
+import { App, PostMessageTransport } from "@modelcontextprotocol/ext-apps";
 import {
 	formatModelContextForPrompt,
 	type ModelContextUpdate,
@@ -24,6 +25,7 @@ type GlobalsKey = keyof SetGlobalsEvent["detail"]["globals"];
  */
 export class OpenAIWidgetClient implements UnifiedWidgetClient {
 	private pendingModelContext: ModelContextUpdate | null = null;
+	private app: App;
 
 	private getGlobal<T>(
 		key: keyof NonNullable<typeof window.openai>,
@@ -58,14 +60,25 @@ export class OpenAIWidgetClient implements UnifiedWidgetClient {
 		return () => window.removeEventListener(SET_GLOBALS_EVENT_TYPE, handler);
 	}
 
+	constructor() {
+		this.app = new App(
+			{ name: "WaniWani Widget", version: "1.0.0" },
+			{},
+			{ autoResize: false },
+		);
+	}
+
 	async connect(): Promise<void> {
 		if (typeof window === "undefined" || !("openai" in window)) {
 			throw new Error("OpenAI global not found. Are you running in ChatGPT?");
 		}
+		await this.app.connect(
+			new PostMessageTransport(window.parent, window.parent),
+		);
 	}
 
 	async close(): Promise<void> {
-		// No-op for OpenAI - connection is managed by the host
+		await this.app.close();
 	}
 
 	getToolOutput<T = Record<string, unknown>>(): T | null {
@@ -96,15 +109,16 @@ export class OpenAIWidgetClient implements UnifiedWidgetClient {
 		}
 	}
 
-	sendFollowUp(prompt: string): void {
-		if (typeof window !== "undefined" && window.openai?.sendFollowUpMessage) {
-			const hiddenContext = formatModelContextForPrompt(
-				this.pendingModelContext,
-			);
-			this.pendingModelContext = null;
-			const message = hiddenContext ? `${prompt}\n\n${hiddenContext}` : prompt;
-			window.openai.sendFollowUpMessage({ prompt: message });
-		}
+	sendFollowUp(prompt: string): Promise<void> {
+		const hiddenContext = formatModelContextForPrompt(this.pendingModelContext);
+		this.pendingModelContext = null;
+		const message = hiddenContext ? `${prompt}\n\n${hiddenContext}` : prompt;
+		return this.app
+			.sendMessage({
+				role: "user",
+				content: [{ type: "text", text: message }],
+			})
+			.then(() => undefined);
 	}
 
 	updateModelContext(context: ModelContextUpdate): void {


### PR DESCRIPTION
## Summary
- switch the ChatGPT OpenAI widget client from `sendFollowUpMessage` to the MCP-standard `ui/message` transport
- connect and close the ext-apps `App` transport explicitly in the OpenAI widget client
- keep the change free of the temporary debug logging added during investigation

## Verification
- `bun run typecheck`
- `bunx biome check src/mcp/react/widgets/openai-client.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how follow-up messages are delivered in the ChatGPT/OpenAI host and adds explicit connect/close lifecycle; failures would surface as missing or duplicated follow-ups rather than compile-time errors.
> 
> **Overview**
> Switches the ChatGPT `OpenAIWidgetClient` follow-up flow from `window.openai.sendFollowUpMessage` to sending MCP-standard `ui/message` via an `@modelcontextprotocol/ext-apps` `App` over `PostMessageTransport`, while still appending the formatted hidden model context.
> 
> Adds explicit `connect()`/`close()` behavior for the OpenAI client by creating and managing the `App` instance (previously OpenAI was treated as already-connected/no-op for close).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c38b9bd05295e4f08b41a0ad36623cd1e26cca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->