### PR TITLE
feat(embed): add mode + layout options and custom triggers

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -266,28 +266,74 @@ No MCP app changes needed — the embed talks to WaniWani API directly.
 | `data-placeholder` | No | Input field placeholder text |
 | `data-suggestions` | No | Comma-separated suggestion chips |
 | `data-position` | No | `"bottom-right"` (default) or `"bottom-left"` |
+| `data-mode` | No | `"floating"` (default), `"custom"`, or `"inline"`. See [Display modes](#display-modes) below. |
+| `data-layout` | No | In `inline` mode: `"card"` (default), `"bar"`, or `"embed"`. Picks the layout component. Ignored in other modes. |
 | `data-width` | No | Panel width in px (default: `400`) |
 | `data-height` | No | Panel height in px (default: `600`) |
-| `data-container` | No | CSS selector for inline mode (no floating bubble) |
 | `data-css` | No | URL to custom stylesheet (injected into Shadow DOM) |
 | `data-primary-color` | No | Primary color hex |
 | `data-background-color` | No | Background color hex |
 | `data-text-color` | No | Text color hex |
 | `data-font-family` | No | Font family |
 
-### Inline Mode
+### Display Modes
 
-Render inside an existing container instead of floating:
+Pick how the widget appears with `data-mode` (or `mode` in `init()`):
+
+| Mode | Behaviour | Use when |
+|---|---|---|
+| `floating` (default) | SDK renders a floating bubble bottom-right/left; clicking it toggles a popover panel. | Standard drop-in chat bubble. |
+| `custom` | Popover panel only — no bubble. Consumer renders their own launcher and calls `WaniWani.chat.open()` / `toggle()`. | You want the bubble replaced by a branded button, nav item, etc. |
+| `inline` | Layout component renders directly into the first `[data-waniwani-embed]` element on the page. No bubble, no panel, no overlay. | You want the chat embedded as a block on a page (e.g. landing page hero). |
+
+#### Inline mode
+
+Place a marker element anywhere on the page — the SDK mounts into it:
 
 ```html
-<div id="chat" style="width: 400px; height: 600px;"></div>
+<div data-waniwani-embed style="width: 400px; height: 600px;"></div>
+
 <script
   src="https://cdn.jsdelivr.net/npm/@waniwani/sdk@latest/dist/chat/embed.js"
   defer
   data-token="wwp_..."
-  data-container="#chat"
+  data-mode="inline"
 ></script>
 ```
+
+Pick the layout with `data-layout` (inline only):
+
+| Value | Component | Shape |
+|---|---|---|
+| `card` (default) | `ChatCard` | Bordered card with header, messages, input. |
+| `bar` | `ChatBar` | Compact input bar that expands upward on focus. |
+| `embed` | `ChatEmbed` | Borderless, fills parent container (no header). |
+
+```html
+<div data-waniwani-embed style="width: 600px; height: 80px;"></div>
+<script src=".../embed.js" defer
+  data-token="wwp_..."
+  data-mode="inline"
+  data-layout="bar"
+></script>
+```
+
+#### Custom launcher
+
+Set `data-mode="custom"` to suppress the built-in bubble. The panel still mounts (hidden) and opens via `WaniWani.chat.open()`:
+
+```html
+<script
+  src="https://cdn.jsdelivr.net/npm/@waniwani/sdk@latest/dist/chat/embed.js"
+  defer
+  data-token="wwp_..."
+  data-mode="custom"
+></script>
+
+<button onclick="WaniWani.chat.toggle()">Chat with us</button>
+```
+
+`open`, `close`, and `toggle` are exposed on the instance returned by `init()` and on `window.WaniWani.chat`. They're no-ops in `inline` mode (nothing to open).
 
 ### Programmatic Init
 
@@ -300,6 +346,11 @@ Render inside an existing container instead of floating:
       title: 'Support',
       theme: { primaryColor: '#6366f1' },
     });
+
+    // Imperative control (floating mode only)
+    chat.open();
+    chat.close();
+    chat.toggle();
 
     // Cleanup
     chat.destroy();

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -56,13 +56,11 @@ describe("resolveConfig — programmatic", () => {
 			token: "tok",
 			welcomeMessage: "Hello!",
 			placeholder: "Type here...",
-			container: "#chat",
 			css: "https://example.com/custom.css",
 		});
 
 		expect(config.welcomeMessage).toBe("Hello!");
 		expect(config.placeholder).toBe("Type here...");
