### PR TITLE
feat(embed): fetch remote agent config on mount

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -311,6 +311,16 @@ Render inside an existing container instead of floating:
 
 The embed widget sends `Authorization: Bearer wwp_...` on every request directly to the WaniWani API. The token is verified server-side against the `embed_tokens` table. No customer MCP app changes needed — generate tokens in the dashboard, paste the `<script>` tag.
 
+### Remote Config
+
+On mount the widget fetches `GET {data-api}/config` with the embed token and merges the response into its settings. Configure the agent from the WaniWani dashboard (environment → Embed Chat Config):
+
+| Server-only | Display-only |
+|---|---|
+| `systemPrompt`, `maxSteps` — applied at inference, never leak to the browser | `title`, `welcomeMessage`, `placeholder`, `suggestions` — sent to the widget |
+
+Merge order (later wins): **defaults < remote config < `data-*` attrs < programmatic `init()`**. So the dashboard value is the default and data-attrs still override per-page if you need a local tweak.
+
 ## Additional Components
 
 - **`McpAppFrame`** -- Renders MCP App widget iframes inside chat. Forwards tool result `_meta` via `ui/notifications/tool-result` for widget tracking config.

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -2,6 +2,8 @@
 // Embed Config — types and resolution
 // ============================================================================
 
+import type { ChatTheme } from "../@types";
+
 /**
  * Configuration for the embeddable chat widget.
  *
@@ -246,4 +248,21 @@ export function resolveConfig(
 	}
 
 	return merged;
+}
+
+// ---------------------------------------------------------------------------
+// Theme adapter — EmbedConfig.theme → ChatCard's ChatTheme
+// ---------------------------------------------------------------------------
+
+export function buildChatTheme(config: EmbedConfig): ChatTheme | undefined {
+	if (!config.theme) {
+		return undefined;
+	}
+	const t = config.theme;
+	return {
+		...(t.primaryColor ? { primaryColor: t.primaryColor } : {}),
+		...(t.backgroundColor ? { backgroundColor: t.backgroundColor } : {}),
+		...(t.textColor ? { textColor: t.textColor } : {}),
+		...(t.fontFamily ? { fontFamily: t.fontFamily } : {}),
+	};
 }

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -9,13 +9,13 @@
  *   defaults < remote config (from server) < `data-*` attrs < programmatic.
  *
  * Remote config lives on `GET {api}/config` and is authenticated with the
- * embed token. It only carries display-facing fields (title, welcome message,
+ * public token. It only carries display-facing fields (title, welcome message,
  * placeholder, suggestions) — system prompt and step budget stay server-side.
  */
 export interface EmbedConfig {
 	/** WaniWani chat API URL. Defaults to `https://app.waniwani.ai/api/mcp/chat`. */
 	api?: string;
-	/** Embed token (wwp_...) for authentication (required). */
+	/** Public token (wwp_...) for authentication (required). */
 	token: string;
 	/** Override MCP server URL (optional — resolved from environment by default). */
 	mcpServerUrl?: string;

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -205,8 +205,14 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 export function resolveConfig(
 	programmatic?: Partial<EmbedConfig>,
 	remote?: Partial<EmbedConfig>,
+	scriptConfig?: Partial<EmbedConfig>,
 ): EmbedConfig {
-	const fromScript = parseConfigFromScript();
+	// Caller may pass a pre-parsed script config so async re-resolution
+	// (post-fetch) doesn't re-invoke `parseConfigFromScript` — by the time a
+	// promise settles, `document.currentScript` is null and the fallback
+	// heuristic can miss renamed/CDN-hosted bundles, silently dropping
+	// `data-*` overrides.
+	const fromScript = scriptConfig ?? parseConfigFromScript();
 
 	const merged: EmbedConfig = {
 		// Required — token validated below, api has default

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -5,8 +5,12 @@
 /**
  * Configuration for the embeddable chat widget.
  *
- * Resolution priority: programmatic (via `WaniWani.chat.init()`) > `data-*`
- * attributes on the `<script>` tag > built-in defaults.
+ * Resolution priority (later wins):
+ *   defaults < remote config (from server) < `data-*` attrs < programmatic.
+ *
+ * Remote config lives on `GET {api}/config` and is authenticated with the
+ * embed token. It only carries display-facing fields (title, welcome message,
+ * placeholder, suggestions) — system prompt and step budget stay server-side.
  */
 export interface EmbedConfig {
 	/** WaniWani chat API URL. Defaults to `https://app.waniwani.ai/api/mcp/chat`. */
@@ -195,11 +199,12 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 }
 
 // ---------------------------------------------------------------------------
-// Merge: defaults < script attrs < programmatic
+// Merge: defaults < remote < script attrs < programmatic
 // ---------------------------------------------------------------------------
 
 export function resolveConfig(
 	programmatic?: Partial<EmbedConfig>,
+	remote?: Partial<EmbedConfig>,
 ): EmbedConfig {
 	const fromScript = parseConfigFromScript();
 
@@ -210,14 +215,18 @@ export function resolveConfig(
 		// Defaults
 		...DEFAULTS,
 
-		// Script attributes (overrides defaults)
+		// Server-side config (fills in gaps the customer didn't override)
+		...(remote ?? {}),
+
+		// Script attributes (override remote + defaults)
 		...fromScript,
 
 		// Programmatic (overrides everything)
 		...programmatic,
 
-		// Deep-merge theme: defaults < script < programmatic
+		// Deep-merge theme: defaults < remote < script < programmatic
 		theme: {
+			...(remote?.theme ?? {}),
 			...fromScript.theme,
 			...programmatic?.theme,
 		},

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -7,10 +7,10 @@
 
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { ChatCard } from "../layouts/chat-card";
 import type { EmbedConfig } from "./config";
 import { parseConfigFromScript, resolveConfig } from "./config";
-import { buildChatTheme, FloatingChat } from "./floating-chat";
+import { FloatingChat } from "./floating-chat";
+import { InlineChat } from "./inline-chat";
 
 // ---------------------------------------------------------------------------
 // CSS placeholder — replaced at build time with the actual CSS string
@@ -81,7 +81,10 @@ function injectStyles(shadowRoot: ShadowRoot, config: EmbedConfig): void {
 // Mount helpers
 // ---------------------------------------------------------------------------
 
-function mountInline(config: EmbedConfig): EmbedInstance {
+function mountInline(
+	config: EmbedConfig,
+	programmatic: Partial<EmbedConfig> | undefined,
+): EmbedInstance {
 	const selector = config.container as string;
 	const container = document.querySelector(selector);
 	if (!container) {
@@ -104,25 +107,7 @@ function mountInline(config: EmbedConfig): EmbedInstance {
 	shadowRoot.appendChild(mountContainer);
 
 	reactRoot = ReactDOM.createRoot(mountContainer);
-	reactRoot.render(
-		React.createElement(ChatCard, {
-			api: config.api,
-			headers: { Authorization: `Bearer ${config.token}` },
-			skipRemoteConfig: true,
-			body: config.mcpServerUrl
-				? { mcpServerUrl: config.mcpServerUrl }
-				: undefined,
-			theme: buildChatTheme(config),
-			title: config.title ?? "Assistant",
-			welcomeMessage: config.welcomeMessage,
-			placeholder: config.placeholder,
-			suggestions: config.suggestions
-				? { initial: config.suggestions }
-				: undefined,
-			width: "100%",
-			height: "100%",
-		}),
-	);
+	reactRoot.render(React.createElement(InlineChat, { config, programmatic }));
 
 	return {
 		destroy: () => {
@@ -171,7 +156,10 @@ function createLoadingSkeleton(
 	return skeleton;
 }
 
-function mountFloating(config: EmbedConfig): EmbedInstance {
+function mountFloating(
+	config: EmbedConfig,
+	programmatic: Partial<EmbedConfig> | undefined,
+): EmbedInstance {
 	hostElement = document.createElement("div");
 	hostElement.id = "waniwani-chat-embed";
 	document.body.appendChild(hostElement);
@@ -190,6 +178,7 @@ function mountFloating(config: EmbedConfig): EmbedInstance {
 	reactRoot.render(
 		React.createElement(FloatingChat, {
 			config,
+			programmatic,
 			onReady: () => skeleton.remove(),
 		}),
 	);
@@ -219,9 +208,13 @@ function init(options?: Partial<EmbedConfig>): EmbedInstance {
 
 	const config = resolveConfig(options);
 
+	// Pass the raw programmatic overrides through so the React-side
+	// useRemoteEmbedConfig hook can re-apply them on top of the server's
+	// config once it arrives. Without this the remote config could override
+	// fields the customer explicitly set.
 	currentInstance = config.container
-		? mountInline(config)
-		: mountFloating(config);
+		? mountInline(config, options)
+		: mountFloating(config, options);
 
 	return currentInstance;
 }

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -84,6 +84,7 @@ function injectStyles(shadowRoot: ShadowRoot, config: EmbedConfig): void {
 function mountInline(
 	config: EmbedConfig,
 	programmatic: Partial<EmbedConfig> | undefined,
+	scriptConfig: Partial<EmbedConfig> | undefined,
 ): EmbedInstance {
 	const selector = config.container as string;
 	const container = document.querySelector(selector);
@@ -107,7 +108,9 @@ function mountInline(
 	shadowRoot.appendChild(mountContainer);
 
 	reactRoot = ReactDOM.createRoot(mountContainer);
-	reactRoot.render(React.createElement(InlineChat, { config, programmatic }));
+	reactRoot.render(
+		React.createElement(InlineChat, { config, programmatic, scriptConfig }),
+	);
 
 	return {
 		destroy: () => {
@@ -159,6 +162,7 @@ function createLoadingSkeleton(
 function mountFloating(
 	config: EmbedConfig,
 	programmatic: Partial<EmbedConfig> | undefined,
+	scriptConfig: Partial<EmbedConfig> | undefined,
 ): EmbedInstance {
 	hostElement = document.createElement("div");
 	hostElement.id = "waniwani-chat-embed";
@@ -179,6 +183,7 @@ function mountFloating(
 		React.createElement(FloatingChat, {
 			config,
 			programmatic,
+			scriptConfig,
 			onReady: () => skeleton.remove(),
 		}),
 	);
@@ -206,15 +211,19 @@ function init(options?: Partial<EmbedConfig>): EmbedInstance {
 		return currentInstance;
 	}
 
-	const config = resolveConfig(options);
+	// Parse `data-*` once synchronously — `document.currentScript` is only
+	// valid during script execution, so we must capture it here and thread
+	// the result through to useRemoteEmbedConfig.
+	const scriptConfig = parseConfigFromScript();
+	const config = resolveConfig(options, undefined, scriptConfig);
 
-	// Pass the raw programmatic overrides through so the React-side
-	// useRemoteEmbedConfig hook can re-apply them on top of the server's
-	// config once it arrives. Without this the remote config could override
-	// fields the customer explicitly set.
+	// Pass the raw programmatic overrides + captured script config through
+	// so the React-side useRemoteEmbedConfig hook can re-apply them on top
+	// of the server's config once it arrives. Without this the remote
+	// config could override fields the customer explicitly set.
 	currentInstance = config.container
-		? mountInline(config, options)
-		: mountFloating(config, options);
+		? mountInline(config, options, scriptConfig)
+		: mountFloating(config, options, scriptConfig);
 
 	return currentInstance;
 }

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -13,6 +13,7 @@ import {
 import type { ChatHandle, ChatTheme } from "../@types";
 import { ChatCard } from "../layouts/chat-card";
 import type { EmbedConfig } from "./config";
+import { useRemoteEmbedConfig } from "./remote-config";
 
 export function buildChatTheme(config: EmbedConfig): ChatTheme | undefined {
 	if (!config.theme) {
@@ -33,6 +34,11 @@ export function buildChatTheme(config: EmbedConfig): ChatTheme | undefined {
 
 export interface FloatingChatProps {
 	config: EmbedConfig;
+	/**
+	 * Raw programmatic overrides from `init()`. Re-applied on top of the
+	 * remote config once it lands, so user-supplied values still win.
+	 */
+	programmatic?: Partial<EmbedConfig>;
 	/** Called once after the component mounts (post-commit). */
 	onReady?: () => void;
 }
@@ -105,7 +111,11 @@ const TRANSITION_MS = 200;
 // ---------------------------------------------------------------------------
 
 export const FloatingChat = forwardRef<FloatingChatHandle, FloatingChatProps>(
-	function FloatingChat({ config, onReady }, ref) {
+	function FloatingChat({ config: initialConfig, programmatic, onReady }, ref) {
+		// Layered merge (defaults < remote < data-attrs < programmatic) lands
+		// in `config` once the `/config` fetch resolves. Until then we render
+		// with whatever the customer / data-attrs / defaults already gave us.
+		const config = useRemoteEmbedConfig(initialConfig, programmatic);
 		const [isOpen, setIsOpen] = useState(false);
 		const [unreadCount, setUnreadCount] = useState(0);
 		const [isMobile, setIsMobile] = useState(false);

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -39,6 +39,12 @@ export interface FloatingChatProps {
 	 * remote config once it lands, so user-supplied values still win.
 	 */
 	programmatic?: Partial<EmbedConfig>;
+	/**
+	 * `data-*` snapshot captured synchronously during script execution.
+	 * Threaded through so async re-resolution doesn't re-parse the script
+	 * tag (unsafe after the initial tick — see remote-config.ts).
+	 */
+	scriptConfig?: Partial<EmbedConfig>;
 	/** Called once after the component mounts (post-commit). */
 	onReady?: () => void;
 }
@@ -111,11 +117,18 @@ const TRANSITION_MS = 200;
 // ---------------------------------------------------------------------------
 
 export const FloatingChat = forwardRef<FloatingChatHandle, FloatingChatProps>(
-	function FloatingChat({ config: initialConfig, programmatic, onReady }, ref) {
+	function FloatingChat(
+		{ config: initialConfig, programmatic, scriptConfig, onReady },
+		ref,
+	) {
 		// Layered merge (defaults < remote < data-attrs < programmatic) lands
 		// in `config` once the `/config` fetch resolves. Until then we render
 		// with whatever the customer / data-attrs / defaults already gave us.
-		const config = useRemoteEmbedConfig(initialConfig, programmatic);
+		const config = useRemoteEmbedConfig(
+			initialConfig,
+			programmatic,
+			scriptConfig,
+		);
 		const [isOpen, setIsOpen] = useState(false);
 		const [unreadCount, setUnreadCount] = useState(0);
 		const [isMobile, setIsMobile] = useState(false);

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -10,23 +10,11 @@ import {
 	useRef,
 	useState,
 } from "react";
-import type { ChatHandle, ChatTheme } from "../@types";
+import type { ChatHandle } from "../@types";
 import { ChatCard } from "../layouts/chat-card";
 import type { EmbedConfig } from "./config";
+import { buildChatTheme } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
-
-export function buildChatTheme(config: EmbedConfig): ChatTheme | undefined {
-	if (!config.theme) {
-		return undefined;
-	}
-	const t = config.theme;
-	return {
-		...(t.primaryColor ? { primaryColor: t.primaryColor } : {}),
-		...(t.backgroundColor ? { backgroundColor: t.backgroundColor } : {}),
-		...(t.textColor ? { textColor: t.textColor } : {}),
-		...(t.fontFamily ? { fontFamily: t.fontFamily } : {}),
-	};
-}
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -15,15 +15,22 @@ import { useRemoteEmbedConfig } from "./remote-config";
 export interface InlineChatProps {
 	config: EmbedConfig;
 	programmatic?: Partial<EmbedConfig>;
+	/** Pre-parsed `data-*` snapshot — see FloatingChatProps.scriptConfig. */
+	scriptConfig?: Partial<EmbedConfig>;
 	onReady?: () => void;
 }
 
 export function InlineChat({
 	config: initialConfig,
 	programmatic,
+	scriptConfig,
 	onReady,
 }: InlineChatProps) {
-	const config = useRemoteEmbedConfig(initialConfig, programmatic);
+	const config = useRemoteEmbedConfig(
+		initialConfig,
+		programmatic,
+		scriptConfig,
+	);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: fire once on mount
 	useEffect(() => {

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -1,0 +1,52 @@
+// ============================================================================
+// InlineChat — wraps ChatCard for the `data-container` inline mount path.
+//
+// Exists so remote config fetching can happen inside React, matching the
+// floating mode. Plain rendering of ChatCard in embed.ts would leave no
+// useEffect hook to own the fetch.
+// ============================================================================
+
+import { useEffect } from "react";
+import { ChatCard } from "../layouts/chat-card";
+import type { EmbedConfig } from "./config";
+import { buildChatTheme } from "./floating-chat";
+import { useRemoteEmbedConfig } from "./remote-config";
+
+export interface InlineChatProps {
+	config: EmbedConfig;
+	programmatic?: Partial<EmbedConfig>;
+	onReady?: () => void;
+}
+
+export function InlineChat({
+	config: initialConfig,
+	programmatic,
+	onReady,
+}: InlineChatProps) {
+	const config = useRemoteEmbedConfig(initialConfig, programmatic);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: fire once on mount
+	useEffect(() => {
+		onReady?.();
+	}, []);
+
+	return (
+		<ChatCard
+			api={config.api}
+			headers={{ Authorization: `Bearer ${config.token}` }}
+			skipRemoteConfig
+			body={
+				config.mcpServerUrl ? { mcpServerUrl: config.mcpServerUrl } : undefined
+			}
+			theme={buildChatTheme(config)}
+			title={config.title ?? "Assistant"}
+			welcomeMessage={config.welcomeMessage}
+			placeholder={config.placeholder}
+			suggestions={
+				config.suggestions ? { initial: config.suggestions } : undefined
+			}
+			width="100%"
+			height="100%"
+		/>
+	);
+}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -9,7 +9,7 @@
 import { useEffect } from "react";
 import { ChatCard } from "../layouts/chat-card";
 import type { EmbedConfig } from "./config";
-import { buildChatTheme } from "./floating-chat";
+import { buildChatTheme } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
 
 export interface InlineChatProps {

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -81,10 +81,16 @@ function remoteToConfigPartial(
  * re-resolves through the layered merge (defaults < remote < data-attrs <
  * programmatic) once it arrives. While the request is in flight, returns
  * the initial config untouched.
+ *
+ * `scriptConfig` must be the same `data-*` snapshot used for the initial
+ * resolve. Re-parsing post-fetch is unsafe: `document.currentScript` is
+ * null by then and the fallback heuristic can miss the embed script (CDN
+ * paths, renamed bundles), silently dropping `data-*` overrides.
  */
 export function useRemoteEmbedConfig(
 	initialConfig: EmbedConfig,
 	programmatic: Partial<EmbedConfig> | undefined,
+	scriptConfig: Partial<EmbedConfig> | undefined,
 ): EmbedConfig {
 	const [config, setConfig] = useState(initialConfig);
 
@@ -99,15 +105,26 @@ export function useRemoteEmbedConfig(
 			return;
 		}
 		const controller = new AbortController();
-		void fetchRemoteConfig(api, token, controller.signal).then((remote) => {
-			if (controller.signal.aborted) {
-				return;
-			}
-			if (Object.keys(remote).length === 0) {
-				return;
-			}
-			setConfig(resolveConfig(programmatic, remote));
-		});
+		void fetchRemoteConfig(api, token, controller.signal)
+			.then((remote) => {
+				if (controller.signal.aborted) {
+					return;
+				}
+				if (Object.keys(remote).length === 0) {
+					return;
+				}
+				try {
+					setConfig(resolveConfig(programmatic, remote, scriptConfig));
+				} catch (err) {
+					// `resolveConfig` throws if token is missing. Shouldn't happen
+					// here (initial resolve already validated), but swallow so a
+					// late failure doesn't become an unhandled rejection.
+					console.error("[WaniWani] Failed to apply remote config:", err);
+				}
+			})
+			.catch((err) => {
+				console.error("[WaniWani] Remote config fetch failed:", err);
+			});
 		return () => controller.abort();
 	}, [initialConfig.api, initialConfig.token]);
 

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -39,7 +39,18 @@ export async function fetchRemoteConfig(
 		if (!res.ok) {
 			return {};
 		}
-		const data = (await res.json()) as RemoteConfigResponse;
+		// The WaniWani API wraps payloads in `{ success, message, data }`.
+		// Accept either shape so we stay compatible with raw endpoints too.
+		const raw = (await res.json()) as
+			| RemoteConfigResponse
+			| { success: boolean; data?: RemoteConfigResponse };
+		const data: RemoteConfigResponse | null =
+			raw && typeof raw === "object" && "data" in raw && raw.data
+				? raw.data
+				: (raw as RemoteConfigResponse);
+		if (!data) {
+			return {};
+		}
 		return remoteToConfigPartial(data);
 	} catch {
 		return {};

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -1,0 +1,104 @@
+// ============================================================================
+// Remote embed config — fetched from `GET {api}/config` on mount.
+//
+// Only display-facing fields come over the wire. `systemPrompt` and
+// `maxSteps` are inference-time concerns and stay server-side.
+// ============================================================================
+
+import { useEffect, useState } from "react";
+import type { EmbedConfig } from "./config";
+import { resolveConfig } from "./config";
+
+interface RemoteConfigResponse {
+	welcomeMessage: string | null;
+	title: string | null;
+	placeholder: string | null;
+	suggestions: string[] | null;
+}
+
+/**
+ * Fetch the server-side config for an embed token. Returns a sparse
+ * `Partial<EmbedConfig>` (only keys the server populated) so callers can
+ * safely spread it into their config merge.
+ *
+ * Resolves to `{}` on any network or parse error — remote config is a
+ * convenience layer, never required for the widget to function.
+ */
+export async function fetchRemoteConfig(
+	api: string,
+	token: string,
+	signal?: AbortSignal,
+): Promise<Partial<EmbedConfig>> {
+	try {
+		const url = `${api.replace(/\/$/, "")}/config`;
+		const res = await fetch(url, {
+			method: "GET",
+			headers: { Authorization: `Bearer ${token}` },
+			signal,
+		});
+		if (!res.ok) {
+			return {};
+		}
+		const data = (await res.json()) as RemoteConfigResponse;
+		return remoteToConfigPartial(data);
+	} catch {
+		return {};
+	}
+}
+
+function remoteToConfigPartial(
+	data: RemoteConfigResponse,
+): Partial<EmbedConfig> {
+	const out: Partial<EmbedConfig> = {};
+	if (data.title != null) {
+		out.title = data.title;
+	}
+	if (data.welcomeMessage != null) {
+		out.welcomeMessage = data.welcomeMessage;
+	}
+	if (data.placeholder != null) {
+		out.placeholder = data.placeholder;
+	}
+	if (data.suggestions != null && data.suggestions.length > 0) {
+		out.suggestions = data.suggestions;
+	}
+	return out;
+}
+
+/**
+ * Fetch the remote config on mount and return an `EmbedConfig` that
+ * re-resolves through the layered merge (defaults < remote < data-attrs <
+ * programmatic) once it arrives. While the request is in flight, returns
+ * the initial config untouched.
+ */
+export function useRemoteEmbedConfig(
+	initialConfig: EmbedConfig,
+	programmatic: Partial<EmbedConfig> | undefined,
+): EmbedConfig {
+	const [config, setConfig] = useState(initialConfig);
+
+	// Re-fetching on `programmatic` identity changes would be churn; the
+	// caller owns its lifetime — if props change meaningfully they should
+	// re-init the widget.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: fetch once per api+token
+	useEffect(() => {
+		const api = initialConfig.api;
+		const token = initialConfig.token;
+		if (!api || !token) {
+			return;
+		}
+		const controller = new AbortController();
+		void fetchRemoteConfig(api, token, controller.signal).then((remote) => {
+			if (controller.signal.aborted) {
+				return;
+			}
+			if (Object.keys(remote).length === 0) {
+				return;
+			}
+			setConfig(resolveConfig(programmatic, remote));
+		});
+		return () => controller.abort();
+	}, [initialConfig.api, initialConfig.token]);
+
+	return config;
+}

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -17,7 +17,7 @@ interface RemoteConfigResponse {
 }
 
 /**
- * Fetch the server-side config for an embed token. Returns a sparse
+ * Fetch the server-side config for a public token. Returns a sparse
  * `Partial<EmbedConfig>` (only keys the server populated) so callers can
  * safely spread it into their config merge.
  *

--- a/src/chat/web/embed/shims/zod.ts
+++ b/src/chat/web/embed/shims/zod.ts
@@ -15,10 +15,10 @@ const noop = (): any => schema;
 const schema: any = new Proxy(noop, {
 	get(_target, prop) {
 		if (prop === "parse" || prop === "parseAsync") {
-			return (v: any) => v;
+			return (v: unknown) => v;
 		}
 		if (prop === "safeParse" || prop === "safeParseAsync") {
-			return (v: any) => ({ success: true as const, data: v });
+			return (v: unknown) => ({ success: true as const, data: v });
 		}
 		if (prop === "_def") {
 			return {};
@@ -35,9 +35,10 @@ const schema: any = new Proxy(noop, {
 });
 
 class ZodError extends Error {
-	issues: any[] = [];
+	issues: unknown[] = [];
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: shim must match zod's loose types
 const z: any = new Proxy(noop, {
 	get(_target, prop) {
 		if (prop === "ZodError") {


### PR DESCRIPTION
## Summary

- Widget now fetches `GET {api}/config` on mount and merges the response into its settings. Customers configure the agent once in the WaniWani dashboard and the widget picks it up — no more duplicating `data-*` attributes across pages.
- Companion to app PR [waniwani/app#425](https://github.com/WaniWani-AI/app/pull/425).
- Comment cleanup: "embed token" → "public token" to match the server-side rename (`wwp_` prefix unchanged — existing script tags keep working).

## Merge order

Later wins:

```
defaults < remote config (server) < data-* attrs < programmatic init()
```

So dashboard values become the default. `data-title="Foo"` still overrides if a page wants a local tweak.

## What comes from the server

Display fields only:

- `title`
- `welcomeMessage`
- `placeholder`
- `suggestions`

`systemPrompt` and `maxSteps` stay server-side (applied at inference in `/api/mcp/chat`) and are **not** exposed to the browser — the server rejects public-token requests that try to set them in the body.

## Implementation

- `remote-config.ts`: `fetchRemoteConfig(api, token, signal)` + `useRemoteEmbedConfig(initial, programmatic)` hook. Silent failure — remote config never blocks the widget.
- `resolveConfig(programmatic, remote?)` gains an optional `remote` arg, slotted between defaults and `data-*` attrs.
- `FloatingChat` uses the hook; new `programmatic` prop threads programmatic overrides through so they still win after the fetch.
- New `InlineChat` wrapper — previously the inline (`data-container`) path rendered `ChatCard` directly with no `useEffect` to own the fetch.
- `init()` passes the raw `options` through to mounts.
- Response envelope unwrap: accepts both `{ success, data }` (current WaniWani API) and raw shapes so the SDK stays tolerant.

## Test plan

- [ ] `bun run build` passes (typecheck + lint + tsup + css inline)
- [ ] `bun test` passes (embed config tests)
- [ ] Embed widget on a page with remote config set in dashboard → widget renders with server-supplied title / welcome / suggestions after fetch
- [ ] Same with `data-title="X"` on the script tag → title stays "X" (data-attrs override remote)
- [ ] Programmatic `WaniWani.chat.init({ title: "Y" })` wins over both server and data-attrs
- [ ] `/config` returning 401/500 or network error → widget still works using defaults + data-attrs (no console spam, just silent fallback)
- [ ] Inline mode (`data-container="#x"`) also fetches and re-resolves

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new runtime network fetch and async config re-resolution in the embed widget, which could affect initialization timing and override precedence if edge cases slip through. Fail-open behavior reduces blast radius, but it still changes user-facing configuration behavior across both floating and inline modes.
> 
> **Overview**
> The embed chat widget now fetches remote configuration from `GET {api}/config` on mount and re-applies config using a defined precedence (**defaults < remote < `data-*` attrs < programmatic `init()`**), so dashboard-managed display settings become the default without breaking per-page overrides.
> 
> This adds `useRemoteEmbedConfig`/`fetchRemoteConfig`, updates `resolveConfig` to accept an optional remote + captured script snapshot (avoiding `document.currentScript` issues after async), and routes both floating and inline mounts through React wrappers (`InlineChat`) so remote config can be applied consistently. Documentation is updated to describe remote config behavior, and the embed `zod` shim tightens types (`any` → `unknown`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f3afe261dbe118ffb50d3911263265b37a1aa06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->