### PR TITLE
fix: release workflow tag detection and GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         id: tag
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "value=v$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+            echo "value=v$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
           else
             echo "value=$TAG" >> "$GITHUB_OUTPUT"
           fi
@@ -109,6 +109,6 @@ jobs:
             gh release create "$TAG" --generate-notes
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.event_name == 'workflow_dispatch' && secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.value }}
           PRERELEASE: ${{ steps.channel.outputs.prerelease }}


### PR DESCRIPTION
## Summary
- Use `jq` instead of `node -p` to read version from package.json — Node 24's TypeScript evaluator breaks on the escaped quotes
- Use `RELEASE_TOKEN` for `gh release create` on `workflow_dispatch` — `GITHUB_TOKEN` can't create releases against protected tags

## Test plan
- [ ] Trigger a manual release from Actions UI and verify the full flow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release pipeline and GitHub Release creation credentials, so misconfiguration could block releases or use the wrong token despite limited code changes.
> 
> **Overview**
> Fixes manual (`workflow_dispatch`) release handling in `.github/workflows/release.yml` by deriving the tag from `package.json` via `jq` instead of `node -p`.
> 
> Updates `gh release create` to use `RELEASE_TOKEN` when the workflow is manually triggered (falling back to `GITHUB_TOKEN` otherwise), improving compatibility with protected tag/release permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e1db25f8d434542e7ac384d5ffd33569b29c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->