### PR TITLE
feat: eval panel — inline rename, per-row play buttons, dark theme

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@waniwani/cli",

--- a/src/chat/server/@types.ts
+++ b/src/chat/server/@types.ts
@@ -144,6 +144,8 @@ export interface ApiHandler {
 	routeGet: (request: Request) => Promise<Response>;
 	/** Routes POST sub-paths (e.g. /tool), defaults to chat */
 	routePost: (request: Request) => Promise<Response>;
+	/** Routes PATCH sub-paths (e.g. /scenarios/:id) */
+	routePatch: (request: Request) => Promise<Response>;
 	/** Handles CORS preflight requests */
 	handleOptions: () => Response;
 }

--- a/src/chat/server/@utils.ts
+++ b/src/chat/server/@utils.ts
@@ -5,7 +5,10 @@ export type CorsFunction = (response: Response) => Response;
 export function createCors(): CorsFunction {
 	return function applyCors(response: Response): Response {
 		response.headers.set("Access-Control-Allow-Origin", "*");
-		response.headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+		response.headers.set(
+			"Access-Control-Allow-Methods",
+			"GET, POST, PATCH, OPTIONS",
+		);
 		response.headers.set(
 			"Access-Control-Allow-Headers",
 			"Content-Type, Authorization, X-Session-Id, X-Client-User-Agent",

--- a/src/chat/server/api-handler.ts
+++ b/src/chat/server/api-handler.ts
@@ -182,6 +182,56 @@ export function createApiHandler(options: ApiHandlerOptions = {}): ApiHandler {
 		}
 	}
 
+	async function routePatch(request: Request): Promise<Response> {
+		log("→ PATCH", request.url);
+		try {
+			const url = new URL(request.url);
+			const segments = url.pathname
+				.replace(/\/$/, "")
+				.split("/")
+				.filter(Boolean);
+			const scenarioId = segments.at(-1);
+			const subRoute = segments.at(-2);
+			log("pathname:", url.pathname, "subRoute:", subRoute, "id:", scenarioId);
+
+			if (evalEnabled && subRoute === "scenarios" && scenarioId) {
+				log("dispatching to update-scenario handler (proxy to app API)");
+				try {
+					const body = await request.json();
+					const res = await fetch(`${apiUrl}/api/mcp/scenarios/${scenarioId}`, {
+						method: "PATCH",
+						headers: {
+							"Content-Type": "application/json",
+							...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+						},
+						body: JSON.stringify(body),
+					});
+					const data = await res.json();
+					if (!res.ok) {
+						return json(
+							{ error: data.message ?? "Failed to update scenario" },
+							res.status,
+						);
+					}
+					return json({ ok: true, scenario: data.data }, 200);
+				} catch (e) {
+					const msg =
+						e instanceof Error ? e.message : "Failed to update scenario";
+					return json({ error: msg }, 400);
+				}
+			}
+
+			log("← 404 no matching sub-route for PATCH", subRoute);
+			return json({ error: "Not found" }, 404);
+		} catch (error) {
+			console.error("[waniwani:router] PATCH handler error:", error);
+			const message =
+				error instanceof Error ? error.message : "Unknown error occurred";
+			log("← 500 from caught error");
+			return json({ error: message }, 500);
+		}
+	}
+
 	function handleOptions(): Response {
 		return cors(new Response(null, { status: 204 }));
 	}
@@ -192,6 +242,7 @@ export function createApiHandler(options: ApiHandlerOptions = {}): ApiHandler {
 		handleTool,
 		routeGet,
 		routePost,
+		routePatch,
 		handleOptions,
 	};
 }

--- a/src/chat/server/next-js/@types.ts
+++ b/src/chat/server/next-js/@types.ts
@@ -79,6 +79,8 @@ export interface NextJsHandlerResult {
 	GET: (request: Request) => Promise<Response>;
 	/** POST handler: proxies chat messages to the WaniWani API */
 	POST: (request: Request) => Promise<Response>;
+	/** PATCH handler: routes updates (e.g. /scenarios/:id) */
+	PATCH: (request: Request) => Promise<Response>;
 	/** OPTIONS handler: CORS preflight */
 	OPTIONS: (request: Request) => Response;
 }

--- a/src/chat/server/next-js/index.ts
+++ b/src/chat/server/next-js/index.ts
@@ -50,6 +50,7 @@ export function toNextJsHandler(
 	return {
 		POST: handler.routePost,
 		GET: handler.routeGet,
+		PATCH: handler.routePatch,
 		OPTIONS: () => handler.handleOptions(),
 	};
 }

--- a/src/chat/web/components/eval-panel.tsx
+++ b/src/chat/web/components/eval-panel.tsx
@@ -309,7 +309,7 @@ export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 			const msg = e instanceof Error ? e.message : "Failed to rename scenario";
 			setRenameError(msg);
 		}
