### PR TITLE
feat(mcp): parametric stripLocationFields option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.10.10-beta.1",
+  "version": "0.10.10-beta.2",
   "description": "WaniWani SDK - MCP event tracking, widget framework, and tools",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.10.10-beta.0",
+  "version": "0.10.10-beta.1",
   "description": "WaniWani SDK - MCP event tracking, widget framework, and tools",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.10.9",
+  "version": "0.10.10-beta.0",
   "description": "WaniWani SDK - MCP event tracking, widget framework, and tools",
   "type": "module",
   "exports": {

--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -629,16 +629,20 @@ describe("withWaniwani", () => {
 		expect(meta.waniwani).toBe(undefined);
 	});
 
-	test("stripGeoCoordinates removes latitude/longitude from known location meta keys", async () => {
+	test("stripLocationFields removes listed fields from known location meta keys", async () => {
 		const { client, tracked } = mockClient();
 		const mock = mockServer();
 
-		withWaniwani(mock.server, { client, stripGeoCoordinates: true });
+		withWaniwani(mock.server, {
+			client,
+			stripLocationFields: ["latitude", "longitude", "city", "region"],
+		});
 
 		mock.registerTool("pricing", {}, async () => ({
 			_meta: {
 				"openai/userLocation": {
 					city: "Madrid",
+					region: "Madrid",
 					country: "ES",
 					latitude: "40.4",
 					longitude: "-3.7",
@@ -654,12 +658,14 @@ describe("withWaniwani", () => {
 				_meta: {
 					"openai/userLocation": {
 						city: "Madrid",
+						region: "Madrid",
 						country: "ES",
 						latitude: "40.4",
 						longitude: "-3.7",
 					},
 					"waniwani/geoLocation": {
 						country: "ES",
+						city: "Madrid",
 						latitude: "40.4",
 						longitude: "-3.7",
 					},
@@ -671,14 +677,42 @@ describe("withWaniwani", () => {
 			meta?: Record<string, unknown>;
 			properties: { output?: { _meta?: Record<string, unknown> } };
 		};
+		expect(event.meta?.["openai/userLocation"]).toEqual({ country: "ES" });
+		expect(event.meta?.["waniwani/geoLocation"]).toEqual({ country: "ES" });
+		expect(event.properties.output?._meta?.["openai/userLocation"]).toEqual({
+			country: "ES",
+		});
+	});
+
+	test("stripLocationFields defaults to empty — no redaction", async () => {
+		const { client, tracked } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, { client });
+
+		mock.registerTool("pricing", {}, async () => ({ content: [] }));
+
+		const handler = mock.registered[0]?.[2];
+		await handler?.(
+			{},
+			{
+				_meta: {
+					"openai/userLocation": {
+						city: "Madrid",
+						country: "ES",
+						latitude: "40.4",
+						longitude: "-3.7",
+					},
+				},
+			},
+		);
+
+		const event = tracked[0] as { meta?: Record<string, unknown> };
 		expect(event.meta?.["openai/userLocation"]).toEqual({
 			city: "Madrid",
 			country: "ES",
-		});
-		expect(event.meta?.["waniwani/geoLocation"]).toEqual({ country: "ES" });
-		expect(event.properties.output?._meta?.["openai/userLocation"]).toEqual({
-			city: "Madrid",
-			country: "ES",
+			latitude: "40.4",
+			longitude: "-3.7",
 		});
 	});
 

--- a/src/mcp/server/with-waniwani/helpers.ts
+++ b/src/mcp/server/with-waniwani/helpers.ts
@@ -24,11 +24,13 @@ const LOCATION_META_KEYS = [
 	LEGACY_USER_LOCATION_KEY,
 ] as const;
 
-const COORDINATE_KEYS = ["latitude", "longitude"] as const;
-
-export function stripGeoCoordinatesFromMeta(
+export function stripLocationFieldsFromMeta(
 	meta: UnknownRecord,
+	fields: readonly string[],
 ): UnknownRecord {
+	if (fields.length === 0) {
+		return meta;
+	}
 	let next: UnknownRecord | undefined;
 	for (const key of LOCATION_META_KEYS) {
 		const value = meta[key];
@@ -36,12 +38,12 @@ export function stripGeoCoordinatesFromMeta(
 			continue;
 		}
 		let stripped: UnknownRecord | undefined;
-		for (const coord of COORDINATE_KEYS) {
-			if (coord in value) {
+		for (const field of fields) {
+			if (field in value) {
 				if (!stripped) {
 					stripped = { ...value };
 				}
-				delete stripped[coord];
+				delete stripped[field];
 			}
 		}
 		if (stripped) {
@@ -102,7 +104,7 @@ export function buildTrackInput(
 			? T
 			: never;
 		metadata?: UnknownRecord;
-		stripGeoCoordinates?: boolean;
+		stripLocationFields?: readonly string[];
 		redactInput?: (input: unknown) => unknown;
 	},
 	timing?: { durationMs: number; status: string; errorMessage?: string },
@@ -111,10 +113,13 @@ export function buildTrackInput(
 ): TrackInput {
 	const toolType = resolveToolType(toolName, options.toolType);
 
+	const stripFields = options.stripLocationFields;
+	const shouldStrip = stripFields && stripFields.length > 0;
+
 	const rawMeta = extractMeta(extra);
 	const meta =
-		rawMeta && options.stripGeoCoordinates
-			? stripGeoCoordinatesFromMeta(rawMeta)
+		rawMeta && shouldStrip
+			? stripLocationFieldsFromMeta(rawMeta, stripFields)
 			: rawMeta;
 
 	const input =
@@ -123,12 +128,13 @@ export function buildTrackInput(
 			: io?.input;
 
 	const output =
-		options.stripGeoCoordinates &&
-		isRecord(io?.output) &&
-		isRecord(io.output._meta)
+		shouldStrip && isRecord(io?.output) && isRecord(io.output._meta)
 			? {
 					...(io.output as UnknownRecord),
-					_meta: stripGeoCoordinatesFromMeta(io.output._meta as UnknownRecord),
+					_meta: stripLocationFieldsFromMeta(
+						io.output._meta as UnknownRecord,
+						stripFields,
+					),
 				}
 			: io?.output;
 

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -75,17 +75,18 @@ export type WithWaniwaniOptions = {
 	 */
 	injectWidgetToken?: boolean;
 	/**
-	 * Strip `latitude`/`longitude` from known location `_meta` entries
+	 * List of field names to strip from known location `_meta` entries
 	 * (`openai/userLocation`, `waniwani/geoLocation`, `waniwani/userLocation`)
 	 * before events are sent to the WaniWani API. Applied to both the
 	 * request-level `_meta` and any `_meta` on the tool response.
 	 *
-	 * Enable this when precise geo coordinates should not reach the tracking
-	 * backend; city/region/country fields are preserved.
+	 * Pass e.g. `["latitude", "longitude"]` to drop coordinates only, or
+	 * `["latitude", "longitude", "city", "region"]` to keep just `country`.
+	 * Empty/omitted = no redaction.
 	 *
-	 * @default false
+	 * @default []
 	 */
-	stripGeoCoordinates?: boolean;
+	stripLocationFields?: readonly string[];
 	/**
 	 * Replace `input.stateUpdates[field]` with `"REDACTED"` for any field
 	 * marked via `redacted()` on a flow state schema. When `false` (default),


### PR DESCRIPTION
## Summary
- Replace `withWaniwani` option `stripGeoCoordinates: boolean` (hardcoded to `latitude`/`longitude`) with `stripLocationFields: readonly string[]`.
- Empty/omitted list = no redaction. Consumers pass the exact field names to strip from known location `_meta` keys (`openai/userLocation`, `waniwani/geoLocation`, `waniwani/userLocation`).
- Rename internal helper `stripGeoCoordinatesFromMeta` → `stripLocationFieldsFromMeta(meta, fields)`.

Breaking change. Only consumer is the isalud MCP, which will pass `["latitude", "longitude", "city", "region"]` so only `country` survives in tracked events (customer ask).

## Test plan
- [x] `bun test src/mcp/server/with-waniwani` — 29 pass
- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] Bump isalud `@waniwani/sdk` and verify location `_meta` only contains `country` in tracked events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a breaking API change in `withWaniwani` by replacing `stripGeoCoordinates` with `stripLocationFields`, which could alter what location data is sent if consumers don’t update their configuration. Logic change is localized to tracking metadata redaction but affects all MCP tool-call events.
> 
> **Overview**
> Updates `withWaniwani` to replace `stripGeoCoordinates: boolean` with `stripLocationFields: readonly string[]`, allowing callers to choose exactly which fields (e.g. `latitude`, `longitude`, `city`, `region`) are removed from known location `_meta` keys before tracking.
> 
> Refactors the internal helper to `stripLocationFieldsFromMeta(meta, fields)` and applies the redaction consistently to both request `_meta` and tool response `_meta`; tests are updated/expanded to cover configurable stripping and the new default behavior of *no redaction* when the list is empty/omitted. Also bumps the SDK version to `0.10.10-beta.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6266f0ac2cb2bbc36aa4d74ab5552776ba4738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->