### PR TITLE
feat(embed): expose sendMessage on window.WaniWani.chat

### DIFF
--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -10,7 +10,7 @@ import ReactDOM from "react-dom/client";
 import type { EmbedConfig } from "./config";
 import { parseConfigFromScript, resolveConfig } from "./config";
 import { FloatingChat, type FloatingChatHandle } from "./floating-chat";
-import { InlineChat } from "./inline-chat";
+import { InlineChat, type InlineChatHandle } from "./inline-chat";
 
 // ---------------------------------------------------------------------------
 // CSS placeholder — replaced at build time with the actual CSS string
@@ -31,6 +31,11 @@ declare global {
 				open: () => void;
 				close: () => void;
 				toggle: () => void;
+				/**
+				 * Programmatically submit a user message to the chat. No-op if the
+				 * embed has not mounted yet or the inner layout has not attached.
+				 */
+				sendMessage: (text: string) => void;
 			};
 		};
 	}
@@ -48,6 +53,8 @@ interface EmbedInstance {
 	close: () => void;
 	/** Toggle the chat panel. No-op in inline mode. */
 	toggle: () => void;
+	/** Submit a user message. No-op until the inner chat layout has mounted. */
+	sendMessage: (text: string) => void;
 }
 
 let currentInstance: EmbedInstance | null = null;
@@ -117,9 +124,16 @@ function mountInline(
 	mountContainer.style.height = "100%";
 	shadowRoot.appendChild(mountContainer);
 
+	const inlineRef = React.createRef<InlineChatHandle>();
+
 	reactRoot = ReactDOM.createRoot(mountContainer);
 	reactRoot.render(
-		React.createElement(InlineChat, { config, programmatic, scriptConfig }),
+		React.createElement(InlineChat, {
+			ref: inlineRef,
+			config,
+			programmatic,
+			scriptConfig,
+		}),
 	);
 
 	return {
@@ -133,6 +147,8 @@ function mountInline(
 		open: () => {},
 		close: () => {},
 		toggle: () => {},
+		sendMessage: (text: string) =>
+			inlineRef.current?.chat?.sendMessage(text),
 	};
 }
 
@@ -217,6 +233,8 @@ function mountFloating(
 		open: () => chatRef.current?.open(),
 		close: () => chatRef.current?.close(),
 		toggle: () => chatRef.current?.toggle(),
+		sendMessage: (text: string) =>
+			chatRef.current?.chat?.sendMessage(text),
 	};
 }
 
@@ -268,6 +286,7 @@ window.WaniWani.chat = {
 	open: () => currentInstance?.open(),
 	close: () => currentInstance?.close(),
 	toggle: () => currentInstance?.toggle(),
+	sendMessage: (text: string) => currentInstance?.sendMessage(text),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -147,8 +147,7 @@ function mountInline(
 		open: () => {},
 		close: () => {},
 		toggle: () => {},
-		sendMessage: (text: string) =>
-			inlineRef.current?.chat?.sendMessage(text),
+		sendMessage: (text: string) => inlineRef.current?.chat?.sendMessage(text),
 	};
 }
 
