### PR TITLE
feat(flows): add omitIntentPII flag to FlowConfig

### DIFF
--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -373,6 +373,12 @@ export type FlowConfig = {
 	 * ```
 	 */
 	state: Record<string, z.ZodType>;
+	/**
+	 * If true, instruct the agent to omit PII (names, emails, phones, addresses,
+	 * IDs, ages, birthdates) from the `intent` and `context` fields. Only adds a
+	 * guidance line to the tool description — does not redact server-side.
+	 */
+	omitIntentPII?: boolean;
 	/** Optional tool annotations */
 	annotations?: {
 		readOnlyHint?: boolean;

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -30,31 +30,36 @@ import {
 // Input schema
 // ============================================================================
 
-const inputSchema = {
-	action: z
-		.enum(["start", "continue"])
-		.describe(
-			'"start" to begin the flow, "continue" to resume after a pause (interrupt or widget)',
-		),
-	intent: z
-		.string()
-		.optional()
-		.describe(
-			'Required when action is "start". Provide a brief summary of the user\'s goal for this flow. Do not invent missing intent.',
-		),
-	context: z
-		.string()
-		.optional()
-		.describe(
-			'Optional when action is "start". Describe the situation or environment that led the user to start this flow — e.g. what page they are on, what they were doing, or what triggered the request. Do not invent missing context.',
-		),
-	stateUpdates: z
-		.record(z.string(), z.unknown())
-		.optional()
-		.describe(
-			"State field values to set before processing the next node. Use this to pass the user's answer (keyed by the field name from the response) and any other values the user mentioned.",
-		),
-};
+function buildInputSchema(config: { omitIntentPII?: boolean }) {
+	const piiNote = config.omitIntentPII
+		? " Do not include PII (names, emails, phones, addresses, IDs, ages, birthdates) — summarize abstractly."
+		: "";
+	return {
+		action: z
+			.enum(["start", "continue"])
+			.describe(
+				'"start" to begin the flow, "continue" to resume after a pause (interrupt or widget)',
+			),
+		intent: z
+			.string()
+			.optional()
+			.describe(
+				`Required when action is "start". Provide a brief summary of the user's goal for this flow. Do not invent missing intent.${piiNote}`,
+			),
+		context: z
+			.string()
+			.optional()
+			.describe(
+				`Optional when action is "start". Describe the situation or environment that led the user to start this flow — e.g. what page they are on, what they were doing, or what triggered the request. Do not invent missing context.${piiNote}`,
+			),
+		stateUpdates: z
+			.record(z.string(), z.unknown())
+			.optional()
+			.describe(
+				"State field values to set before processing the next node. Use this to pass the user's answer (keyed by the field name from the response) and any other values the user mentioned.",
+			),
+	};
+}
 
 // ============================================================================
 // Compile
@@ -64,6 +69,7 @@ export function compileFlow<TState extends Record<string, unknown>>(
 	input: CompileInput<TState>,
 ): RegisteredFlow {
 	const { config, nodes, edges } = input;
+	const inputSchema = buildInputSchema(config);
 	const flowGraph = extractFlowGraph(config, nodes, edges, input.nodeOptions);
 	const protocol = buildFlowProtocol(config);
 	const fullDescription = `${config.description}\n${protocol}`;

--- a/src/mcp/server/flows/protocol.ts
+++ b/src/mcp/server/flows/protocol.ts
@@ -43,7 +43,7 @@ export function buildFlowProtocol(config: FlowConfig): string {
 	if (config.omitIntentPII) {
 		lines.push(
 			"   Do NOT include PII in `intent` or `context` — no names, emails, phones, addresses, IDs, ages, or birthdates.",
-			"   Summarize the goal abstractly (e.g. \"user wants a quote\", not \"Jane Doe wants a quote\").",
+			'   Summarize the goal abstractly (e.g. "user wants a quote", not "Jane Doe wants a quote").',
 		);
 	}
 

--- a/src/mcp/server/flows/protocol.ts
+++ b/src/mcp/server/flows/protocol.ts
@@ -40,6 +40,13 @@ export function buildFlowProtocol(config: FlowConfig): string {
 		"   Only extract values the user explicitly stated — do NOT guess or invent values.",
 	];
 
+	if (config.omitIntentPII) {
+		lines.push(
+			"   Do NOT include PII in `intent` or `context` — no names, emails, phones, addresses, IDs, ages, or birthdates.",
+			"   Summarize the goal abstractly (e.g. \"user wants a quote\", not \"Jane Doe wants a quote\").",
+		);
+	}
+
 	if (config.state) {
 		const parts: string[] = [];
 		for (const [key, schema] of Object.entries(config.state)) {


### PR DESCRIPTION
## Summary
- Adds opt-in `omitIntentPII?: boolean` to `FlowConfig`.
- When set, appends PII-omission guidance to the flow tool's `intent` / `context` Zod `.describe()` strings and to the `## FLOW EXECUTION PROTOCOL` prose.
- No server-side redaction — prompt-level signal only. Off by default, no behavior change for existing consumers.

## Motivation
When an MCP flow starts in ChatGPT, the agent fills the `intent` field from prior conversation, which may contain PII. Consumers that care about this (e.g. isalud) can now opt in per flow to instruct the agent to summarize abstractly.

## Usage
```ts
createFlow({ id, title, description, state, omitIntentPII: true })
```

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test src/mcp/server/flows/` — 54/54 pass
- [ ] Consumer side: wire `omitIntentPII: true` into an isalud flow and confirm tool description reflects the guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is opt-in and only changes tool description/protocol strings (no server-side redaction or execution logic changes), though it may affect agent prompting when enabled.
> 
> **Overview**
> Adds an optional `omitIntentPII` flag to `FlowConfig` that, when enabled, **adds explicit guidance to omit PII** from the `intent`/`context` fields.
> 
> Flow compilation now builds the input schema dynamically so the `intent`/`context` Zod `.describe()` text and the `FLOW EXECUTION PROTOCOL` include PII-avoidance instructions when the flag is set; default behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1e3f1bda927d7d052b5bcfdb99223f9d16fc1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->