### PR TITLE
feat(mcp): declarative PII redaction for tracked tool events

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -28,6 +28,7 @@ export {
 	createFlow,
 	createFlowTestHarness,
 	END,
+	redacted,
 	START,
 	StateGraph,
 } from "./server/flows";

--- a/src/mcp/server/flows/__tests__/redacted.test.ts
+++ b/src/mcp/server/flows/__tests__/redacted.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { McpServer } from "../@types";
+import { END, START } from "../@types";
+import { createFlow } from "../create-flow";
+import {
+	collectRedactedStateFields,
+	isFieldRedacted,
+	REDACTED_STATE_UPDATE_FIELDS_META_KEY,
+	redacted,
+} from "../redacted";
+
+type Handler = (input: unknown, extra: unknown) => Promise<unknown>;
+type RegisterToolArgs = [string, Record<string, unknown>, Handler];
+
+function mockServer() {
+	const registered: RegisterToolArgs[] = [];
+	const server = {
+		registerTool: (...args: unknown[]) => {
+			registered.push(args as RegisterToolArgs);
+		},
+	};
+	return { server: server as unknown as McpServer, registered };
+}
+
+describe("redacted()", () => {
+	test("marks a schema so isFieldRedacted returns true", () => {
+		const schema = redacted(z.string().describe("age"));
+		expect(isFieldRedacted(schema)).toBe(true);
+	});
+
+	test("unmarked schemas return false", () => {
+		expect(isFieldRedacted(z.string())).toBe(false);
+	});
+
+	test("collectRedactedStateFields returns marked field names", () => {
+		const fields = collectRedactedStateFields({
+			locale: z.enum(["es", "en"]).default("es"),
+			ages: redacted(z.string().describe("ages")),
+			zipcode: redacted(z.string().describe("zipcode")),
+			company: z.string().default("all"),
+		});
+		expect(fields.sort()).toEqual(["ages", "zipcode"]);
+	});
+
+	test("empty state returns empty list", () => {
+		expect(collectRedactedStateFields(undefined)).toEqual([]);
+		expect(collectRedactedStateFields({})).toEqual([]);
+	});
+});
+
+describe("flow compile — redacted state fields on tool _meta", () => {
+	test("attaches field names to tool _meta when any are marked", async () => {
+		const flow = createFlow({
+			id: "test_flow",
+			title: "Test",
+			description: "desc",
+			state: {
+				locale: z.enum(["es", "en"]).default("es"),
+				ages: redacted(z.string().describe("ages")),
+				zipcode: redacted(z.string().describe("zipcode")),
+			},
+		})
+			.addEdge(START, END)
+			.compile();
+
+		const mock = mockServer();
+		await flow.register(mock.server);
+
+		const [, config] = mock.registered[0] ?? [];
+		const meta = config?._meta as Record<string, unknown> | undefined;
+		expect(meta).toBeDefined();
+		expect(
+			(meta?.[REDACTED_STATE_UPDATE_FIELDS_META_KEY] as string[]).sort(),
+		).toEqual(["ages", "zipcode"]);
+	});
+
+	test("omits _meta when no fields are marked", async () => {
+		const flow = createFlow({
+			id: "plain_flow",
+			title: "Plain",
+			description: "desc",
+			state: {
+				locale: z.enum(["es", "en"]).default("es"),
+			},
+		})
+			.addEdge(START, END)
+			.compile();
+
+		const mock = mockServer();
+		await flow.register(mock.server);
+
+		const [, config] = mock.registered[0] ?? [];
+		const meta = config?._meta as Record<string, unknown> | undefined;
+		expect(meta?.[REDACTED_STATE_UPDATE_FIELDS_META_KEY]).toBe(undefined);
+	});
+});

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -20,6 +20,10 @@ import { executeFrom, resolveNextNode, type ValidateFn } from "./execute";
 import { type FlowStore, WaniwaniFlowStore } from "./flow-store";
 import { deepMerge, expandDotPaths } from "./nested";
 import { buildFlowProtocol } from "./protocol";
+import {
+	collectRedactedStateFields,
+	REDACTED_STATE_UPDATE_FIELDS_META_KEY,
+} from "./redacted";
 
 // ============================================================================
 // Input schema
@@ -196,11 +200,19 @@ export function compileFlow<TState extends Record<string, unknown>>(
 		};
 	}
 
