### PR TITLE
ci: automate npm releases via GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - beta
+          - alpha
 
 jobs:
   release:
@@ -13,6 +25,17 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Check admin access
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          if [[ "$PERMISSION" != "admin" ]]; then
+            echo "::error::Only admins can trigger manual releases"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v5
@@ -23,6 +46,32 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       - run: bun install --frozen-lockfile
+
+      - name: Bump version and create tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BUMP="${{ inputs.bump }}"
+          if [[ "$BUMP" == "beta" ]]; then
+            npm version prerelease --preid beta
+          elif [[ "$BUMP" == "alpha" ]]; then
+            npm version prerelease --preid alpha
+          else
+            npm version "$BUMP"
+          fi
+          git push --follow-tags
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "value=v$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=$TAG" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          TAG: ${{ github.ref_name }}
 
       - run: bun run build
 
@@ -40,7 +89,7 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ steps.tag.outputs.value }}
 
       - name: Publish to npm
         run: npm publish --access public --tag ${{ steps.channel.outputs.npm_tag }} --provenance --ignore-scripts
@@ -54,5 +103,5 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ steps.tag.outputs.value }}
           PRERELEASE: ${{ steps.channel.outputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+
+      - name: Determine release channel
+        id: channel
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "$TAG" == *"alpha"* ]]; then
+            echo "npm_tag=alpha" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG" == *"beta"* ]]; then
+            echo "npm_tag=beta" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        run: npm publish --access public --tag ${{ steps.channel.outputs.npm_tag }} --provenance
+
+      - name: Create GitHub Release
+        run: |
+          if [[ "${{ steps.channel.outputs.prerelease }}" == "true" ]]; then
+            gh release create "${{ github.ref_name }}" --generate-notes --prerelease
+          else
+            gh release create "${{ github.ref_name }}" --generate-notes
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
       - uses: oven-sh/setup-bun@v2
 
       - run: bun install --frozen-lockfile
@@ -24,7 +29,6 @@ jobs:
       - name: Determine release channel
         id: channel
         run: |
-          TAG="${{ github.ref_name }}"
           if [[ "$TAG" == *"alpha"* ]]; then
             echo "npm_tag=alpha" >> "$GITHUB_OUTPUT"
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
@@ -35,16 +39,20 @@ jobs:
             echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
+        env:
+          TAG: ${{ github.ref_name }}
 
       - name: Publish to npm
         run: npm publish --access public --tag ${{ steps.channel.outputs.npm_tag }} --provenance
 
       - name: Create GitHub Release
         run: |
-          if [[ "${{ steps.channel.outputs.prerelease }}" == "true" ]]; then
-            gh release create "${{ github.ref_name }}" --generate-notes --prerelease
+          if [[ "$PRERELEASE" == "true" ]]; then
+            gh release create "$TAG" --generate-notes --prerelease
           else
-            gh release create "${{ github.ref_name }}" --generate-notes
+            gh release create "$TAG" --generate-notes
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          PRERELEASE: ${{ steps.channel.outputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - uses: oven-sh/setup-bun@v2
 
@@ -42,7 +43,7 @@ jobs:
           TAG: ${{ github.ref_name }}
 
       - name: Publish to npm
-        run: npm publish --access public --tag ${{ steps.channel.outputs.npm_tag }} --provenance
+        run: npm publish --access public --tag ${{ steps.channel.outputs.npm_tag }} --provenance --ignore-scripts
 
       - name: Create GitHub Release
         run: |

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@waniwani/cli",

--- a/package.json
+++ b/package.json
@@ -63,10 +63,11 @@
     "lint": "biome check .",
     "lint:fix": "biome check . --write",
     "prepublishOnly": "bun run build",
-    "release": "npm whoami && bun run build && npm version patch && npm publish --access public",
-    "release:minor": "npm whoami && bun run build && npm version minor && npm publish --access public",
-    "release:major": "npm whoami && bun run build && npm version major && npm publish --access public",
-    "release:beta": "npm whoami && bun run build && npm version prerelease --preid beta && npm publish --access public --tag beta"
+    "release": "npm version patch && git push --follow-tags",
+    "release:minor": "npm version minor && git push --follow-tags",
+    "release:major": "npm version major && git push --follow-tags",
+    "release:beta": "npm version prerelease --preid beta && git push --follow-tags",
+    "release:alpha": "npm version prerelease --preid alpha && git push --follow-tags"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "1.25.2",


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that publishes to npm when a `v*` tag is pushed, using OIDC trusted publishing (no secrets needed)
- Supports stable, beta, and alpha release channels with correct npm dist-tags
- Simplifies release scripts to just version bump + tag push (`bun run release`)
- Tag protection ruleset already configured on the repo — only admins can create `v*` tags

## Setup completed
- [x] npm trusted publisher configured for `WaniWani-AI/sdk` → `release.yml`
- [x] Tag protection ruleset active on the repo

## Test plan
- [ ] Merge and run `bun run release` to verify the full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an automated publish pipeline that can create tags/releases and publish to npm; misconfiguration could publish unintended versions or to the wrong dist-tag. Manual dispatch adds an admin check, but the workflow still impacts release integrity and supply-chain provenance settings.
> 
> **Overview**
> **Adds automated releases.** Introduces a new GitHub Actions workflow (`.github/workflows/release.yml`) that builds and publishes to npm on `v*` tag pushes (using OIDC via `id-token: write`), and creates a corresponding GitHub Release with generated notes.
> 
> **Supports manual releases and channels.** `workflow_dispatch` can bump versions (including *alpha*/*beta* prereleases), pushes the new tag, maps tags to npm dist-tags (`latest`/`beta`/`alpha`), and blocks manual runs unless the actor has `admin` permission.
> 
> **Simplifies local release scripts.** Updates `package.json` release scripts to only run `npm version …` and `git push --follow-tags` (adds `release:alpha`), removing local build/publish steps; `bun.lock` is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae5cd3ae8c069aa06257939ac8a0db0cf28e089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->