-		expect(config.container).toBe("#chat");
 		expect(config.css).toBe("https://example.com/custom.css");
 	});
 

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -21,8 +21,6 @@ export interface EmbedConfig {
 	token: string;
 	/** Override MCP server URL (optional — resolved from environment by default). */
 	mcpServerUrl?: string;
-	/** CSS selector for inline mode — renders ChatCard inside this element instead of a floating bubble. */
-	container?: string;
 	/** Title shown in the chat header. Defaults to `"Assistant"`. */
 	title?: string;
 	/** Welcome message shown before the first user message. */
@@ -33,6 +31,24 @@ export interface EmbedConfig {
 	suggestions?: string[];
 	/** Position of the floating bubble. Defaults to `"bottom-right"`. */
 	position?: "bottom-right" | "bottom-left";
+	/**
+	 * Display mode.
+	 * - `"floating"` (default): SDK renders a floating bubble that toggles a popover panel.
+	 * - `"custom"`: popover panel only — consumer renders their own launcher and opens
+	 *   it via `WaniWani.chat.open()` / `toggle()`.
+	 * - `"inline"`: no bubble or panel — ChatCard is rendered directly into the first
+	 *   `[data-waniwani-embed]` element found on the page.
+	 */
+	mode?: "floating" | "custom" | "inline";
+	/**
+	 * Layout component used in `mode: "inline"`.
+	 * - `"card"` (default): `ChatCard` — bordered card with header + messages + input.
+	 * - `"bar"`: `ChatBar` — compact bar that expands upward on focus.
+	 * - `"embed"`: `ChatEmbed` — borderless, fills parent container.
+	 *
+	 * Ignored in `floating` and `custom` modes (always renders `ChatCard` in the panel).
+	 */
+	layout?: "card" | "bar" | "embed";
 	/** Panel width in pixels. Defaults to `400`. */
 	width?: number;
 	/** Panel height in pixels. Defaults to `600`. */
@@ -119,11 +135,6 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 	}
 
 	// Optional strings
-	const container = str("data-container");
-	if (container) {
-		config.container = container;
-	}
-
 	const title = str("data-title");
 	if (title) {
 		config.title = title;
@@ -162,6 +173,18 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 	const position = str("data-position");
 	if (position === "bottom-right" || position === "bottom-left") {
 		config.position = position;
+	}
+
+	// Display mode
+	const mode = str("data-mode");
+	if (mode === "floating" || mode === "custom" || mode === "inline") {
+		config.mode = mode;
+	}
+
+	// Inline layout
+	const layout = str("data-layout");
+	if (layout === "card" || layout === "bar" || layout === "embed") {
+		config.layout = layout;
 	}
 
 	// Dimensions
@@ -245,6 +268,10 @@ export function resolveConfig(
 			"[WaniWani] Missing required config: `token`. " +
 				"Set data-token on the script tag or pass it to WaniWani.chat.init().",
 		);
+	}
+
+	if (!merged.mode) {
+		merged.mode = "floating";
 	}
 
 	return merged;

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -9,7 +9,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import type { EmbedConfig } from "./config";
 import { parseConfigFromScript, resolveConfig } from "./config";
-import { FloatingChat } from "./floating-chat";
+import { FloatingChat, type FloatingChatHandle } from "./floating-chat";
 import { InlineChat } from "./inline-chat";
 
 // ---------------------------------------------------------------------------
@@ -28,6 +28,9 @@ declare global {
 			chat?: {
 				init: (options?: Partial<EmbedConfig>) => EmbedInstance;
 				destroy: () => void;
+				open: () => void;
+				close: () => void;
+				toggle: () => void;
 			};
 		};
 	}
