### PR TITLE
feat(embed): support widget resource proxy + generalize iframe init

### DIFF
--- a/src/chat/web/components/mcp-app-frame.tsx
+++ b/src/chat/web/components/mcp-app-frame.tsx
@@ -172,18 +172,17 @@ export function McpAppFrame({
 		[autoHeight],
 	);
 
-	// Build the iframe src URL directly — avoids null-origin issues with srcdoc.
-	// Parse through URL so callers can pre-populate query params on
-	// `resourceEndpoint` (e.g. the embed appends a `token` so the
-	// cross-origin GET carries auth without needing custom headers).
+	// Build the iframe src URL via string concatenation so the value is
+	// stable across SSR and CSR — `new URL(..., window.location.href)`
+	// would produce an absolute URL that differs between server (falling
+	// back to a stub origin) and client, causing a hydration mismatch
+	// and a wasted iframe load against the stub origin before hydration
+	// corrects it. The browser resolves relative URLs against the
+	// document itself, so this works for both absolute and relative
+	// `resourceEndpoint` values.
 	const iframeSrc = useMemo(() => {
-		const base =
-			typeof window !== "undefined"
-				? window.location.href
-				: "http://localhost/";
-		const u = new URL(resourceEndpoint, base);
-		u.searchParams.set("uri", resourceUri);
-		return u.toString();
+		const separator = resourceEndpoint.includes("?") ? "&" : "?";
+		return `${resourceEndpoint}${separator}uri=${encodeURIComponent(resourceUri)}`;
 	}, [resourceEndpoint, resourceUri]);
 
 	const isDarkRef = useRef(isDark);

--- a/src/chat/web/components/mcp-app-frame.tsx
+++ b/src/chat/web/components/mcp-app-frame.tsx
@@ -172,11 +172,19 @@ export function McpAppFrame({
 		[autoHeight],
 	);
 
-	// Build the iframe src URL directly — avoids null-origin issues with srcdoc
-	const iframeSrc = useMemo(
-		() => `${resourceEndpoint}?uri=${encodeURIComponent(resourceUri)}`,
-		[resourceEndpoint, resourceUri],
-	);
+	// Build the iframe src URL directly — avoids null-origin issues with srcdoc.
+	// Parse through URL so callers can pre-populate query params on
+	// `resourceEndpoint` (e.g. the embed appends a `token` so the
+	// cross-origin GET carries auth without needing custom headers).
+	const iframeSrc = useMemo(() => {
+		const base =
+			typeof window !== "undefined"
+				? window.location.href
+				: "http://localhost/";
+		const u = new URL(resourceEndpoint, base);
+		u.searchParams.set("uri", resourceUri);
+		return u.toString();
+	}, [resourceEndpoint, resourceUri]);
 
 	const isDarkRef = useRef(isDark);
 	isDarkRef.current = isDark;

--- a/src/chat/web/layouts/chat-bar.tsx
+++ b/src/chat/web/layouts/chat-bar.tsx
@@ -54,7 +54,21 @@ export const ChatBar = forwardRef<ChatHandle, ChatBarProps>(
 			Math.round((typeof width === "number" ? width : 600) * 1.2);
 
 		const effectiveApi = api ?? "/api/waniwani";
-		const effectiveResourceEndpoint = `${effectiveApi}/resource`;
+		// Iframe GET for widget HTML can't set custom headers. When the
+		// caller passed an `Authorization: Bearer …` header (embed path),
+		// propagate that token in the URL so the cross-origin resource
+		// fetch is authenticated. Same-origin proxy setups (customer
+		// next-js adapter) won't pass headers and get a plain endpoint.
+		const authHeaderValue =
+			props.headers && (props.headers as Record<string, string>).Authorization;
+		const resourceToken =
+			typeof authHeaderValue === "string" &&
+			authHeaderValue.startsWith("Bearer ")
+				? authHeaderValue.slice(7)
+				: null;
+		const effectiveResourceEndpoint = resourceToken
+			? `${effectiveApi}/resource?token=${encodeURIComponent(resourceToken)}`
+			: `${effectiveApi}/resource`;
 
 		const resolvedTheme = mergeTheme(userTheme);
 		const cssVars = themeToCSSProperties(resolvedTheme);

--- a/src/chat/web/layouts/chat-bar.tsx
+++ b/src/chat/web/layouts/chat-bar.tsx
@@ -30,6 +30,7 @@ import { useChatEngine } from "../hooks/use-chat-engine";
 import { useConfig } from "../hooks/use-config";
 import { useSuggestions } from "../hooks/use-suggestions";
 import { useTypingPlaceholder } from "../hooks/use-typing-placeholder";
+import { buildResourceEndpoint } from "../lib/resource-endpoint";
 import { cn } from "../lib/utils";
 import { isDarkTheme, mergeTheme, themeToCSSProperties } from "../theme";
 
@@ -54,21 +55,10 @@ export const ChatBar = forwardRef<ChatHandle, ChatBarProps>(
 			Math.round((typeof width === "number" ? width : 600) * 1.2);
 
 		const effectiveApi = api ?? "/api/waniwani";
-		// Iframe GET for widget HTML can't set custom headers. When the
-		// caller passed an `Authorization: Bearer …` header (embed path),
-		// propagate that token in the URL so the cross-origin resource
-		// fetch is authenticated. Same-origin proxy setups (customer
-		// next-js adapter) won't pass headers and get a plain endpoint.
-		const authHeaderValue =
-			props.headers && (props.headers as Record<string, string>).Authorization;
-		const resourceToken =
-			typeof authHeaderValue === "string" &&
-			authHeaderValue.startsWith("Bearer ")
-				? authHeaderValue.slice(7)
-				: null;
-		const effectiveResourceEndpoint = resourceToken
-			? `${effectiveApi}/resource?token=${encodeURIComponent(resourceToken)}`
-			: `${effectiveApi}/resource`;
+		const effectiveResourceEndpoint = buildResourceEndpoint(
+			effectiveApi,
+			props.headers,
+		);
 
 		const resolvedTheme = mergeTheme(userTheme);
 		const cssVars = themeToCSSProperties(resolvedTheme);

--- a/src/chat/web/layouts/chat-card.tsx
+++ b/src/chat/web/layouts/chat-card.tsx
@@ -52,7 +52,21 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 		} = props;
 
 		const effectiveApi = api ?? "/api/waniwani";
-		const effectiveResourceEndpoint = `${effectiveApi}/resource`;
+		// Iframe GET for widget HTML can't set custom headers. When the
+		// caller passed an `Authorization: Bearer …` header (embed path),
+		// propagate that token in the URL so the cross-origin resource
+		// fetch is authenticated. Same-origin proxy setups (customer
+		// next-js adapter) won't pass headers and get a plain endpoint.
+		const authHeaderValue =
+			props.headers && (props.headers as Record<string, string>).Authorization;
+		const resourceToken =
+			typeof authHeaderValue === "string" &&
+			authHeaderValue.startsWith("Bearer ")
+				? authHeaderValue.slice(7)
+				: null;
+		const effectiveResourceEndpoint = resourceToken
+			? `${effectiveApi}/resource?token=${encodeURIComponent(resourceToken)}`
+			: `${effectiveApi}/resource`;
 
 		const resolvedTheme = mergeTheme(userTheme);
 		const cssVars = themeToCSSProperties(resolvedTheme);

--- a/src/chat/web/layouts/chat-card.tsx
+++ b/src/chat/web/layouts/chat-card.tsx
@@ -30,6 +30,7 @@ import { useChatEngine } from "../hooks/use-chat-engine";
 import { useConfig } from "../hooks/use-config";
 import { useSuggestions } from "../hooks/use-suggestions";
 import { useTypingPlaceholder } from "../hooks/use-typing-placeholder";
+import { buildResourceEndpoint } from "../lib/resource-endpoint";
 import { cn } from "../lib/utils";
 import { isDarkTheme, mergeTheme, themeToCSSProperties } from "../theme";
 
@@ -52,21 +53,10 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 		} = props;
 
 		const effectiveApi = api ?? "/api/waniwani";
-		// Iframe GET for widget HTML can't set custom headers. When the
-		// caller passed an `Authorization: Bearer …` header (embed path),
-		// propagate that token in the URL so the cross-origin resource
-		// fetch is authenticated. Same-origin proxy setups (customer
-		// next-js adapter) won't pass headers and get a plain endpoint.
-		const authHeaderValue =
-			props.headers && (props.headers as Record<string, string>).Authorization;
-		const resourceToken =
-			typeof authHeaderValue === "string" &&
-			authHeaderValue.startsWith("Bearer ")
-				? authHeaderValue.slice(7)
-				: null;
-		const effectiveResourceEndpoint = resourceToken
-			? `${effectiveApi}/resource?token=${encodeURIComponent(resourceToken)}`
-			: `${effectiveApi}/resource`;
+		const effectiveResourceEndpoint = buildResourceEndpoint(
+			effectiveApi,
+			props.headers,
+		);
 
 		const resolvedTheme = mergeTheme(userTheme);
 		const cssVars = themeToCSSProperties(resolvedTheme);

--- a/src/chat/web/lib/resource-endpoint.ts
+++ b/src/chat/web/lib/resource-endpoint.ts
@@ -1,0 +1,23 @@
+/**
+ * Build the resource-endpoint URL used by widget iframes to fetch their
+ * HTML via GET.
+ *
+ * Iframe navigations can't set custom headers, so when the chat caller
+ * passed an `Authorization: Bearer …` header (the embed path), we
+ * propagate the token in the URL. Same-origin proxy setups (customer
+ * next-js adapter) don't need this and get a plain endpoint back.
+ */
+export function buildResourceEndpoint(
+	api: string,
+	headers: HeadersInit | undefined,
+): string {
+	const authHeaderValue =
+		headers && (headers as Record<string, string>).Authorization;
+	const resourceToken =
+		typeof authHeaderValue === "string" && authHeaderValue.startsWith("Bearer ")
+			? authHeaderValue.slice(7)
+			: null;
+	return resourceToken
+		? `${api}/resource?token=${encodeURIComponent(resourceToken)}`
+		: `${api}/resource`;
+}

--- a/src/chat/web/lib/resource-endpoint.ts
+++ b/src/chat/web/lib/resource-endpoint.ts
@@ -6,13 +6,17 @@
  * passed an `Authorization: Bearer …` header (the embed path), we
  * propagate the token in the URL. Same-origin proxy setups (customer
  * next-js adapter) don't need this and get a plain endpoint back.
+ *
+ * Parameter is deliberately narrowed to `Record<string, string>` to match
+ * `ChatBaseProps.headers`. Widening it to `HeadersInit` would silently
+ * drop the token for `Headers`/tuple-array shapes (they need `.get()` /
+ * iteration) and leave the iframe returning 401 with no clear signal.
  */
 export function buildResourceEndpoint(
 	api: string,
-	headers: HeadersInit | undefined,
+	headers: Record<string, string> | undefined,
 ): string {
-	const authHeaderValue =
-		headers && (headers as Record<string, string>).Authorization;
+	const authHeaderValue = headers?.Authorization;
 	const resourceToken =
 		typeof authHeaderValue === "string" && authHeaderValue.startsWith("Bearer ")
 			? authHeaderValue.slice(7)

--- a/src/mcp/react/components/initialize-next-in-iframe.tsx
+++ b/src/mcp/react/components/initialize-next-in-iframe.tsx
@@ -1,25 +1,54 @@
 /**
+ * Initializes & patches Next.js functionality so an app can run as a
+ * widget inside a cross-origin iframe. Used by every MCP widget host —
+ * ChatGPT's sandbox, the embed's `/api/mcp/chat/resource` proxy, and any
+ * future host that renders the widget on a domain other than its own
+ * `baseUrl`.
  *
- * Initializes & patches Next.js functionalities
- * so it can be run inside the ChatGPT iframe:
- * - history.pushState / history.replaceState - Prevents full-origin URLs in history
- * - window.fetch - Rewrites same-origin requests to use the correct base URL
- * - html attribute observer - Prevents ChatGPT from modifying the root element
+ * What it patches:
+ * - `history.pushState` / `history.replaceState` — prevents full-origin
+ *   URLs from ending up in the iframe's history (browsers reject cross-
+ *   origin pushes in sandboxed iframes).
+ * - `window.fetch` — rewrites same-origin requests to the widget's real
+ *   `baseUrl`. Without this, relative `/api/...` calls from the widget
+ *   hit the host's origin (ChatGPT sandbox, WaniWani embed proxy, etc.)
+ *   and 404. `passthroughOrigins` opts specific origins out of the
+ *   rewrite (see prop doc).
+ * - `<html>` attribute observer — strips attributes the host injects
+ *   after hydration (ChatGPT mutates `<html>` for theming), while
+ *   preserving `class` / `style` / `lang`.
  *
- * More information about this component can be found here:
- *
+ * More background on the ChatGPT case:
  * https://vercel.com/blog/running-next-js-inside-chatgpt-a-deep-dive-into-native-app-integration
  */
-export function InitializeNextJsInChatGpt({ baseUrl }: { baseUrl: string }) {
+export function InitializeNextJsInIframe({
+	baseUrl,
+	passthroughOrigins,
+}: {
+	baseUrl: string;
+	/**
+	 * Origins whose fetches should skip the same-origin → baseUrl rewrite.
+	 * Set this to the WaniWani API origin when the widget is loaded through
+	 * a proxy that shares origin with the API (e.g. the embed's
+	 * `/api/mcp/chat/resource` route on `app.waniwani.ai`). Without this,
+	 * widget tracking calls to the WaniWani API get rewritten to the
+	 * widget's own host and 404.
+	 */
+	passthroughOrigins?: string[];
+}) {
 	return (
 		<>
 			<base href={baseUrl}></base>
 			<script>{`window.innerBaseUrl = ${JSON.stringify(baseUrl)}`}</script>
+			<script>{`window.__wwPassthroughOrigins = ${JSON.stringify(passthroughOrigins ?? [])}`}</script>
 			<script>{`window.__isChatGptApp = typeof window.openai !== "undefined";`}</script>
 			<script>
 				{"(" +
 					(() => {
 						const baseUrl = window.innerBaseUrl;
+						const passthroughOrigins: string[] =
+							(window as unknown as { __wwPassthroughOrigins: string[] })
+								.__wwPassthroughOrigins ?? [];
 						const htmlElement = document.documentElement;
 						const observer = new MutationObserver((mutations) => {
 							mutations.forEach((mutation) => {
@@ -133,6 +162,14 @@ export function InitializeNextJsInChatGpt({ baseUrl }: { baseUrl: string }) {
 										...init,
 										mode: "cors",
 									});
+								}
+
+								// Explicit passthrough list — never rewrite these.
+								// Needed when the widget shares origin with a
+								// non-Next-app host (e.g. the WaniWani app serving the
+								// embed iframe + the tracking API from the same host).
+								if (passthroughOrigins.indexOf(url.origin) !== -1) {
+									return originalFetch.call(window, input, init);
 								}
 
 								if (url.origin === window.location.origin) {

--- a/src/mcp/react/index.ts
+++ b/src/mcp/react/index.ts
@@ -1,7 +1,7 @@
 // Client-side React hooks and components for MCP widgets
 
 // Components
-export { InitializeNextJsInChatGpt } from "./components/initialize-next-in-chat-gpt";
+export { InitializeNextJsInIframe } from "./components/initialize-next-in-iframe";
 // Dev tools
 export {
 	DevModeProvider,


### PR DESCRIPTION
## Summary

- Chat embed now appends the bearer token to the widget resource endpoint so the cross-origin iframe GET is authenticated without needing custom headers (`chat-bar.tsx`, `chat-card.tsx`). `mcp-app-frame.tsx` switches to URL-based iframe src construction so pre-existing query params on `resourceEndpoint` survive.
- Rename `InitializeNextJsInChatGpt` → `InitializeNextJsInIframe`. The component was never ChatGPT-specific — it patches Next.js for any cross-origin iframe host (ChatGPT sandbox, WaniWani embed proxy, etc.).
- New `passthroughOrigins` prop on the iframe initializer. Hosts can opt specific origins out of the same-origin → `baseUrl` fetch rewrite. Needed when the widget is embedded through a proxy that shares origin with a non-Next.js API (e.g. the embed iframe at `app.waniwani.ai` + the tracking API on the same host — without this the wrapper would hijack tracking calls to the widget host and 404).

## Why

Pairs with the new `GET /api/mcp/chat/resource` proxy in the WaniWani app. The proxy serves the widget HTML from the WaniWani origin, which breaks two assumptions the SDK used to make:

1. The iframe origin is untrusted (ChatGPT sandbox) — the embed proxy puts it on `app.waniwani.ai`, which is also the tracking API host.
2. The widget resource endpoint can be hit without auth — the embed proxy requires a `wwp_…` token. Passing it in the URL is the only option since iframe GET can't set custom headers.

## Test plan

- [ ] Playground (same-origin load via `/api/waniwani/[[...path]]`): widget loads, tracking batches POST to same origin, no regressions.
- [ ] Chat embed locally (helsinki app + camby prod build on 3001): widget iframe loads through `/api/mcp/chat/resource`, tracking POSTs to helsinki app (not hijacked to camby).
- [ ] Verify no stale `InitializeNextJsInChatGpt` references in published types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces token propagation via iframe resource URLs and changes iframe URL construction, which can affect authentication and caching behavior for embedded widgets. Also adjusts cross-origin `fetch` rewriting logic, which could impact network routing in iframe-hosted apps if misconfigured.
> 
> **Overview**
> Enables authenticated widget iframe loads by introducing `buildResourceEndpoint`, which (when an `Authorization: Bearer …` header is provided) appends a `token` query param to the widget `.../resource` URL; `ChatBar` and `ChatCard` now use this helper.
> 
> Updates `McpAppFrame` to build `iframe.src` by concatenating `uri=...` onto `resourceEndpoint` (preserving existing query params and avoiding SSR/CSR hydration mismatches).
> 
> Generalizes the Next.js-in-iframe bootstrap by renaming `InitializeNextJsInChatGpt` to `InitializeNextJsInIframe` and adding `passthroughOrigins` to skip the same-origin → `baseUrl` `fetch` rewrite for selected origins; the public export is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de61b5ca47fcf293c31e07f19414563fc73365a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->