-		setEditingId(null);
+		setEditingId((prev) => (prev === id ? null : prev));
 	}
 
 	if (!config.eval) {

--- a/src/chat/web/components/eval-panel.tsx
+++ b/src/chat/web/components/eval-panel.tsx
@@ -188,7 +188,11 @@ function InlineRenameInput({
 			return;
 		}
 		setSaving(true);
-		await onSave(value.trim());
+		try {
+			await onSave(value.trim());
+		} finally {
+			setSaving(false);
+		}
 	}
 
 	function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
@@ -219,16 +223,14 @@ function InlineRenameInput({
 			>
 				{saving ? <LoaderIcon /> : <CheckIcon />}
 			</button>
-			{!saving && (
-				<button
-					type="button"
-					onClick={onCancel}
-					className="ww:bg-foreground ww:text-background ww:rounded-full ww:p-1 ww:transition-colors ww:cursor-pointer ww:shrink-0"
-					title="Cancel"
-				>
-					<XIcon />
-				</button>
-			)}
+			<button
+				type="button"
+				onClick={onCancel}
+				className="ww:bg-foreground ww:text-background ww:rounded-full ww:p-1 ww:transition-colors ww:cursor-pointer ww:shrink-0"
+				title="Cancel"
+			>
+				<XIcon />
+			</button>
 		</div>
 	);
 }

--- a/src/chat/web/components/eval-panel.tsx
+++ b/src/chat/web/components/eval-panel.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type RefObject, useRef, useState } from "react";
+import {
+	type KeyboardEvent,
+	type RefObject,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import type { ChatHandle } from "../@types";
 import { useConfig } from "../hooks/use-config";
 import { type EvalScenario, useScenarios } from "../hooks/use-scenarios";
@@ -27,6 +33,75 @@ function getUserText(msg: ScenarioMessage): string {
 		.join("");
 }
 
+// ---- Icons ----
+
+function PlayIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="12"
+			height="12"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			stroke="none"
+			className={className}
+			role="img"
+		>
+			<title>Run scenario</title>
+			<path d="M6 4l15 8-15 8V4z" />
+		</svg>
+	);
+}
+
+function PencilIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="11"
+			height="11"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={className}
+			role="img"
+		>
+			<title>Rename scenario</title>
+			<path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" />
+		</svg>
+	);
+}
+
+function LoaderIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="12"
+			height="12"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={cn("ww:animate-spin", className)}
+			role="img"
+		>
+			<title>Running</title>
+			<path d="M12 2v4" />
+			<path d="M12 18v4" />
+			<path d="m4.93 4.93 2.83 2.83" />
+			<path d="m16.24 16.24 2.83 2.83" />
+			<path d="M2 12h4" />
+			<path d="M18 12h4" />
+			<path d="m4.93 19.07 2.83-2.83" />
+			<path d="m16.24 4.93 2.83 2.83" />
+		</svg>
+	);
+}
+
 // ---- Sub-components ----
 
 function ScenarioSkeleton() {
@@ -42,6 +117,59 @@ function ScenarioSkeleton() {
 				</div>
 			))}
 		</div>