@@ -39,6 +42,12 @@ declare global {
 
 interface EmbedInstance {
 	destroy: () => void;
+	/** Open the chat panel. No-op in inline mode. */
+	open: () => void;
+	/** Close the chat panel. No-op in inline mode. */
+	close: () => void;
+	/** Toggle the chat panel. No-op in inline mode. */
+	toggle: () => void;
 }
 
 let currentInstance: EmbedInstance | null = null;
@@ -81,16 +90,17 @@ function injectStyles(shadowRoot: ShadowRoot, config: EmbedConfig): void {
 // Mount helpers
 // ---------------------------------------------------------------------------
 
+const INLINE_MARKER_ATTR = "data-waniwani-embed";
+
 function mountInline(
 	config: EmbedConfig,
 	programmatic: Partial<EmbedConfig> | undefined,
 	scriptConfig: Partial<EmbedConfig> | undefined,
 ): EmbedInstance {
-	const selector = config.container as string;
-	const container = document.querySelector(selector);
+	const container = document.querySelector(`[${INLINE_MARKER_ATTR}]`);
 	if (!container) {
 		throw new Error(
-			`[WaniWani] Container element not found: ${config.container}`,
+			`[WaniWani] No inline mount target. Place \`<div ${INLINE_MARKER_ATTR}></div>\` in your page for \`mode: "inline"\`.`,
 		);
 	}
 
@@ -120,6 +130,9 @@ function mountInline(
 			hostElement = null;
 			currentInstance = null;
 		},
+		open: () => {},
+		close: () => {},
+		toggle: () => {},
 	};
 }
 
@@ -170,21 +183,26 @@ function mountFloating(
 
 	const shadowRoot = hostElement.attachShadow({ mode: "open" });
 
-	// Show loading skeleton immediately (CSS-only, no React needed)
-	const skeleton = createLoadingSkeleton(shadowRoot, config);
+	// Show loading skeleton immediately (CSS-only, no React needed) —
+	// skip in custom mode since there's no bubble to stand in for.
+	const skeleton =
+		config.mode === "custom" ? null : createLoadingSkeleton(shadowRoot, config);
 
 	injectStyles(shadowRoot, config);
 
 	const mountContainer = document.createElement("div");
 	shadowRoot.appendChild(mountContainer);
 
+	const chatRef = React.createRef<FloatingChatHandle>();
+
 	reactRoot = ReactDOM.createRoot(mountContainer);
 	reactRoot.render(
 		React.createElement(FloatingChat, {
+			ref: chatRef,
 			config,
 			programmatic,
 			scriptConfig,
-			onReady: () => skeleton.remove(),
+			onReady: () => skeleton?.remove(),
 		}),
 	);
 
@@ -196,6 +214,9 @@ function mountFloating(
 			hostElement = null;
 			currentInstance = null;
 		},
+		open: () => chatRef.current?.open(),
+		close: () => chatRef.current?.close(),
+		toggle: () => chatRef.current?.toggle(),
 	};
 }
 
@@ -221,9 +242,10 @@ function init(options?: Partial<EmbedConfig>): EmbedInstance {
 	// so the React-side useRemoteEmbedConfig hook can re-apply them on top
 	// of the server's config once it arrives. Without this the remote
 	// config could override fields the customer explicitly set.
-	currentInstance = config.container
-		? mountInline(config, options, scriptConfig)
-		: mountFloating(config, options, scriptConfig);
+	currentInstance =
+		config.mode === "inline"
+			? mountInline(config, options, scriptConfig)
+			: mountFloating(config, options, scriptConfig);
 
 	return currentInstance;
 }
