### PR TITLE
fix: window.fetch override type error with newer TS types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build

--- a/src/mcp/react/components/initialize-next-in-chat-gpt.tsx
+++ b/src/mcp/react/components/initialize-next-in-chat-gpt.tsx
@@ -111,7 +111,7 @@ export function InitializeNextJsInChatGpt({ baseUrl }: { baseUrl: string }) {
 						if (isInIframe && window.location.origin !== appOrigin) {
 							const originalFetch = window.fetch;
 
-							window.fetch = (
+							(window as { fetch: typeof window.fetch }).fetch = ((
 								input: URL | RequestInfo,
 								init?: RequestInit,
 							): Promise<Response> => {
@@ -155,7 +155,7 @@ export function InitializeNextJsInChatGpt({ baseUrl }: { baseUrl: string }) {
 								}
 
 								return originalFetch.call(window, input, init);
-							};
+							}) as typeof window.fetch;
 						}
 					}).toString() +
 					")()"}


### PR DESCRIPTION
## Summary

- CI release fails: `Property 'preconnect' is missing in type '...' but required in type 'typeof fetch'`
- Newer TS/Node types added `preconnect` to `typeof fetch`
- Fix: cast fetch reassignment as `typeof window.fetch`

## Test plan

- [x] CI build passes (typecheck step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a basic CI build job and a TypeScript-only cast for the `window.fetch` reassignment; behavior is unchanged aside from type-checking.
> 
> **Overview**
> Adds a GitHub Actions `CI` workflow that installs dependencies with Bun and runs `bun run build` on pushes and PRs to `main`.
> 
> Adjusts the `window.fetch` override in `initialize-next-in-chat-gpt.tsx` to explicitly cast the reassigned function as `typeof window.fetch`, resolving newer TS/DOM type requirements without changing runtime request-rewrite logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc079bbdde19f379d512c44a8962123e0601226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->