+	);
+}
+
+function InlineRenameInput({
+	initialName,
+	onSave,
+	onCancel,
+}: {
+	initialName: string;
+	onSave: (name: string) => void;
+	onCancel: () => void;
+}) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const doneRef = useRef(false);
+	const [value, setValue] = useState(initialName);
+
+	useEffect(() => {
+		inputRef.current?.focus();
+		inputRef.current?.select();
+	}, []);
+
+	function commit() {
+		if (doneRef.current) {
+			return;
+		}
+		doneRef.current = true;
+		const trimmed = value.trim();
+		if (trimmed && trimmed !== initialName) {
+			onSave(trimmed);
+		} else {
+			onCancel();
+		}
+	}
+
+	function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+		if (e.key === "Enter") {
+			commit();
+		} else if (e.key === "Escape") {
+			doneRef.current = true;
+			onCancel();
+		}
+	}
+
+	return (
+		<input
+			ref={inputRef}
+			type="text"
+			value={value}
+			onChange={(e) => setValue(e.target.value)}
+			onKeyDown={handleKeyDown}
+			onBlur={commit}
+			className="ww:w-full ww:bg-transparent ww:text-xs ww:font-mono ww:text-foreground ww:outline-none ww:border-b ww:border-foreground/30 ww:py-0.5"
+		/>
 	);
 }
 
@@ -70,11 +198,12 @@ type ScenarioPanelProps = {
  */
 export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 	const effectiveApi = api ?? "/api/waniwani";
-	const [selected, setSelected] = useState<EvalScenario | null>(null);
-	const [running, setRunning] = useState(false);
+	const [runningId, setRunningId] = useState<string | null>(null);
+	const [editingId, setEditingId] = useState<string | null>(null);
+	const [renameError, setRenameError] = useState<string | null>(null);
 	const abortRef = useRef<AbortController | null>(null);
 	const config = useConfig(effectiveApi);
-	const { scenarios, isLoading, reload } = useScenarios(
+	const { scenarios, isLoading, reload, rename } = useScenarios(
 		effectiveApi,
 		config.eval,
 	);
@@ -82,7 +211,7 @@ export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 	async function runScenario(scenario: EvalScenario) {
 		abortRef.current?.abort();
 		abortRef.current = new AbortController();
-		setRunning(true);
+		setRunningId(scenario.id);
 
 		try {
 			if (!chatRef?.current) {
@@ -108,8 +237,19 @@ export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 				console.error("[ScenarioPanel] run failed:", e);
 			}
 		} finally {
-			setRunning(false);
+			setRunningId(null);
 		}
+	}
+
+	async function handleRename(id: string, newName: string) {
+		setRenameError(null);
+		try {
+			await rename(id, newName);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : "Failed to rename scenario";
+			setRenameError(msg);
+		}
+		setEditingId(null);
 	}
 
 	if (!config.eval) {
@@ -151,6 +291,20 @@ export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 				</button>
 			</div>
 
+			{/* Rename error */}
+			{renameError && (
+				<div className="ww:mx-3 ww:my-2 ww:px-2 ww:py-1.5 ww:text-[11px] ww:font-mono ww:text-red-400 ww:bg-red-500/10 ww:rounded ww:flex ww:items-start ww:gap-1.5">
+					<span className="ww:flex-1">{renameError}</span>
+					<button
+						type="button"
+						onClick={() => setRenameError(null)}
+						className="ww:shrink-0 ww:text-red-400 ww:hover:text-red-300 ww:cursor-pointer"
+					>
+						&times;
+					</button>
+				</div>
+			)}
+
 			{/* Scenario list */}
 			<div className="ww:flex-1 ww:overflow-y-auto ww:min-h-0">
 				{isLoading ? (
@@ -160,37 +314,72 @@ export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 						No scenarios found
 					</p>
 				) : (
-					scenarios.map((s) => (
-						<button
-							key={s.name}
-							type="button"
-							onClick={() => setSelected(s)}
-							className={cn(
-								"ww:w-full ww:text-left ww:px-3 ww:py-2 ww:text-xs ww:font-mono ww:transition-colors ww:border-l-2",
-								selected?.name === s.name
-									? "ww:border-[#03d916] ww:bg-[#03d916]/5 ww:text-foreground"
-									: "ww:border-transparent ww:text-foreground/70 ww:hover:text-foreground ww:hover:bg-muted/30",
-							)}
-						>
-							<span className="ww:block ww:truncate">{s.name}</span>
-						</button>
-					))
+					scenarios.map((s) => {
+						const isRunning = runningId === s.id;
+						const isEditing = editingId === s.id;
+
+						return (
+							<div
+								key={s.id}
+								className={cn(
+									"ww:group ww:flex ww:items-center ww:gap-1 ww:px-3 ww:py-2 ww:border-l-2 ww:transition-colors",
+									isRunning
+										? "ww:border-[#03d916] ww:bg-[#03d916]/10"
+										: "ww:border-transparent ww:hover:bg-muted/50",
+								)}
+							>
+								{/* Play / spinner */}
+								<button
+									type="button"
+									onClick={() => runScenario(s)}
+									disabled={runningId !== null}
+									className="ww:shrink-0 ww:text-muted-foreground ww:hover:text-[#03d916] ww:disabled:opacity-40 ww:transition-colors ww:cursor-pointer ww:p-0.5"
+									title="Run scenario"
+								>
+									{isRunning ? <LoaderIcon /> : <PlayIcon />}
+								</button>
+
+								{/* Name (inline editable) */}
+								<div className="ww:flex-1 ww:min-w-0">
+									{isEditing ? (
+										<InlineRenameInput
+											initialName={s.name}
+											onSave={(name) => handleRename(s.id, name)}
+											onCancel={() => setEditingId(null)}
+										/>
+									) : (
+										<button
+											type="button"
+											className="ww:block ww:truncate ww:text-xs ww:font-mono ww:text-foreground ww:cursor-default ww:bg-transparent ww:border-none ww:p-0 ww:text-left"
+											onDoubleClick={() => setEditingId(s.id)}
+											onKeyDown={(e) => {
+												if (e.key === "F2") {
+													setEditingId(s.id);
+												}
+											}}
+											title={s.name}
+										>
+											{s.name}
+										</button>
+									)}
+								</div>
+
+								{/* Rename button */}
+								{!isEditing && !isRunning && (
+									<button
+										type="button"
+										onClick={() => setEditingId(s.id)}
+										className="ww:shrink-0 ww:opacity-0 ww:group-hover:opacity-100 ww:text-muted-foreground ww:hover:text-foreground ww:transition-all ww:cursor-pointer ww:p-0.5"
+										title="Rename scenario"
+									>
+										<PencilIcon />
+									</button>
+								)}
+							</div>
+						);
+					})
 				)}
 			</div>
-
-			{/* Run */}
-			{selected && (
-				<div className="ww:border-t ww:border-border/50 ww:p-3">
-					<button
-						type="button"
-						onClick={() => runScenario(selected)}
-						disabled={running}
-						className="ww:w-full ww:py-2 ww:rounded-md ww:text-xs ww:font-mono ww:font-medium ww:bg-foreground ww:text-background ww:hover:opacity-90 ww:disabled:opacity-50 ww:transition-opacity ww:cursor-pointer"
-					>
-						{running ? "Running..." : "Run scenario"}
-					</button>
-				</div>
-			)}
 		</div>
 	);
 }

--- a/src/chat/web/components/eval-panel.tsx
+++ b/src/chat/web/components/eval-panel.tsx
@@ -74,6 +74,49 @@ function PencilIcon({ className }: { className?: string }) {
 	);
 }
 