+	const redactedStateFields = collectRedactedStateFields(
+		config.state as Record<string, z.ZodType> | undefined,
+	);
 	const toolConfig = {
 		title: config.title,
 		description: fullDescription,
 		inputSchema,
 		annotations: config.annotations,
+		...(redactedStateFields.length > 0 && {
+			_meta: {
+				[REDACTED_STATE_UPDATE_FIELDS_META_KEY]: redactedStateFields,
+			},
+		}),
 	};
 
 	const toolHandler = (async (args: FlowToolInput, extra: unknown) => {

--- a/src/mcp/server/flows/index.ts
+++ b/src/mcp/server/flows/index.ts
@@ -18,6 +18,8 @@ export { createFlow } from "./create-flow";
 // State store
 export type { FlowStore } from "./flow-store";
 export { WaniwaniFlowStore } from "./flow-store";
+// Schema field redaction marker
+export { redacted } from "./redacted";
 // Builder
 export { StateGraph } from "./state-graph";
 // Test utilities

--- a/src/mcp/server/flows/redacted.ts
+++ b/src/mcp/server/flows/redacted.ts
@@ -1,0 +1,68 @@
+import type { z } from "zod";
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Mark a Zod schema as PII — its value will be replaced with `"REDACTED"` in
+ * any `tool.called` event payload sent to the WaniWani API. The handler still
+ * receives the original value; only the tracked copy is scrubbed.
+ *
+ * Apply at the end of the schema chain so the marker is attached to the final
+ * schema:
+ *
+ * ```ts
+ * ages: redacted(z.string().describe("Comma-separated ages")),
+ * zipcode: redacted(z.string().describe("Spanish postal code")),
+ * ```
+ *
+ * Uses Zod v4's `.meta()` registry, so the marker is preserved across schema
+ * clones (`.optional()`, `.default()`, etc.).
+ */
+export function redacted<T extends z.ZodType>(schema: T): T {
+	const existing = readMeta(schema);
+	const waniwani = isRecord(existing.waniwani) ? existing.waniwani : {};
+	return (schema as unknown as { meta: (m: UnknownRecord) => T }).meta({
+		...existing,
+		waniwani: { ...waniwani, redacted: true },
+	});
+}
+
+export function isFieldRedacted(schema: z.ZodType): boolean {
+	const meta = readMeta(schema);
+	const waniwani = meta.waniwani;
+	return isRecord(waniwani) && waniwani.redacted === true;
+}
+
+function readMeta(schema: z.ZodType): UnknownRecord {
+	const metaFn = (schema as unknown as { meta?: () => unknown }).meta;
+	if (typeof metaFn !== "function") {
+		return {};
+	}
+	const value = metaFn.call(schema);
+	return isRecord(value) ? value : {};
+}
+
+/**
+ * Walk a flow state schema and return the field names marked via `redacted()`.
+ */
+export function collectRedactedStateFields(
+	state: Record<string, z.ZodType> | undefined,
+): string[] {
+	if (!state) {
+		return [];
+	}
+	const out: string[] = [];
+	for (const [name, schema] of Object.entries(state)) {
+		if (isFieldRedacted(schema)) {
+			out.push(name);
+		}
+	}
+	return out;
+}
+
+export const REDACTED_STATE_UPDATE_FIELDS_META_KEY =
+	"waniwani/redactedStateUpdateFields";

--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -628,4 +628,239 @@ describe("withWaniwani", () => {
 		});
 		expect(meta.waniwani).toBe(undefined);
 	});
