### PR TITLE
fix: guard against non-array scenarios response

### DIFF
--- a/src/chat/web/hooks/use-scenarios.ts
+++ b/src/chat/web/hooks/use-scenarios.ts
@@ -28,7 +28,7 @@ export function useScenarios(api: string, enabled: boolean) {
 		setIsLoading(true);
 		fetch(`${api}/scenarios`)
 			.then((r) => r.json())
-			.then((data: EvalScenario[]) => setScenarios(data))
+			.then((data) => setScenarios(Array.isArray(data) ? data : []))
 			.catch(() => {})
 			.finally(() => setIsLoading(false));
 	}, [api, enabled]);


### PR DESCRIPTION
## Summary

- `useScenarios` hook crashes when API returns error object (e.g. `{success: false}`) instead of array
- Happens with `WANIWANI_EVAL=1` but invalid/missing API key
- Fix: `Array.isArray(data) ? data : []` before `setScenarios`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small defensive change in a client hook to avoid crashes when the scenarios endpoint returns an unexpected JSON shape; behavior on valid responses is unchanged.
> 
> **Overview**
> Prevents `useScenarios` from crashing when `${api}/scenarios` returns a non-array JSON payload (e.g., error objects) by only calling `setScenarios` with the response when `Array.isArray(data)` and otherwise falling back to `[]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a5f2604c4869a04c7c8df102ae2d83eb330ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->