@@ -240,7 +262,13 @@ function destroy(): void {
 // ---------------------------------------------------------------------------
 
 window.WaniWani = window.WaniWani || {};
-window.WaniWani.chat = { init, destroy };
+window.WaniWani.chat = {
+	init,
+	destroy,
+	open: () => currentInstance?.open(),
+	close: () => currentInstance?.close(),
+	toggle: () => currentInstance?.toggle(),
+};
 
 // ---------------------------------------------------------------------------
 // Auto-init from script tag data attributes

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -208,6 +208,7 @@ export const FloatingChat = forwardRef<FloatingChatHandle, FloatingChatProps>(
 		// -----------------------------------------------------------------------
 		// Position helpers
 		// -----------------------------------------------------------------------
+		const isCustomMode = config.mode === "custom";
 		const isLeft = config.position === "bottom-left";
 		const panelWidth = config.width ?? 400;
 		const panelHeight = config.height ?? 600;
@@ -263,7 +264,7 @@ export const FloatingChat = forwardRef<FloatingChatHandle, FloatingChatProps>(
 				}
 			: {
 					position: "absolute",
-					bottom: BUBBLE_SIZE + PANEL_GAP,
+					bottom: isCustomMode ? 0 : BUBBLE_SIZE + PANEL_GAP,
 					...(isLeft ? { left: 0 } : { right: 0 }),
 					width: panelWidth,
 					height: panelHeight,
@@ -372,27 +373,30 @@ export const FloatingChat = forwardRef<FloatingChatHandle, FloatingChatProps>(
 					</div>
 				</div>
 
-				{/* Bubble */}
-				<button
-					type="button"
-					onClick={toggle}
-					style={{ ...bubbleStyle, position: "relative" }}
-					aria-label={isOpen ? "Close chat" : "Open chat"}
-					onMouseEnter={(e) => {
-						(e.currentTarget as HTMLButtonElement).style.transform =
-							"scale(1.08)";
-						(e.currentTarget as HTMLButtonElement).style.boxShadow =
-							"0 6px 20px rgba(0, 0, 0, 0.2)";
-					}}
-					onMouseLeave={(e) => {
-						(e.currentTarget as HTMLButtonElement).style.transform = "scale(1)";
-						(e.currentTarget as HTMLButtonElement).style.boxShadow =
-							"0 4px 12px rgba(0, 0, 0, 0.15)";
-					}}
-				>
-					<ChatIcon />
-					{hasUnread && <span style={unreadDotStyle} />}
-				</button>
+				{/* Bubble — hidden in custom-trigger mode (consumer renders their own) */}
+				{!isCustomMode && (
+					<button
+						type="button"
+						onClick={toggle}
+						style={{ ...bubbleStyle, position: "relative" }}
+						aria-label={isOpen ? "Close chat" : "Open chat"}
+						onMouseEnter={(e) => {
+							(e.currentTarget as HTMLButtonElement).style.transform =
+								"scale(1.08)";
+							(e.currentTarget as HTMLButtonElement).style.boxShadow =
+								"0 6px 20px rgba(0, 0, 0, 0.2)";
+						}}
+						onMouseLeave={(e) => {
+							(e.currentTarget as HTMLButtonElement).style.transform =
+								"scale(1)";
+							(e.currentTarget as HTMLButtonElement).style.boxShadow =
+								"0 4px 12px rgba(0, 0, 0, 0.15)";
+						}}
+					>
+						<ChatIcon />
+						{hasUnread && <span style={unreadDotStyle} />}
+					</button>
+				)}
 			</div>
 		);
 	},

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -1,13 +1,15 @@
 // ============================================================================
-// InlineChat — wraps ChatCard for the `data-container` inline mount path.
+// InlineChat — wraps ChatCard/ChatBar/ChatEmbed for the inline mount path.
 //
 // Exists so remote config fetching can happen inside React, matching the
-// floating mode. Plain rendering of ChatCard in embed.ts would leave no
+// floating mode. Plain rendering of the layout in embed.ts would leave no
 // useEffect hook to own the fetch.
 // ============================================================================
 
 import { useEffect } from "react";
+import { ChatBar } from "../layouts/chat-bar";
 import { ChatCard } from "../layouts/chat-card";
+import { ChatEmbed } from "../layouts/chat-embed";
 import type { EmbedConfig } from "./config";
 import { buildChatTheme } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
@@ -37,21 +39,37 @@ export function InlineChat({
 		onReady?.();
 	}, []);
 
+	const shared = {
+		api: config.api,
+		headers: { Authorization: `Bearer ${config.token}` },
+		skipRemoteConfig: true as const,
+		body: config.mcpServerUrl
+			? { mcpServerUrl: config.mcpServerUrl }
+			: undefined,
+		theme: buildChatTheme(config),
+		welcomeMessage: config.welcomeMessage,
+		placeholder: config.placeholder,
+		suggestions: config.suggestions
+			? { initial: config.suggestions }
+			: undefined,
+	};
+
+	const layout = config.layout ?? "card";
+
+	if (layout === "bar") {
+		return <ChatBar {...shared} title={config.title ?? "Assistant"} />;
+	}
+
+	if (layout === "embed") {
+		// ChatEmbed requires a non-optional `api`; shared.api is already resolved
+		// from defaults, so non-null assertion is safe.
+		return <ChatEmbed {...shared} api={shared.api as string} />;
+	}
+
 	return (
 		<ChatCard
-			api={config.api}
-			headers={{ Authorization: `Bearer ${config.token}` }}
-			skipRemoteConfig
-			body={
-				config.mcpServerUrl ? { mcpServerUrl: config.mcpServerUrl } : undefined
-			}
-			theme={buildChatTheme(config)}
+			{...shared}
 			title={config.title ?? "Assistant"}
-			welcomeMessage={config.welcomeMessage}
-			placeholder={config.placeholder}
-			suggestions={
-				config.suggestions ? { initial: config.suggestions } : undefined
-			}
 			width="100%"
 			height="100%"
 		/>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the public embed script API by replacing `data-container` with `mode`/`layout` and adding imperative `open`/`close`/`toggle`, which can break existing integrations and affects how/where the widget mounts and renders.
> 
> **Overview**
> Adds **configurable display modes** to the chat embed via `data-mode`/`mode`: `floating` (default), `custom` (panel only, no bubble), and `inline` (mounts into the first `[data-waniwani-embed]` marker element).
> 
> Introduces `data-layout`/`layout` for inline rendering (`card`, `bar`, `embed`) and updates inline mounting accordingly, while exposing global and instance-level imperative controls (`open`/`close`/`toggle`) for custom launchers; docs and tests are updated and the legacy `data-container` inline option is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4023ab004039944fd52eb905f9f0cb340400634e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->