@@ -233,8 +232,7 @@ function mountFloating(
 		open: () => chatRef.current?.open(),
 		close: () => chatRef.current?.close(),
 		toggle: () => chatRef.current?.toggle(),
-		sendMessage: (text: string) =>
-			chatRef.current?.chat?.sendMessage(text),
+		sendMessage: (text: string) => chatRef.current?.chat?.sendMessage(text),
 	};
 }
 

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -86,13 +86,7 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 		if (layout === "embed") {
 			// ChatEmbed requires a non-optional `api`; shared.api is already resolved
 			// from defaults, so non-null assertion is safe.
-			return (
-				<ChatEmbed
-					{...shared}
-					ref={chatRef}
-					api={shared.api as string}
-				/>
-			);
+			return <ChatEmbed {...shared} ref={chatRef} api={shared.api as string} />;
 		}
 
 		return (

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -6,7 +6,8 @@
 // useEffect hook to own the fetch.
 // ============================================================================
 
-import { useEffect } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import type { ChatHandle } from "../@types";
 import { ChatBar } from "../layouts/chat-bar";
 import { ChatCard } from "../layouts/chat-card";
 import { ChatEmbed } from "../layouts/chat-embed";
@@ -22,56 +23,86 @@ export interface InlineChatProps {
 	onReady?: () => void;
 }
 
-export function InlineChat({
-	config: initialConfig,
-	programmatic,
-	scriptConfig,
-	onReady,
-}: InlineChatProps) {
-	const config = useRemoteEmbedConfig(
-		initialConfig,
-		programmatic,
-		scriptConfig,
-	);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: fire once on mount
-	useEffect(() => {
-		onReady?.();
-	}, []);
-
-	const shared = {
-		api: config.api,
-		headers: { Authorization: `Bearer ${config.token}` },
-		skipRemoteConfig: true as const,
-		body: config.mcpServerUrl
-			? { mcpServerUrl: config.mcpServerUrl }
-			: undefined,
-		theme: buildChatTheme(config),
-		welcomeMessage: config.welcomeMessage,
-		placeholder: config.placeholder,
-		suggestions: config.suggestions
-			? { initial: config.suggestions }
-			: undefined,
-	};
-
-	const layout = config.layout ?? "card";
-
-	if (layout === "bar") {
-		return <ChatBar {...shared} title={config.title ?? "Assistant"} />;
-	}
-
-	if (layout === "embed") {
-		// ChatEmbed requires a non-optional `api`; shared.api is already resolved
-		// from defaults, so non-null assertion is safe.
-		return <ChatEmbed {...shared} api={shared.api as string} />;
-	}
-
-	return (
-		<ChatCard
-			{...shared}
-			title={config.title ?? "Assistant"}
-			width="100%"
-			height="100%"
-		/>
-	);
+export interface InlineChatHandle {
+	/** Ref to the underlying ChatCard/ChatBar/ChatEmbed handle. Null until mounted. */
+	chat: ChatHandle | null;
 }
+
+export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
+	function InlineChat(
+		{ config: initialConfig, programmatic, scriptConfig, onReady },
+		ref,
+	) {
+		const config = useRemoteEmbedConfig(
+			initialConfig,
+			programmatic,
+			scriptConfig,
+		);
+
+		const chatRef = useRef<ChatHandle>(null);
+
+		// biome-ignore lint/correctness/useExhaustiveDependencies: fire once on mount
+		useEffect(() => {
+			onReady?.();
+		}, []);
+
+		useImperativeHandle(
+			ref,
+			() => ({
+				get chat() {
+					return chatRef.current;
+				},
+			}),
+			[],
+		);
+
+		const shared = {
+			api: config.api,
+			headers: { Authorization: `Bearer ${config.token}` },
+			skipRemoteConfig: true as const,
+			body: config.mcpServerUrl
+				? { mcpServerUrl: config.mcpServerUrl }
+				: undefined,
+			theme: buildChatTheme(config),
+			welcomeMessage: config.welcomeMessage,
+			placeholder: config.placeholder,
+			suggestions: config.suggestions
+				? { initial: config.suggestions }
+				: undefined,
+		};
+
+		const layout = config.layout ?? "card";
+
+		if (layout === "bar") {
+			return (
+				<ChatBar
+					{...shared}
+					ref={chatRef}
+					title={config.title ?? "Assistant"}
+				/>
+			);
+		}
+
+		if (layout === "embed") {
+			// ChatEmbed requires a non-optional `api`; shared.api is already resolved
+			// from defaults, so non-null assertion is safe.
+			return (
+				<ChatEmbed
+					{...shared}
+					ref={chatRef}
+					api={shared.api as string}
+				/>
+			);
+		}
+
+		return (
+			<ChatCard
+				{...shared}
+				ref={chatRef}
+				title={config.title ?? "Assistant"}
+				width="100%"
+				height="100%"
+			/>
+		);
+	},
+);


### PR DESCRIPTION
## Summary
- Adds `sendMessage(text)` to `EmbedInstance` and `window.WaniWani.chat` so host pages can programmatically submit user messages.
- `InlineChat` now forwards a handle exposing the inner `ChatHandle`; both inline and floating mounts thread a `chatRef` through to the underlying layout.
- Unblocks replacing React `ChatCard` + `chatRef.current?.sendMessage(...)` usage on host pages that embed via the CDN script tag (e.g. the waniwani.ai site).

## Usage
```html
<script src="https://cdn.jsdelivr.net/npm/@waniwani/sdk@beta/dist/chat/embed.js" defer
        data-api="https://app.waniwani.ai/api/mcp/chat" data-token="wwp_..."></script>
<div data-waniwani-embed></div>
<script>
  document.querySelector("#demo-btn").onclick = () =>
    window.WaniWani.chat.sendMessage("I'd like to request a demo");
</script>
```

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run build` emits `dist/chat/embed.js` without errors
- [ ] Manual: mount inline embed, call `window.WaniWani.chat.sendMessage("hi")` in devtools, user message appears in chat
- [ ] Manual: same for floating mode (`data-mode="floating"`)
- [ ] No-op before mount: `window.WaniWani.chat.sendMessage(...)` called before embed has initialized should not throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional imperative API that no-ops when the embed/chat handle is not mounted, without changing existing open/close/toggle behavior.
> 
> **Overview**
> Adds `sendMessage(text)` to the embed’s imperative surface (`EmbedInstance` and `window.WaniWani.chat`) so host pages can programmatically submit a user message.
> 
> Updates the inline mount path to forward an `InlineChatHandle` via `ref` that exposes the underlying `ChatHandle`, and threads refs through `ChatCard`/`ChatBar`/`ChatEmbed` so `sendMessage` works consistently in both inline and floating modes (no-op until mounted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9f1d305134bb78bcd57ad4c2c3211040673ae7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->