### PR TITLE
fix: use admin PAT for manual releases to bypass rulesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,13 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Check admin access
+      - name: Check manual release requirements
         if: github.event_name == 'workflow_dispatch'
         run: |
+          if [[ -z "$RELEASE_TOKEN" ]]; then
+            echo "::error::RELEASE_TOKEN secret is not set. Add an admin fine-grained PAT as a repo secret."
+            exit 1
+          fi
           PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
           if [[ "$PERMISSION" != "admin" ]]; then
             echo "::error::Only admins can trigger manual releases"
@@ -35,6 +39,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v6
+        with:
+          token: ${{ github.event_name == 'workflow_dispatch' && secrets.RELEASE_TOKEN || github.token }}
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Summary
- Uses a `RELEASE_TOKEN` (admin fine-grained PAT) for the `workflow_dispatch` push step so it can bypass branch protection and tag rulesets
- Tag-push triggered releases still use the default `GITHUB_TOKEN` (no PAT needed)
- Admin access check still gates who can trigger manual releases

## Setup needed
- Add a fine-grained PAT scoped to `WaniWani-AI/sdk` with Contents read/write as repo secret `RELEASE_TOKEN`

## Test plan
- [ ] Add `RELEASE_TOKEN` secret, then trigger a manual release from Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release pipeline and introduces reliance on a new privileged secret (`RELEASE_TOKEN`) for manual runs, which could affect tagging/publishing if misconfigured.
> 
> **Overview**
> Manual (`workflow_dispatch`) releases now enforce that a `RELEASE_TOKEN` secret is present and continue to require the triggering user to have admin permissions.
> 
> The workflow uses `RELEASE_TOKEN` for `actions/checkout` only on manual releases (falling back to the default token for tag-triggered runs), allowing the version bump/tag push step to bypass branch/tag rulesets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b0558352c4c0be8f357106077ec5e07bbe4117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->