+
+	test("stripGeoCoordinates removes latitude/longitude from known location meta keys", async () => {
+		const { client, tracked } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, { client, stripGeoCoordinates: true });
+
+		mock.registerTool("pricing", {}, async () => ({
+			_meta: {
+				"openai/userLocation": {
+					city: "Madrid",
+					country: "ES",
+					latitude: "40.4",
+					longitude: "-3.7",
+				},
+			},
+			content: [],
+		}));
+
+		const handler = mock.registered[0]?.[2];
+		await handler?.(
+			{},
+			{
+				_meta: {
+					"openai/userLocation": {
+						city: "Madrid",
+						country: "ES",
+						latitude: "40.4",
+						longitude: "-3.7",
+					},
+					"waniwani/geoLocation": {
+						country: "ES",
+						latitude: "40.4",
+						longitude: "-3.7",
+					},
+				},
+			},
+		);
+
+		const event = tracked[0] as {
+			meta?: Record<string, unknown>;
+			properties: { output?: { _meta?: Record<string, unknown> } };
+		};
+		expect(event.meta?.["openai/userLocation"]).toEqual({
+			city: "Madrid",
+			country: "ES",
+		});
+		expect(event.meta?.["waniwani/geoLocation"]).toEqual({ country: "ES" });
+		expect(event.properties.output?._meta?.["openai/userLocation"]).toEqual({
+			city: "Madrid",
+			country: "ES",
+		});
+	});
+
+	test("applies redactMeta to request meta and output _meta", async () => {
+		const { client, tracked } = mockClient();
+		const mock = mockServer();
+
+		const redactMeta = (meta: Record<string, unknown>) => {
+			const next = { ...meta };
+			const loc = next["openai/userLocation"];
+			if (loc && typeof loc === "object") {
+				const {
+					latitude: _lat,
+					longitude: _lng,
+					...rest
+				} = loc as Record<string, unknown>;
+				next["openai/userLocation"] = rest;
+			}
+			return next;
+		};
+
+		withWaniwani(mock.server, { client, redactMeta });
+
+		mock.registerTool("pricing", {}, async () => ({
+			_meta: {
+				"openai/userLocation": {
+					city: "Madrid",
+					latitude: "40.4",
+					longitude: "-3.7",
+				},
+			},
+			content: [],
+		}));
+
+		const handler = mock.registered[0]?.[2];
+		await handler?.(
+			{},
+			{
+				_meta: {
+					"openai/userLocation": {
+						city: "Madrid",
+						latitude: "40.4",
+						longitude: "-3.7",
+					},
+				},
+			},
+		);
+
+		const event = tracked[0] as {
+			meta?: Record<string, unknown>;
+			properties: { output?: { _meta?: Record<string, unknown> } };
+		};
+		expect(event.meta?.["openai/userLocation"]).toEqual({ city: "Madrid" });
+		expect(event.properties.output?._meta?.["openai/userLocation"]).toEqual({
+			city: "Madrid",
+		});
+	});
+
+	test("auto-redacts stateUpdates fields listed in tool definition _meta", async () => {
+		const { client, tracked } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, { client });
+
+		let handlerSaw: unknown;
+		mock.registerTool(
+			"flow_tool",
+			{
+				_meta: {
+					"waniwani/redactedStateUpdateFields": ["ages", "zipcode"],
+				},
+			},
+			async (input: unknown) => {
+				handlerSaw = input;
+				return { content: [] };
+			},
+		);
+
+		const handler = mock.registered[0]?.[2];
+		await handler?.(
+			{
+				action: "continue",
+				stateUpdates: { ages: "35,32", zipcode: "28001", modality: "all" },
+			},
+			{},
+		);
+
+		expect(handlerSaw).toEqual({
+			action: "continue",
+			stateUpdates: { ages: "35,32", zipcode: "28001", modality: "all" },
+		});
+
+		const event = tracked[0] as {
+			properties: { input?: Record<string, unknown> };
+		};
+		expect(event.properties.input).toEqual({
+			action: "continue",
+			stateUpdates: {
+				ages: "REDACTED",
+				zipcode: "REDACTED",
+				modality: "all",
+			},
+		});
+	});
+
+	test("applyFieldRedactions: false disables the built-in stateUpdates redaction", async () => {
+		const { client, tracked } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, { client, applyFieldRedactions: false });
+
+		mock.registerTool(
+			"flow_tool",
+			{
+				_meta: {
+					"waniwani/redactedStateUpdateFields": ["ages"],
+				},
+			},
+			async () => ({ content: [] }),
+		);
+
+		const handler = mock.registered[0]?.[2];
+		await handler?.(
+			{ action: "continue", stateUpdates: { ages: "35,32" } },
+			{},
+		);
+
+		const event = tracked[0] as {
+			properties: { input?: Record<string, unknown> };
+		};
+		expect(event.properties.input).toEqual({
+			action: "continue",
+			stateUpdates: { ages: "35,32" },
+		});
+	});
+
+	test("applies redactInput to tracked input only", async () => {
+		const { client, tracked } = mockClient();
+		const mock = mockServer();
+
+		const redactInput = (input: unknown, toolName: string) => {
+			if (toolName !== "flow" || typeof input !== "object" || !input) {
+				return input;
+			}
+			const { stateUpdates, ...rest } = input as Record<string, unknown>;
+			if (!stateUpdates || typeof stateUpdates !== "object") {
+				return input;
+			}
+			return {
+				...rest,
+				stateUpdates: {
+					...(stateUpdates as Record<string, unknown>),
+					age: "REDACTED",
+				},
+			};
+		};
+
+		let handlerSawInput: unknown;
+		withWaniwani(mock.server, { client, redactInput });
+		mock.registerTool("flow", {}, async (input: unknown) => {
+			handlerSawInput = input;
+			return { content: [] };
+		});
+
+		const handler = mock.registered[0]?.[2];
+		await handler?.(
+			{ action: "continue", stateUpdates: { age: 35, zipcode: "28001" } },
+			{},
+		);
+
+		// Handler sees original input
+		expect(handlerSawInput).toEqual({
+			action: "continue",
+			stateUpdates: { age: 35, zipcode: "28001" },
+		});
+		// Tracked event has redacted input
+		const event = tracked[0] as {
+			properties: { input?: Record<string, unknown> };
+		};
+		expect(event.properties.input).toEqual({
+			action: "continue",
+			stateUpdates: { age: "REDACTED", zipcode: "28001" },
+		});
+	});
 });

