### PR TITLE
feat(embed): default mode to inline

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -244,7 +244,11 @@ No MCP app changes needed — the embed talks to WaniWani API directly.
 
 ### Script Tag (declarative)
 
+Default mode is `inline` — the chat mounts into the first `[data-waniwani-embed]` element on the page:
+
 ```html
+<div data-waniwani-embed style="width: 400px; height: 600px;"></div>
+
 <script
   src="https://cdn.jsdelivr.net/npm/@waniwani/sdk@latest/dist/chat/embed.js"
   defer
@@ -254,6 +258,8 @@ No MCP app changes needed — the embed talks to WaniWani API directly.
   data-primary-color="#6366f1"
 ></script>
 ```
+
+For a floating bubble instead, add `data-mode="floating"`.
 
 ### Script Tag Options
 
@@ -266,7 +272,7 @@ No MCP app changes needed — the embed talks to WaniWani API directly.
 | `data-placeholder` | No | Input field placeholder text |
 | `data-suggestions` | No | Comma-separated suggestion chips |
 | `data-position` | No | `"bottom-right"` (default) or `"bottom-left"` |
-| `data-mode` | No | `"floating"` (default), `"custom"`, or `"inline"`. See [Display modes](#display-modes) below. |
+| `data-mode` | No | `"inline"` (default), `"floating"`, or `"custom"`. See [Display modes](#display-modes) below. |
 | `data-layout` | No | In `inline` mode: `"card"` (default), `"bar"`, or `"embed"`. Picks the layout component. Ignored in other modes. |
 | `data-width` | No | Panel width in px (default: `400`) |
 | `data-height` | No | Panel height in px (default: `600`) |
@@ -282,9 +288,9 @@ Pick how the widget appears with `data-mode` (or `mode` in `init()`):
 
 | Mode | Behaviour | Use when |
 |---|---|---|
-| `floating` (default) | SDK renders a floating bubble bottom-right/left; clicking it toggles a popover panel. | Standard drop-in chat bubble. |
+| `inline` (default) | Layout component renders directly into the first `[data-waniwani-embed]` element on the page. No bubble, no panel, no overlay. | You want the chat embedded as a block on a page (e.g. landing page hero). |
+| `floating` | SDK renders a floating bubble bottom-right/left; clicking it toggles a popover panel. | Standard drop-in chat bubble. |
 | `custom` | Popover panel only — no bubble. Consumer renders their own launcher and calls `WaniWani.chat.open()` / `toggle()`. | You want the bubble replaced by a branded button, nav item, etc. |
-| `inline` | Layout component renders directly into the first `[data-waniwani-embed]` element on the page. No bubble, no panel, no overlay. | You want the chat embedded as a block on a page (e.g. landing page hero). |
 
 #### Inline mode
 

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -32,12 +32,12 @@ export interface EmbedConfig {
 	/** Position of the floating bubble. Defaults to `"bottom-right"`. */
 	position?: "bottom-right" | "bottom-left";
 	/**
-	 * Display mode.
-	 * - `"floating"` (default): SDK renders a floating bubble that toggles a popover panel.
+	 * Display mode. Defaults to `"inline"`.
+	 * - `"inline"` (default): no bubble or panel — ChatCard is rendered directly into the first
+	 *   `[data-waniwani-embed]` element found on the page.
+	 * - `"floating"`: SDK renders a floating bubble that toggles a popover panel.
 	 * - `"custom"`: popover panel only — consumer renders their own launcher and opens
 	 *   it via `WaniWani.chat.open()` / `toggle()`.
-	 * - `"inline"`: no bubble or panel — ChatCard is rendered directly into the first
-	 *   `[data-waniwani-embed]` element found on the page.
 	 */
 	mode?: "floating" | "custom" | "inline";
 	/**
@@ -271,7 +271,7 @@ export function resolveConfig(
 	}
 
 	if (!merged.mode) {
-		merged.mode = "floating";
+		merged.mode = "inline";
 	}
 
 	return merged;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the embed widget’s default display mode from a floating bubble to inline rendering, which can alter appearance/UX for existing consumers who relied on the previous default.
> 
> **Overview**
> **Embed chat now defaults to `inline` mode** instead of `floating`, mounting directly into the first `[data-waniwani-embed]` element when `mode`/`data-mode` isn’t provided.
> 
> Documentation and config comments/examples were updated to reflect the new default and to explicitly instruct users to set `data-mode="floating"` when they want the previous bubble behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c6121e3e75af84b1a157594c3a32c9787125d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->