### PR TITLE
fix(embed): stretch inline host + sync remote suggestions

### DIFF
--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -111,9 +111,12 @@ function mountInline(
 		);
 	}
 
-	// Create shadow DOM inside the target container
+	// Create shadow DOM inside the target container. Stretch to fill the
+	// parent so the embedder's sizing (e.g. `h-[640px]`) drives the chat.
 	hostElement = document.createElement("div");
 	hostElement.id = "waniwani-chat-embed";
+	hostElement.style.width = "100%";
+	hostElement.style.height = "100%";
 	container.appendChild(hostElement);
 
 	const shadowRoot = hostElement.attachShadow({ mode: "open" });

--- a/src/chat/web/hooks/use-suggestions.ts
+++ b/src/chat/web/hooks/use-suggestions.ts
@@ -38,9 +38,10 @@ function isConfigObject(
 export function useSuggestions(options: UseSuggestionsOptions) {
 	const { messages, status, config } = options;
 
-	const [suggestions, setSuggestions] = useState<string[]>(
-		(isConfigObject(config) && config.initial ? config.initial : []) ?? [],
-	);
+	const initial =
+		isConfigObject(config) && config.initial ? config.initial : undefined;
+
+	const [suggestions, setSuggestions] = useState<string[]>(initial ?? []);
 	const prevStatusRef = useRef<ChatStatus>(status);
 
 	const isDynamicEnabled =
@@ -50,6 +51,16 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 		setSuggestions([]);
 	}, []);
 
+	// Sync initial suggestions when the remote config arrives post-mount.
+	// Only applied while the conversation is empty; once the user has sent
+	// a message, suggestions are driven by streaming responses (or cleared).
+	const hasMessages = messages.length > 0;
+	useEffect(() => {
+		if (!hasMessages && initial && initial.length > 0) {
+			setSuggestions(initial);
+		}
+	}, [initial, hasMessages]);
+
 	// Clear when a new user message arrives
 	const lastMessage = messages[messages.length - 1];
 	useEffect(() => {
@@ -58,7 +69,7 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 		}
 	}, [lastMessage, clear]);
 
-	// Extract suggestions from message parts on streaming → ready transition
+	// Extract suggestions from message parts on streaming -> ready transition
 	useEffect(() => {
 		const prevStatus = prevStatusRef.current;
 		prevStatusRef.current = status;


### PR DESCRIPTION
## Summary
Two bugs surfaced when pointing the embed at a real agent on the waniwani.ai preview:

1. **Inline chat collapsed to content height.** `hostElement` in `mountInline` was created without any styling, so the shadow DOM sat at content height regardless of the embedder's sizing (`h-[640px]`, `h-full`, etc). Chat rendered as a short card instead of filling the container.
2. **Starter suggestions from remote config never showed.** `useSuggestions` seeded state via `useState(config.initial ?? [])`. That initializer runs only on first mount, which is *before* `useRemoteEmbedConfig` finishes its `GET /config` fetch. When the remote config arrived with `suggestions: [...]`, the state stayed `[]`.

## Changes
- `mountInline`: force `hostElement.style.width/height = "100%"` so the embedder's box model drives the chat.
- `useSuggestions`: added effect that syncs `initial` -> state while the conversation is empty. Once the user has sent a message, behavior is unchanged (cleared, then driven by streaming `data-suggestions` parts when dynamic is enabled).

## Test plan
- [ ] Inline embed inside a `h-[640px]` container renders full height
- [ ] Agent with non-empty `suggestions` in `GET /config` shows chips above the input before the first message
- [ ] Sending a message still clears chips
- [ ] Dynamic `data-suggestions` streaming path still overwrites chips on the `streaming -> ready` transition
- [ ] Floating mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior changes limited to inline layout sizing and suggestion state initialization; potential regressions are confined to chat embed presentation and when suggestions render/clear.
> 
> **Overview**
> Fixes the **inline** embed so the shadow-DOM host element stretches to `100%` width/height, allowing the parent container’s sizing to control the chat height.
> 
> Updates `useSuggestions` to **apply `config.initial` suggestions when they arrive after mount**, but only while there are no messages, preserving existing behavior once a conversation starts (clearing on user messages and updating from streamed suggestions on `streaming` -> `ready`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f70de15ae41ed642017cc36e96886e1f9512ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->