+function CheckIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="12"
+			height="12"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={className}
+			role="img"
+		>
+			<title>Confirm</title>
+			<path d="M20 6 9 17l-5-5" />
+		</svg>
+	);
+}
+
+function XIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="12"
+			height="12"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={className}
+			role="img"
+		>
+			<title>Cancel</title>
+			<path d="M18 6 6 18" />
+			<path d="m6 6 12 12" />
+		</svg>
+	);
+}
+
 function LoaderIcon({ className }: { className?: string }) {
 	return (
 		<svg
@@ -126,50 +169,67 @@ function InlineRenameInput({
 	onCancel,
 }: {
 	initialName: string;
-	onSave: (name: string) => void;
+	onSave: (name: string) => Promise<void>;
 	onCancel: () => void;
 }) {
 	const inputRef = useRef<HTMLInputElement>(null);
-	const doneRef = useRef(false);
 	const [value, setValue] = useState(initialName);
+	const [saving, setSaving] = useState(false);
 
 	useEffect(() => {
 		inputRef.current?.focus();
 		inputRef.current?.select();
 	}, []);
 
-	function commit() {
-		if (doneRef.current) {
+	const canSave = value.trim() !== "" && value.trim() !== initialName;
+
+	async function commit() {
+		if (!canSave || saving) {
 			return;
 		}
-		doneRef.current = true;
-		const trimmed = value.trim();
-		if (trimmed && trimmed !== initialName) {
-			onSave(trimmed);
-		} else {
-			onCancel();
-		}
+		setSaving(true);
+		await onSave(value.trim());
 	}
 
 	function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
 		if (e.key === "Enter") {
 			commit();
 		} else if (e.key === "Escape") {
-			doneRef.current = true;
 			onCancel();
 		}
 	}
 
 	return (
-		<input
-			ref={inputRef}
-			type="text"
-			value={value}
-			onChange={(e) => setValue(e.target.value)}
-			onKeyDown={handleKeyDown}
-			onBlur={commit}
-			className="ww:w-full ww:bg-transparent ww:text-xs ww:font-mono ww:text-foreground ww:outline-none ww:border-b ww:border-foreground/30 ww:py-0.5"
-		/>
+		<div className="ww:flex ww:items-center ww:gap-1">
+			<input
+				ref={inputRef}
+				type="text"
+				value={value}
+				onChange={(e) => setValue(e.target.value)}
+				onKeyDown={handleKeyDown}
+				disabled={saving}
+				className="ww:flex-1 ww:min-w-0 ww:bg-transparent ww:text-xs ww:leading-normal ww:font-mono ww:text-foreground ww:outline-none ww:border-b ww:border-foreground/30 ww:p-0 ww:disabled:opacity-50"
+			/>
+			<button
+				type="button"
+				onClick={commit}
+				disabled={!canSave || saving}
+				className="ww:bg-foreground ww:text-background ww:rounded-full ww:p-1 ww:disabled:opacity-30 ww:transition-colors ww:cursor-pointer ww:shrink-0"
+				title="Confirm rename"
+			>
+				{saving ? <LoaderIcon /> : <CheckIcon />}
+			</button>
+			{!saving && (
+				<button
+					type="button"
+					onClick={onCancel}
+					className="ww:bg-foreground ww:text-background ww:rounded-full ww:p-1 ww:transition-colors ww:cursor-pointer ww:shrink-0"
+					title="Cancel"
+				>
+					<XIcon />
+				</button>
+			)}
+		</div>
 	);
 }
 
@@ -258,18 +318,19 @@ export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 
 	return (
 		<div
+			data-waniwani-chat=""
 			className="ww:flex ww:flex-col ww:h-full ww:overflow-hidden ww:text-foreground ww:border-l ww:border-border ww:shrink-0"
 			style={{ width: PANEL_WIDTH }}
 		>
 			{/* Header */}
 			<div className="ww:px-3 ww:py-2 ww:border-b ww:border-border/50 ww:flex ww:items-center ww:justify-between">
-				<span className="ww:text-[10px] ww:font-mono ww:uppercase ww:tracking-widest ww:text-muted-foreground">
+				<span className="ww:text-[10px] ww:font-mono ww:uppercase ww:tracking-widest ww:text-foreground/60">
 					Scenarios
 				</span>
 				<button
 					type="button"
 					onClick={reload}
-					className="ww:text-muted-foreground ww:hover:text-foreground ww:transition-colors ww:cursor-pointer"
+					className="ww:bg-foreground ww:text-background ww:rounded-full ww:p-1 ww:transition-colors ww:cursor-pointer"
 					title="Reload scenarios"
 				>
 					<svg
@@ -310,7 +371,7 @@ export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 				{isLoading ? (
 					<ScenarioSkeleton />
 				) : scenarios.length === 0 ? (
-					<p className="ww:text-xs ww:font-mono ww:text-muted-foreground ww:text-center ww:py-8 ww:px-4">
+					<p className="ww:text-xs ww:font-mono ww:text-foreground/50 ww:text-center ww:py-8 ww:px-4">
 						No scenarios found
 					</p>
 				) : (
@@ -328,17 +389,6 @@ export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 										: "ww:border-transparent ww:hover:bg-muted/50",
 								)}
 							>
-								{/* Play / spinner */}
-								<button
-									type="button"
-									onClick={() => runScenario(s)}
-									disabled={runningId !== null}
-									className="ww:shrink-0 ww:text-muted-foreground ww:hover:text-[#03d916] ww:disabled:opacity-40 ww:transition-colors ww:cursor-pointer ww:p-0.5"
-									title="Run scenario"
-								>
-									{isRunning ? <LoaderIcon /> : <PlayIcon />}
-								</button>
-
 								{/* Name (inline editable) */}
 								<div className="ww:flex-1 ww:min-w-0">
 									{isEditing ? (
@@ -348,32 +398,38 @@ export function ScenarioPanel({ api, chatRef }: ScenarioPanelProps) {
 											onCancel={() => setEditingId(null)}
 										/>
 									) : (
-										<button
-											type="button"
-											className="ww:block ww:truncate ww:text-xs ww:font-mono ww:text-foreground ww:cursor-default ww:bg-transparent ww:border-none ww:p-0 ww:text-left"
-											onDoubleClick={() => setEditingId(s.id)}
-											onKeyDown={(e) => {
-												if (e.key === "F2") {
-													setEditingId(s.id);
-												}
-											}}
+										<span
+											className="ww:block ww:truncate ww:text-xs ww:font-mono ww:text-foreground"
 											title={s.name}
 										>
 											{s.name}
-										</button>
+										</span>
 									)}
 								</div>
 
-								{/* Rename button */}
-								{!isEditing && !isRunning && (
-									<button
-										type="button"
-										onClick={() => setEditingId(s.id)}
-										className="ww:shrink-0 ww:opacity-0 ww:group-hover:opacity-100 ww:text-muted-foreground ww:hover:text-foreground ww:transition-all ww:cursor-pointer ww:p-0.5"
-										title="Rename scenario"
-									>
-										<PencilIcon />
-									</button>
+								{/* Action buttons (right side) */}
+								{!isEditing && (
+									<div className="ww:flex ww:items-center ww:gap-1 ww:shrink-0">
+										{!isRunning && (
+											<button
+												type="button"
+												onClick={() => setEditingId(s.id)}
+												className="ww:opacity-0 ww:group-hover:opacity-100 ww:bg-foreground ww:text-background ww:rounded-full ww:p-1 ww:transition-all ww:cursor-pointer"
+												title="Rename scenario"
+											>
+												<PencilIcon />
+											</button>
+										)}
+										<button
+											type="button"
+											onClick={() => runScenario(s)}
+											disabled={runningId !== null}
+											className="ww:bg-foreground ww:text-background ww:rounded-full ww:p-1 ww:disabled:opacity-40 ww:transition-colors ww:cursor-pointer"
+											title="Run scenario"
+										>
+											{isRunning ? <LoaderIcon /> : <PlayIcon />}
+										</button>
+									</div>
 								)}
 							</div>
 						);

--- a/src/chat/web/hooks/use-scenarios.ts
+++ b/src/chat/web/hooks/use-scenarios.ts
@@ -9,6 +9,7 @@ type ScenarioMessage = {
 	parts: ScenarioPart[];
 };
 export type EvalScenario = {
+	id: string;
 	name: string;
 	type?: "regulatory" | "functional" | "adversarial";
 	mode?: "regenerate" | "inject";
@@ -36,5 +37,22 @@ export function useScenarios(api: string, enabled: boolean) {
 		load();
 	}, [load]);
 
-	return { scenarios, isLoading, reload: load };
+	const rename = useCallback(
+		async (id: string, name: string) => {
+			const res = await fetch(`${api}/scenarios/${id}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ name }),
+			});
+			if (!res.ok) {
+				throw new Error("Failed to rename scenario");
+			}
+			setScenarios((prev) =>
+				prev.map((s) => (s.id === id ? { ...s, name } : s)),
+			);
+		},
+		[api],
+	);
+
+	return { scenarios, isLoading, reload: load, rename };
 }

--- a/src/chat/web/hooks/use-scenarios.ts
+++ b/src/chat/web/hooks/use-scenarios.ts
@@ -45,7 +45,10 @@ export function useScenarios(api: string, enabled: boolean) {
 				body: JSON.stringify({ name }),
 			});
 			if (!res.ok) {
-				throw new Error("Failed to rename scenario");
+				const data = await res.json().catch(() => null);
+				throw new Error(
+					data?.error ?? `Failed to rename scenario (${res.status})`,
+				);
 			}
 			setScenarios((prev) =>
 				prev.map((s) => (s.id === id ? { ...s, name } : s)),

--- a/src/chat/web/tailwind.css
+++ b/src/chat/web/tailwind.css
@@ -99,6 +99,26 @@
 	--ww-font-sans: var(--ww-font, system-ui, -apple-system, "Segoe UI", sans-serif);
 }
 
+.dark [data-waniwani-chat],
+[data-waniwani-chat].dark {
+	--ww-color-background: var(--ww-bg, #212121);
+	--ww-color-foreground: var(--ww-text, #ececec);
+	--ww-color-primary: var(--ww-primary, #6366f1);
+	--ww-color-primary-foreground: var(--ww-primary-fg, #ffffff);
+	--ww-color-muted-foreground: var(--ww-muted, #8e8ea0);
+	--ww-color-border: var(--ww-border, #444444);
+	--ww-color-input: var(--ww-input-bg, #2f2f2f);
+	--ww-color-accent: var(--ww-assistant-bubble, #2f2f2f);
+	--ww-color-accent-foreground: var(--ww-text, #ececec);
+	--ww-color-user-bubble: var(--ww-user-bubble, #303030);
+	--ww-color-card: var(--ww-bg, #212121);
+	--ww-color-card-foreground: var(--ww-text, #ececec);
+	--ww-color-card-header: var(--ww-header-bg, #1e1e1e);
+	--ww-color-card-header-foreground: var(--ww-header-text, #ececec);
+	--ww-color-status: var(--ww-status, #22c55e);
+	--ww-color-tool-card: var(--ww-tool-card, #262626);
+}
+
 /* ─── Streamdown overrides ─────────────────────────────────────────────
    Streamdown uses unprefixed Tailwind classes internally, but our CSS is
    compiled with prefix(ww). We re-apply the styles via data-streamdown


### PR DESCRIPTION
## Summary

- **Per-row play buttons** — replaced select-then-run with inline play/spinner per scenario row, styled as rounded white buttons matching chat bar
- **Inline rename** — pencil icon (hover-reveal) opens inline input with check/cancel buttons; Enter commits, Escape cancels, loading spinner during PATCH
- **Dark theme support** — added `.dark [data-waniwani-chat]` CSS fallbacks so eval panel inherits correct theme vars without JS theme injection
- **PATCH endpoint** — new `routePatch` on API handler proxies scenario rename requests to app API
- **Rename error banner** — dismissible inline error shown on failed renames
- **`id` field on `EvalScenario`** — scenarios keyed by id instead of name

## Screenshots




<img width="640" height="301" alt="pr-screenshot-normal" src="https://github.com/user-attachments/assets/85e0a43a-161c-4985-9055-d9b402ff9755" />
<img width="640" height="285" alt="pr-screenshot-edit" src="https://github.com/user-attachments/assets/24188372-c804-47da-9bb0-8316edcc295d" />

<!-- Paste screenshots from /tmp/pr-screenshot-normal.png, /tmp/pr-screenshot-edit.png, /tmp/pr-screenshot-full.png -->

## Test plan

- [x] Verify scenario list renders with readable text on dark theme
- [x] Click play button → scenario runs, spinner shows, other buttons disabled
- [x] Click pencil → inline rename input with check/cancel buttons
- [x] Enter commits rename, Escape cancels, check button shows spinner during save
- [ ] Rename error shows dismissible banner
- [x] Verify light theme still works (no regression from dark CSS fallbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `PATCH` route and CORS method support for updating eval scenarios, plus UI logic for renaming/running scenarios; risk is mainly around request routing/proxying and error handling for the new endpoint.
> 
> **Overview**
> Updates the dev-only eval scenarios panel to run scenarios via **per-row play buttons** (with per-scenario spinner/disabled state) and to support **inline renaming** with enter/escape handling and a dismissible error banner.
> 
> Adds client-side `PATCH` rename support in `useScenarios` and introduces a server-side `routePatch` that proxies `PATCH /scenarios/:id` to the app API; Next.js adapter and CORS helpers are updated to expose `PATCH` as a first-class handler/method.
> 
> Adds CSS variable fallbacks for **dark mode** under `.dark [data-waniwani-chat]` so the eval panel inherits correct theme tokens without JS injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3f2a9b38e18b492e2966419ca1af224a07fedf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->