--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -682,61 +682,6 @@ describe("withWaniwani", () => {
 		});
 	});
 
-	test("applies redactMeta to request meta and output _meta", async () => {
-		const { client, tracked } = mockClient();
-		const mock = mockServer();
-
-		const redactMeta = (meta: Record<string, unknown>) => {
-			const next = { ...meta };
-			const loc = next["openai/userLocation"];
-			if (loc && typeof loc === "object") {
-				const {
-					latitude: _lat,
-					longitude: _lng,
-					...rest
-				} = loc as Record<string, unknown>;
-				next["openai/userLocation"] = rest;
-			}
-			return next;
-		};
-
-		withWaniwani(mock.server, { client, redactMeta });
-
-		mock.registerTool("pricing", {}, async () => ({
-			_meta: {
-				"openai/userLocation": {
-					city: "Madrid",
-					latitude: "40.4",
-					longitude: "-3.7",
-				},
-			},
-			content: [],
-		}));
-
-		const handler = mock.registered[0]?.[2];
-		await handler?.(
-			{},
-			{
-				_meta: {
-					"openai/userLocation": {
-						city: "Madrid",
-						latitude: "40.4",
-						longitude: "-3.7",
-					},
-				},
-			},
-		);
-
-		const event = tracked[0] as {
-			meta?: Record<string, unknown>;
-			properties: { output?: { _meta?: Record<string, unknown> } };
-		};
-		expect(event.meta?.["openai/userLocation"]).toEqual({ city: "Madrid" });
-		expect(event.properties.output?._meta?.["openai/userLocation"]).toEqual({
-			city: "Madrid",
-		});
-	});
-
 	test("auto-redacts stateUpdates fields listed in tool definition _meta", async () => {
 		const { client, tracked } = mockClient();
 		const mock = mockServer();
@@ -812,55 +757,6 @@ describe("withWaniwani", () => {
 		expect(event.properties.input).toEqual({
 			action: "continue",
 			stateUpdates: { ages: "35,32" },
-		});
-	});
-
-	test("applies redactInput to tracked input only", async () => {
-		const { client, tracked } = mockClient();
-		const mock = mockServer();
-
-		const redactInput = (input: unknown, toolName: string) => {
-			if (toolName !== "flow" || typeof input !== "object" || !input) {
-				return input;
-			}
-			const { stateUpdates, ...rest } = input as Record<string, unknown>;
-			if (!stateUpdates || typeof stateUpdates !== "object") {
-				return input;
-			}
-			return {
-				...rest,
-				stateUpdates: {
-					...(stateUpdates as Record<string, unknown>),
-					age: "REDACTED",
-				},
-			};
-		};
-
-		let handlerSawInput: unknown;
-		withWaniwani(mock.server, { client, redactInput });
-		mock.registerTool("flow", {}, async (input: unknown) => {
-			handlerSawInput = input;
-			return { content: [] };
-		});
-
-		const handler = mock.registered[0]?.[2];
-		await handler?.(
-			{ action: "continue", stateUpdates: { age: 35, zipcode: "28001" } },
-			{},
-		);
-
-		// Handler sees original input
-		expect(handlerSawInput).toEqual({
-			action: "continue",
-			stateUpdates: { age: 35, zipcode: "28001" },
-		});
-		// Tracked event has redacted input
-		const event = tracked[0] as {
-			properties: { input?: Record<string, unknown> };
-		};
-		expect(event.properties.input).toEqual({
-			action: "continue",
-			stateUpdates: { age: "REDACTED", zipcode: "28001" },
 		});
 	});
 });

