### PR TITLE
feat: lenient chat transport for forward-compatible streaming

### DIFF
--- a/src/chat/server/handle-chat.ts
+++ b/src/chat/server/handle-chat.ts
@@ -112,6 +112,7 @@ export function createChatRequestHandler(deps: ApiHandlerDeps) {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
+					"X-WaniWani-Stream-Protocol": "2",
 					...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
 					...(clientUserAgent
 						? { "X-Client-User-Agent": clientUserAgent }

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -2,8 +2,8 @@
 
 import { useChat } from "@ai-sdk/react";
 import type { FileUIPart } from "ai";
-import { DefaultChatTransport } from "ai";
 import { nanoid } from "nanoid";
+import { LenientChatTransport } from "../lib/lenient-chat-transport";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ModelContextUpdate } from "../../../shared/model-context";
 import { hasModelContext } from "../../../shared/model-context";
@@ -94,7 +94,7 @@ export function useChatEngine(props: ChatBaseProps) {
 	}, []);
 
 	const transportRef = useRef(
-		new DefaultChatTransport({
+		new LenientChatTransport({
 			api,
 			headers: () => ({
 				...headersRef.current,

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -3,12 +3,12 @@
 import { useChat } from "@ai-sdk/react";
 import type { FileUIPart } from "ai";
 import { nanoid } from "nanoid";
-import { LenientChatTransport } from "../lib/lenient-chat-transport";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ModelContextUpdate } from "../../../shared/model-context";
 import { hasModelContext } from "../../../shared/model-context";
 import type { ChatBaseProps } from "../@types";
 import type { PromptInputMessage } from "../ai-elements/prompt-input";
+import { LenientChatTransport } from "../lib/lenient-chat-transport";
 import type { VisitorContext } from "../lib/visitor-context";
 import { collectVisitorContext } from "../lib/visitor-context";
 

--- a/src/chat/web/lib/lenient-chat-transport.ts
+++ b/src/chat/web/lib/lenient-chat-transport.ts
@@ -1,0 +1,130 @@
+/**
+ * A forward-compatible chat transport that handles version mismatches between
+ * the server's `ai` package and the client's `ai` package.
+ *
+ * Two layers of protection:
+ * 1. When a chunk fails validation due to unrecognized fields (from a newer
+ *    `ai` version using `strictObject`), extracts exactly which fields are
+ *    rejected, strips only those, and retries. This preserves events like
+ *    tool outputs so widgets keep rendering.
+ * 2. If the chunk is a completely unknown event type, silently skips it.
+ *    The chat keeps working; only the unrecognised visual is missing.
+ */
+import { DefaultChatTransport, uiMessageChunkSchema } from "ai";
+import type { UIMessage, UIMessageChunk } from "ai";
+
+/**
+ * Extracts unrecognized field names from a validation error.
+ *
+ * Ideally we'd use Zod's `.strip()` to silently drop unknown keys, but
+ * `uiMessageChunkSchema()` wraps the Zod union in a `zodSchema()` closure
+ * that only exposes a `.validate` method — the raw Zod schema is unreachable,
+ * so we can't call `.strip()` on each union branch. Duplicating the schema
+ * here would be fragile and defeat the forward-compatibility goal.
+ *
+ * Instead we parse the Zod error: when a `strictObject` union branch matches
+ * on `type` but rejects unknown fields, the error contains `invalid_union`
+ * with per-branch errors. We find the branch that matched on `type` (no
+ * `invalid_value` on the `type` path) and return its `unrecognized_keys`.
+ */
+function extractKeysToStrip(error: unknown): string[] | null {
+	const cause = (error as { cause?: unknown })?.cause;
+	// biome-ignore lint/suspicious/noExplicitAny: Zod error internals vary across versions
+	const issues: any[] | undefined =
+		(cause as { issues?: unknown[] })?.issues ??
+		(cause as { errors?: unknown[] })?.errors;
+	if (!Array.isArray(issues)) return null;
+
+	// biome-ignore lint/suspicious/noExplicitAny: navigating untyped Zod error tree
+	const unionIssue = issues.find((i: any) => i.code === "invalid_union");
+	if (!unionIssue?.errors) return null;
+
+	for (const branchErrors of unionIssue.errors) {
+		if (!Array.isArray(branchErrors)) continue;
+
+		// Skip branches where `type` didn't match — they have invalid_value on path ["type"]
+		const hasTypeMismatch = branchErrors.some(
+			// biome-ignore lint/suspicious/noExplicitAny: untyped error
+			(e: any) =>
+				(e.code === "invalid_value" || e.code === "invalid_literal") &&
+				e.path?.[0] === "type",
+		);
+		if (hasTypeMismatch) continue;
+
+		// This branch matched on type — extract its unrecognized keys
+		const unrecognized = branchErrors
+			// biome-ignore lint/suspicious/noExplicitAny: untyped error
+			.filter((e: any) => e.code === "unrecognized_keys")
+			// biome-ignore lint/suspicious/noExplicitAny: untyped error
+			.flatMap((e: any) => e.keys ?? []);
+
+		if (unrecognized.length > 0) return unrecognized;
+	}
+
+	return null;
+}
+
+export class LenientChatTransport<
+	UI_MESSAGE extends UIMessage = UIMessage,
+> extends DefaultChatTransport<UI_MESSAGE> {
+	protected override processResponseStream(
+		stream: ReadableStream<Uint8Array>,
+	): ReadableStream<UIMessageChunk> {
+		let buffer = "";
+
+		const schema = uiMessageChunkSchema();
+		const validate = schema.validate?.bind(schema);
+
+		return stream
+			.pipeThrough(new TextDecoderStream() as TransformStream<Uint8Array, string>)
+			.pipeThrough(
+				new TransformStream<string, UIMessageChunk>({
+					async transform(text, controller) {
+						buffer += text;
+						const parts = buffer.split("\n");
+						buffer = parts.pop() ?? "";
+
+						for (const line of parts) {
+							const trimmed = line.trim();
+							if (!trimmed.startsWith("data:")) continue;
+							const data = trimmed.slice(5).trim();
+							if (data === "[DONE]") continue;
+
+							try {
+								const parsed = JSON.parse(data);
+
+								if (!validate) {
+									controller.enqueue(parsed as UIMessageChunk);
+									continue;
+								}
+
+								const result = await validate(parsed);
+								if (result.success) {
+									controller.enqueue(result.value);
+									continue;
+								}
+
+								// Validation failed — try stripping only the unrecognized keys
+								const keysToStrip = extractKeysToStrip(result.error);
+								if (keysToStrip?.length) {
+									const stripped = { ...parsed };
+									for (const key of keysToStrip) {
+										delete stripped[key];
+									}
+									const retry = await validate(stripped);
+									if (retry.success) {
+										controller.enqueue(retry.value);
+										continue;
+									}
+								}
+
+								// Truly unknown event type — skip silently
+							} catch {
+								// Malformed JSON — skip
+							}
+						}
+					},
+				}),
+			);
+	}
+}

--- a/src/chat/web/lib/lenient-chat-transport.ts
+++ b/src/chat/web/lib/lenient-chat-transport.ts
@@ -10,8 +10,9 @@
  * 2. If the chunk is a completely unknown event type, silently skips it.
  *    The chat keeps working; only the unrecognised visual is missing.
  */
-import { DefaultChatTransport, uiMessageChunkSchema } from "ai";
+
 import type { UIMessage, UIMessageChunk } from "ai";
+import { DefaultChatTransport, uiMessageChunkSchema } from "ai";
 
 /**
  * Extracts unrecognized field names from a validation error.
@@ -33,14 +34,20 @@ function extractKeysToStrip(error: unknown): string[] | null {
 	const issues: any[] | undefined =
 		(cause as { issues?: unknown[] })?.issues ??
 		(cause as { errors?: unknown[] })?.errors;
-	if (!Array.isArray(issues)) return null;
+	if (!Array.isArray(issues)) {
+		return null;
+	}
 
 	// biome-ignore lint/suspicious/noExplicitAny: navigating untyped Zod error tree
 	const unionIssue = issues.find((i: any) => i.code === "invalid_union");
-	if (!unionIssue?.errors) return null;
+	if (!unionIssue?.errors) {
+		return null;
+	}
 
 	for (const branchErrors of unionIssue.errors) {
-		if (!Array.isArray(branchErrors)) continue;
+		if (!Array.isArray(branchErrors)) {
+			continue;
+		}
 
 		// Skip branches where `type` didn't match — they have invalid_value on path ["type"]
 		const hasTypeMismatch = branchErrors.some(
@@ -49,7 +56,9 @@ function extractKeysToStrip(error: unknown): string[] | null {
 				(e.code === "invalid_value" || e.code === "invalid_literal") &&
 				e.path?.[0] === "type",
 		);
-		if (hasTypeMismatch) continue;
+		if (hasTypeMismatch) {
+			continue;
+		}
 
 		// This branch matched on type — extract its unrecognized keys
 		const unrecognized = branchErrors
@@ -58,7 +67,9 @@ function extractKeysToStrip(error: unknown): string[] | null {
 			// biome-ignore lint/suspicious/noExplicitAny: untyped error
 			.flatMap((e: any) => e.keys ?? []);
 
-		if (unrecognized.length > 0) return unrecognized;
+		if (unrecognized.length > 0) {
+			return unrecognized;
+		}
 	}
 
 	return null;
@@ -76,7 +87,9 @@ export class LenientChatTransport<
 		const validate = schema.validate?.bind(schema);
 
 		return stream
-			.pipeThrough(new TextDecoderStream() as TransformStream<Uint8Array, string>)
+			.pipeThrough(
+				new TextDecoderStream() as TransformStream<Uint8Array, string>,
+			)
 			.pipeThrough(
 				new TransformStream<string, UIMessageChunk>({
 					async transform(text, controller) {
@@ -86,9 +99,13 @@ export class LenientChatTransport<
 
 						for (const line of parts) {
 							const trimmed = line.trim();
-							if (!trimmed.startsWith("data:")) continue;
+							if (!trimmed.startsWith("data:")) {
+								continue;
+							}
 							const data = trimmed.slice(5).trim();
-							if (data === "[DONE]") continue;
+							if (data === "[DONE]") {
+								continue;
+							}
 
 							try {
 								const parsed = JSON.parse(data);
@@ -114,7 +131,6 @@ export class LenientChatTransport<
 									const retry = await validate(stripped);
 									if (retry.success) {
 										controller.enqueue(retry.value);
-										continue;
 									}
 								}
 


### PR DESCRIPTION
## Summary
- Adds `LenientChatTransport` that extends `DefaultChatTransport` to gracefully handle version mismatches between server and client `ai` packages. When the server sends chunks with fields the client schema doesn't recognize (`strictObject` rejects them), the transport strips only those fields and retries validation. Completely unknown event types are silently skipped.
- Switches `useChatEngine` from `DefaultChatTransport` to `LenientChatTransport`.
- Adds `X-WaniWani-Stream-Protocol: 2` header to chat server requests.

## Test plan
- [ ] Verify chat streaming works normally with matching server/client `ai` versions
- [ ] Simulate a newer server sending extra fields on known chunk types — chat should still render
- [ ] Simulate a newer server sending an unknown chunk type — chat should continue without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side streaming parsing/validation to be permissive, which could mask unexpected chunk formats and affect rendering/debuggability. Also alters upstream chat request headers to opt into stream protocol v2, which may impact compatibility with the API.
> 
> **Overview**
> Improves forward compatibility of chat streaming by introducing `LenientChatTransport`, which tolerates `ai` schema mismatches by stripping only *unrecognized* fields on known chunk types and silently skipping unknown/malformed events.
> 
> Updates `useChatEngine` to use this new transport instead of `DefaultChatTransport`, and adds an `X-WaniWani-Stream-Protocol: 2` header when proxying chat requests to the upstream WaniWani API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962a9e8b4a8b5948495ff59830619aee16fbcd8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->