### PR TITLE
fix: skip publish when version already exists on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,10 +98,23 @@ jobs:
         env:
           TAG: ${{ steps.tag.outputs.value }}
 
+      - name: Check if already published
+        id: check
+        run: |
+          VERSION=$(jq -r .version package.json)
+          if npm view "@waniwani/sdk@$VERSION" version 2>/dev/null; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::v$VERSION is already published to npm, skipping"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
+        if: steps.check.outputs.published == 'false'
         run: npm publish --access public --tag ${{ steps.channel.outputs.npm_tag }} --provenance --ignore-scripts
 
       - name: Create GitHub Release
+        if: steps.check.outputs.published == 'false'
         run: |
           if [[ "$PRERELEASE" == "true" ]]; then
             gh release create "$TAG" --generate-notes --prerelease


### PR DESCRIPTION
## Summary
- Checks npm registry before publishing; skips if the version already exists
- Prevents failures from the duplicate workflow run that occurs when `workflow_dispatch` pushes a `v*` tag (PAT pushes re-trigger tag workflows, unlike `GITHUB_TOKEN`)

## Test plan
- [ ] Trigger a manual release from Actions UI — first run publishes, second run skips cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is confined to the GitHub Actions release workflow and only adds a guard to avoid duplicate publishes/releases when the npm version is already present.
> 
> **Overview**
> Adds an npm registry preflight check to `.github/workflows/release.yml` that detects whether the `package.json` version of `@waniwani/sdk` is already published.
> 
> If the version exists, the workflow emits a notice and **skips** both `npm publish` and `gh release create`, preventing failures from duplicate tag-triggered runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc3ab0f241bd25e168b57a2324dcd89855671dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->