--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -741,7 +741,7 @@ describe("withWaniwani", () => {
 		const { client, tracked } = mockClient();
 		const mock = mockServer();
 
-		withWaniwani(mock.server, { client });
+		withWaniwani(mock.server, { client, applyFieldRedactions: true });
 
 		let handlerSaw: unknown;
 		mock.registerTool(
@@ -784,11 +784,11 @@ describe("withWaniwani", () => {
 		});
 	});
 
-	test("applyFieldRedactions: false disables the built-in stateUpdates redaction", async () => {
+	test("applyFieldRedactions defaults to false — markers are ignored", async () => {
 		const { client, tracked } = mockClient();
 		const mock = mockServer();
 
-		withWaniwani(mock.server, { client, applyFieldRedactions: false });
+		withWaniwani(mock.server, { client });
 
 		mock.registerTool(
 			"flow_tool",

--- a/src/mcp/server/with-waniwani/helpers.ts
+++ b/src/mcp/server/with-waniwani/helpers.ts
@@ -103,38 +103,32 @@ export function buildTrackInput(
 			: never;
 		metadata?: UnknownRecord;
 		stripGeoCoordinates?: boolean;
-		redactMeta?: (meta: UnknownRecord) => UnknownRecord;
-		redactInput?: (input: unknown, toolName: string) => unknown;
+		redactInput?: (input: unknown) => unknown;
 	},
 	timing?: { durationMs: number; status: string; errorMessage?: string },
 	clientInfo?: { name: string; version: string },
 	io?: { input?: unknown; output?: unknown },
 ): TrackInput {
 	const toolType = resolveToolType(toolName, options.toolType);
-	const applyMetaRedaction =
-		options.stripGeoCoordinates || options.redactMeta
-			? (m: UnknownRecord) => {
-					const stripped = options.stripGeoCoordinates
-						? stripGeoCoordinatesFromMeta(m)
-						: m;
-					return options.redactMeta ? options.redactMeta(stripped) : stripped;
-				}
-			: undefined;
 
 	const rawMeta = extractMeta(extra);
 	const meta =
-		rawMeta && applyMetaRedaction ? applyMetaRedaction(rawMeta) : rawMeta;
+		rawMeta && options.stripGeoCoordinates
+			? stripGeoCoordinatesFromMeta(rawMeta)
+			: rawMeta;
 
 	const input =
 		io?.input !== undefined && options.redactInput
-			? options.redactInput(io.input, toolName)
+			? options.redactInput(io.input)
 			: io?.input;
 
 	const output =
-		applyMetaRedaction && isRecord(io?.output) && isRecord(io.output._meta)
+		options.stripGeoCoordinates &&
+		isRecord(io?.output) &&
+		isRecord(io.output._meta)
 			? {
 					...(io.output as UnknownRecord),
-					_meta: applyMetaRedaction(io.output._meta as UnknownRecord),
+					_meta: stripGeoCoordinatesFromMeta(io.output._meta as UnknownRecord),
 				}
 			: io?.output;
 

--- a/src/mcp/server/with-waniwani/helpers.ts
+++ b/src/mcp/server/with-waniwani/helpers.ts
@@ -16,6 +16,43 @@ export type WaniwaniTracker = Pick<
 const SESSION_ID_KEY = "waniwani/sessionId";
 const GEO_LOCATION_KEY = "waniwani/geoLocation";
 const LEGACY_USER_LOCATION_KEY = "waniwani/userLocation";
+const OPENAI_USER_LOCATION_KEY = "openai/userLocation";
+
+const LOCATION_META_KEYS = [
+	OPENAI_USER_LOCATION_KEY,
+	GEO_LOCATION_KEY,
+	LEGACY_USER_LOCATION_KEY,
+] as const;
+
+const COORDINATE_KEYS = ["latitude", "longitude"] as const;
+
+export function stripGeoCoordinatesFromMeta(
+	meta: UnknownRecord,
+): UnknownRecord {
+	let next: UnknownRecord | undefined;
+	for (const key of LOCATION_META_KEYS) {
+		const value = meta[key];
+		if (!isRecord(value)) {
+			continue;
+		}
+		let stripped: UnknownRecord | undefined;
+		for (const coord of COORDINATE_KEYS) {
+			if (coord in value) {
+				if (!stripped) {
+					stripped = { ...value };
+				}
+				delete stripped[coord];
+			}
+		}
+		if (stripped) {
+			if (!next) {
+				next = { ...meta };
+			}
+			next[key] = stripped;
+		}
+	}
+	return next ?? meta;
+}
 
 export function isRecord(value: unknown): value is UnknownRecord {
 	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -65,13 +102,42 @@ export function buildTrackInput(
 			? T
 			: never;
 		metadata?: UnknownRecord;
+		stripGeoCoordinates?: boolean;
+		redactMeta?: (meta: UnknownRecord) => UnknownRecord;
+		redactInput?: (input: unknown, toolName: string) => unknown;
 	},
 	timing?: { durationMs: number; status: string; errorMessage?: string },
 	clientInfo?: { name: string; version: string },
 	io?: { input?: unknown; output?: unknown },
 ): TrackInput {
 	const toolType = resolveToolType(toolName, options.toolType);
-	const meta = extractMeta(extra);
+	const applyMetaRedaction =
+		options.stripGeoCoordinates || options.redactMeta
+			? (m: UnknownRecord) => {
+					const stripped = options.stripGeoCoordinates
+						? stripGeoCoordinatesFromMeta(m)
+						: m;
+					return options.redactMeta ? options.redactMeta(stripped) : stripped;
+				}
+			: undefined;
+
+	const rawMeta = extractMeta(extra);
+	const meta =
+		rawMeta && applyMetaRedaction ? applyMetaRedaction(rawMeta) : rawMeta;
+
+	const input =
+		io?.input !== undefined && options.redactInput
+			? options.redactInput(io.input, toolName)
+			: io?.input;
+
+	const output =
+		applyMetaRedaction && isRecord(io?.output) && isRecord(io.output._meta)
+			? {
+					...(io.output as UnknownRecord),
+					_meta: applyMetaRedaction(io.output._meta as UnknownRecord),
+				}
+			: io?.output;
+
 	console.log(
 		"[waniwani:debug] buildTrackInput meta:",
 		JSON.stringify(meta),
@@ -85,8 +151,8 @@ export function buildTrackInput(
 			name: toolName,
 			type: toolType,
 			...(timing ?? {}),
-			...(io?.input !== undefined && { input: io.input }),
-			...(io?.output !== undefined && { output: io.output }),
+			...(input !== undefined && { input }),
+			...(output !== undefined && { output }),
 		},
 		meta,
 		source: extractSource(meta),

--- a/src/mcp/server/with-waniwani/helpers.ts
+++ b/src/mcp/server/with-waniwani/helpers.ts
@@ -132,13 +132,6 @@ export function buildTrackInput(
 				}
 			: io?.output;
 
-	console.log(
-		"[waniwani:debug] buildTrackInput meta:",
-		JSON.stringify(meta),
-		"-> source:",
-		extractSource(meta),
-	);
-
 	return {
 		event: "tool.called",
 		properties: {

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -1,6 +1,7 @@
 import type { ToolCalledProperties } from "../../../tracking/index.js";
 import { createLogger } from "../../../utils/logger.js";
 import { waniwani } from "../../../waniwani.js";
+import { REDACTED_STATE_UPDATE_FIELDS_META_KEY } from "../flows/redacted.js";
 import { createScopedClient, SCOPED_CLIENT_KEY } from "../scoped-client.js";
 import type { McpServer } from "../tools/types";
 import { extractSessionId } from "../utils.js";
@@ -100,11 +101,6 @@ const log = createLogger("mcp", !!process.env.WANIWANI_DEBUG);
 
 const DEFAULT_BASE_URL = "https://app.waniwani.ai";
 
-// Mirrored from flows/redacted.ts — fields listed here on a tool's definition
-// `_meta` are auto-replaced with "REDACTED" inside `input.stateUpdates` before
-// tracking. Flows emit this key from `redacted()` markers on state schemas.
-const REDACTED_STATE_UPDATE_FIELDS_META_KEY =
-	"waniwani/redactedStateUpdateFields";
 const REDACTED_VALUE = "REDACTED";
 
 function buildStateUpdateRedactor(

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -71,11 +71,94 @@ export type WithWaniwaniOptions = {
 	 * @default true
 	 */
 	injectWidgetToken?: boolean;
+	/**
+	 * Strip `latitude`/`longitude` from known location `_meta` entries
+	 * (`openai/userLocation`, `waniwani/geoLocation`, `waniwani/userLocation`)
+	 * before events are sent to the WaniWani API. Applied to both the
+	 * request-level `_meta` and any `_meta` on the tool response.
+	 *
+	 * Enable this when precise geo coordinates should not reach the tracking
+	 * backend; city/region/country fields are preserved.
+	 *
+	 * @default false
+	 */
+	stripGeoCoordinates?: boolean;
+	/**
+	 * Replace `input.stateUpdates[field]` with `"REDACTED"` for any field
+	 * marked via `redacted()` on a flow state schema. When `false`, the
+	 * declarative markers are ignored and raw values are tracked.
+	 *
+	 * Wire this to an env var (e.g. `NODE_ENV === "production"`) when you want
+	 * real values in development logs but redacted values in production.
+	 *
+	 * @default true
+	 */
+	applyFieldRedactions?: boolean;
+	/**
+	 * Transform every `_meta` object before it is sent to the WaniWani API.
+	 * Applied after `stripGeoCoordinates`. Return a new object — do not mutate
+	 * the input. Use for custom PII redaction beyond the built-in flag.
+	 */
+	redactMeta?: (meta: UnknownRecord) => UnknownRecord;
+	/**
+	 * Transform tool input before it is sent to the WaniWani API. Return a new
+	 * value — do not mutate the input. Use to redact PII fields from tool
+	 * arguments (e.g. age, postcode). The original input handed to the tool
+	 * handler is unaffected.
+	 */
+	redactInput?: (input: unknown, toolName: string) => unknown;
 };
 
 const log = createLogger("mcp", !!process.env.WANIWANI_DEBUG);
 
 const DEFAULT_BASE_URL = "https://app.waniwani.ai";
+
+// Mirrored from flows/redacted.ts — fields listed here on a tool's definition
+// `_meta` are auto-replaced with "REDACTED" inside `input.stateUpdates` before
+// tracking. Flows emit this key from `redacted()` markers on state schemas.
+const REDACTED_STATE_UPDATE_FIELDS_META_KEY =
+	"waniwani/redactedStateUpdateFields";
+const REDACTED_VALUE = "REDACTED";
+
+function buildStateUpdateRedactor(
+	definitionMeta: UnknownRecord | undefined,
+): ((input: unknown) => unknown) | undefined {
+	if (!definitionMeta) {
+		return undefined;
+	}
+	const fields = definitionMeta[REDACTED_STATE_UPDATE_FIELDS_META_KEY];
+	if (!Array.isArray(fields) || fields.length === 0) {
+		return undefined;
+	}
+	const fieldSet = new Set(
+		fields.filter((f): f is string => typeof f === "string"),
+	);
+	if (fieldSet.size === 0) {
+		return undefined;
+	}
+
+	return (input: unknown) => {
+		if (!isRecord(input)) {
+			return input;
+		}
+		const stateUpdates = input.stateUpdates;
+		if (!isRecord(stateUpdates)) {
+			return input;
+		}
+		let changed = false;
+		const next: UnknownRecord = { ...stateUpdates };
+		for (const field of fieldSet) {
+			if (field in next) {
+				next[field] = REDACTED_VALUE;
+				changed = true;
+			}
+		}
+		if (!changed) {
+			return input;
+		}
+		return { ...input, stateUpdates: next };
+	};
+}
 
 type WrapContext = {
 	server: McpServer;
@@ -94,6 +177,22 @@ function createWrappedHandler(
 	definitionMeta: UnknownRecordOrUndefined,
 ): MaybeWrappedHandler {
 	const { server, tracker, opts, tokenCache, injectToken } = ctx;
+
+	const stateUpdateRedactor =
+		opts.applyFieldRedactions !== false
+			? buildStateUpdateRedactor(definitionMeta)
+			: undefined;
+	const effectiveOpts: WithWaniwaniOptions = stateUpdateRedactor
+		? {
+				...opts,
+				redactInput: (input, tName) => {
+					const redacted = stateUpdateRedactor(input);
+					return opts.redactInput
+						? opts.redactInput(redacted, tName)
+						: redacted;
+				},
+			}
+		: opts;
 
 	const wrappedHandler: MaybeWrappedHandler = async (
 		input: unknown,
@@ -164,7 +263,7 @@ function createWrappedHandler(
 				buildTrackInput(
 					toolName,
 					extra,
-					opts,
+					effectiveOpts,
 					{
 						durationMs,
 						status: isErrorResult ? "error" : "ok",
@@ -209,7 +308,7 @@ function createWrappedHandler(
 				buildTrackInput(
 					toolName,
 					extra,
-					opts,
+					effectiveOpts,
 					{
 						durationMs,
 						status: "error",

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -94,19 +94,6 @@ export type WithWaniwaniOptions = {
 	 * @default false
 	 */
 	applyFieldRedactions?: boolean;
-	/**
-	 * Transform every `_meta` object before it is sent to the WaniWani API.
-	 * Applied after `stripGeoCoordinates`. Return a new object — do not mutate
-	 * the input. Use for custom PII redaction beyond the built-in flag.
-	 */
-	redactMeta?: (meta: UnknownRecord) => UnknownRecord;
-	/**
-	 * Transform tool input before it is sent to the WaniWani API. Return a new
-	 * value — do not mutate the input. Use to redact PII fields from tool
-	 * arguments (e.g. age, postcode). The original input handed to the tool
-	 * handler is unaffected.
-	 */
-	redactInput?: (input: unknown, toolName: string) => unknown;
 };
 
 const log = createLogger("mcp", !!process.env.WANIWANI_DEBUG);
@@ -182,16 +169,8 @@ function createWrappedHandler(
 		opts.applyFieldRedactions === true
 			? buildStateUpdateRedactor(definitionMeta)
 			: undefined;
-	const effectiveOpts: WithWaniwaniOptions = stateUpdateRedactor
-		? {
-				...opts,
-				redactInput: (input, tName) => {
-					const redacted = stateUpdateRedactor(input);
-					return opts.redactInput
-						? opts.redactInput(redacted, tName)
-						: redacted;
-				},
-			}
+	const effectiveOpts = stateUpdateRedactor
+		? { ...opts, redactInput: stateUpdateRedactor }
 		: opts;
 
 	const wrappedHandler: MaybeWrappedHandler = async (

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -85,13 +85,13 @@ export type WithWaniwaniOptions = {
 	stripGeoCoordinates?: boolean;
 	/**
 	 * Replace `input.stateUpdates[field]` with `"REDACTED"` for any field
-	 * marked via `redacted()` on a flow state schema. When `false`, the
-	 * declarative markers are ignored and raw values are tracked.
+	 * marked via `redacted()` on a flow state schema. When `false` (default),
+	 * the declarative markers are ignored and raw values are tracked.
 	 *
-	 * Wire this to an env var (e.g. `NODE_ENV === "production"`) when you want
-	 * real values in development logs but redacted values in production.
+	 * Wire this to an env var when you want real values in development logs
+	 * but redacted values in production.
 	 *
-	 * @default true
+	 * @default false
 	 */
 	applyFieldRedactions?: boolean;
 	/**
@@ -179,7 +179,7 @@ function createWrappedHandler(
 	const { server, tracker, opts, tokenCache, injectToken } = ctx;
 
 	const stateUpdateRedactor =
-		opts.applyFieldRedactions !== false
+		opts.applyFieldRedactions === true
 			? buildStateUpdateRedactor(definitionMeta)
 			: undefined;
 	const effectiveOpts: WithWaniwaniOptions = stateUpdateRedactor


### PR DESCRIPTION
## Summary

Add two opt-in knobs on `withWaniwani()` so MCP servers can keep PII out of `tool.called` events without per-field wiring at the call site.

- **`redacted(schema)`** — new Zod schema wrapper exported from `@waniwani/sdk/mcp`. `createFlow` walks the state schema, collects marked field names, and stores them on the tool's `_meta` under `waniwani/redactedStateUpdateFields`. At track time, matching `input.stateUpdates.<field>` values are replaced with `"REDACTED"`. The handler still receives the original values; only the tracked copy is scrubbed. Gated by `applyFieldRedactions` (default `false`) so consumers can toggle via env var.
- **`stripGeoCoordinates: boolean`** (default `false`) — strips `latitude`/`longitude` from `openai/userLocation`, `waniwani/geoLocation`, and `waniwani/userLocation` on both request `_meta` and output `_meta`. City/region/country fields are preserved.

Both options are opt-in (default `false`) — the SDK does nothing to existing consumers unless they flip a flag.

### Usage

```ts
// Flow definition
import { createFlow, redacted } from "@waniwani/sdk/mcp";
import { z } from "zod";

createFlow({
  id: "insurance_comparison",
  state: {
    ages: redacted(z.string().describe("Comma-separated ages")),
    zipcode: redacted(z.string().describe("Postal code")),
    // other fields unchanged
  },
});

// Server wiring
withWaniwani(server, {
  client: wani,
  stripGeoCoordinates: process.env.REDACT_PII === "true",
  applyFieldRedactions: process.env.REDACT_PII === "true",
});
```

## Test plan

- [x] `bun test` — 136 tests pass, including new coverage for:
  - `redacted()` marker persistence through Zod `.meta()`
  - `collectRedactedStateFields` walker
  - Flow compile attaches `_meta` only when fields are marked
  - `withWaniwani` auto-redacts stateUpdates via tool `_meta` (gated by `applyFieldRedactions`)
  - `applyFieldRedactions` defaults to `false` — markers ignored unless explicitly enabled
  - `stripGeoCoordinates` removes lat/lng from all known location keys on both request and output `_meta`
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Verified end-to-end in the iSalud MCP: handler receives real ages/zipcode, tracked event shows `"REDACTED"` when `REDACT_TOOL_INPUT_PII=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches centralized tracking/wrapping logic (`withWaniwani`/`buildTrackInput`) and changes what data is emitted to the tracking backend when flags are enabled, which could affect observability and downstream analytics.
> 
> **Overview**
> Adds opt-in PII scrubbing for `tool.called` tracking emitted by `withWaniwani()`: a new `stripGeoCoordinates` option removes `latitude`/`longitude` from known location meta keys in both request `_meta` and response `_meta` before sending events.
> 
> Introduces declarative state-field redaction for flows via a new `redacted(zodSchema)` marker; `compileFlow` collects marked state fields and publishes them on the tool definition `_meta` under `waniwani/redactedStateUpdateFields`, and `withWaniwani({ applyFieldRedactions: true })` uses that list to replace matching `input.stateUpdates.*` values with `"REDACTED"` **only in tracked event payloads** (handlers still receive original input). Adds unit tests covering the marker, flow metadata emission, geo stripping, and redaction gating/defaults, and exports `redacted` from the public MCP entrypoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37be8040c944392ad9da0210cbf7d5e17caf11f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->