### PR TITLE
feat(chat): persist thread history with menu UI + memoryUserId embed plumbing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "ai": "^6.0.141",
         "autoevals": "^0.0.132",
         "clsx": "^2.1.1",
+        "fake-indexeddb": "^6.2.5",
         "happy-dom": "^20.7.0",
         "lucide-react": "^0.563.0",
         "postcss": "^8.5.6",
@@ -448,6 +449,8 @@
     "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "ai": "^6.0.141",
     "autoevals": "^0.0.132",
     "clsx": "^2.1.1",
+    "fake-indexeddb": "^6.2.5",
     "happy-dom": "^20.7.0",
     "lucide-react": "^0.563.0",
     "postcss": "^8.5.6",

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -135,6 +135,18 @@ export interface ChatBaseProps {
 	 * @internal
 	 */
 	skipRemoteConfig?: boolean;
+	/**
+	 * Persist the conversation across page reloads using IndexedDB so the user
+	 * can resume previous threads. Defaults to `true`.
+	 */
+	enableThreadHistory?: boolean;
+	/**
+	 * Force a specific thread to be active. When provided, the embed renders
+	 * that thread's messages and ignores the most-recently-updated default.
+	 */
+	activeThreadId?: string;
+	/** Fired whenever the active thread changes (new chat, switch, delete). */
+	onThreadChange?: (threadId: string) => void;
 }
 
 // ============================================================================

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -137,7 +137,7 @@ export interface ChatBaseProps {
 	skipRemoteConfig?: boolean;
 	/**
 	 * Persist the conversation across page reloads using IndexedDB so the user
-	 * can resume previous threads. Defaults to `true`.
+	 * can resume previous threads. Defaults to `false` — opt in explicitly.
 	 */
 	enableThreadHistory?: boolean;
 	/**

--- a/src/chat/web/components/mcp-app-frame.tsx
+++ b/src/chat/web/components/mcp-app-frame.tsx
@@ -179,7 +179,9 @@ export function McpAppFrame({
 	// and a wasted iframe load against the stub origin before hydration
 	// corrects it. The browser resolves relative URLs against the
 	// document itself, so this works for both absolute and relative
-	// `resourceEndpoint` values.
+	// `resourceEndpoint` values. Callers may pre-populate query params on
+	// `resourceEndpoint` (e.g. the embed appends a `token` so the
+	// cross-origin GET carries auth) — the separator check handles that.
 	const iframeSrc = useMemo(() => {
 		const separator = resourceEndpoint.includes("?") ? "&" : "?";
 		return `${resourceEndpoint}${separator}uri=${encodeURIComponent(resourceUri)}`;

--- a/src/chat/web/components/thread-menu.tsx
+++ b/src/chat/web/components/thread-menu.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { StoredThread } from "../lib/thread-store";
+
+interface ThreadMenuProps {
+	threads: StoredThread[];
+	activeThreadId?: string;
+	onNewThread: () => void;
+	onSelectThread: (threadId: string) => void;
+	onDeleteThread: (threadId: string) => void;
+}
+
+const VISIBLE_THREAD_LIMIT = 20;
+
+function formatRelative(iso: string): string {
+	const then = Date.parse(iso);
+	if (Number.isNaN(then)) {
+		return "";
+	}
+	const diff = Date.now() - then;
+	if (diff < 60_000) {
+		return "just now";
+	}
+	if (diff < 60 * 60_000) {
+		return `${Math.floor(diff / 60_000)}m ago`;
+	}
+	if (diff < 24 * 60 * 60_000) {
+		return `${Math.floor(diff / (60 * 60_000))}h ago`;
+	}
+	const days = Math.floor(diff / (24 * 60 * 60_000));
+	return `${days}d ago`;
+}
+
+function PlusIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			role="img"
+			aria-label="New chat"
+		>
+			<title>New chat</title>
+			<line x1="12" y1="5" x2="12" y2="19" />
+			<line x1="5" y1="12" x2="19" y2="12" />
+		</svg>
+	);
+}
+
+function HistoryIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			role="img"
+			aria-label="Thread history"
+		>
+			<title>Thread history</title>
+			<path d="M3 12a9 9 0 1 0 3-6.7" />
+			<polyline points="3 4 3 9 8 9" />
+			<line x1="12" y1="7" x2="12" y2="12" />
+			<line x1="12" y1="12" x2="15" y2="14" />
+		</svg>
+	);
+}
+
+function TrashIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="14"
+			height="14"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			role="img"
+			aria-label="Delete thread"
+		>
+			<title>Delete thread</title>
+			<polyline points="3 6 5 6 21 6" />
+			<path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6" />
+			<path d="M10 11v6" />
+			<path d="M14 11v6" />
+		</svg>
+	);
+}
+
+export function ThreadMenu({
+	threads,
+	activeThreadId,
+	onNewThread,
+	onSelectThread,
+	onDeleteThread,
+}: ThreadMenuProps) {
+	const [open, setOpen] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+		const handler = (event: MouseEvent) => {
+			if (
+				containerRef.current &&
+				!containerRef.current.contains(event.target as Node)
+			) {
+				setOpen(false);
+			}
+		};
+		document.addEventListener("mousedown", handler);
+		return () => document.removeEventListener("mousedown", handler);
+	}, [open]);
+
+	const visible = threads.slice(0, VISIBLE_THREAD_LIMIT);
+	const hidden = Math.max(0, threads.length - VISIBLE_THREAD_LIMIT);
+
+	return (
+		<div
+			ref={containerRef}
+			className="ww:relative ww:flex ww:items-center ww:gap-1"
+		>
+			<button
+				type="button"
+				onClick={onNewThread}
+				title="New chat"
+				aria-label="New chat"
+				className="ww:p-1.5 ww:rounded-md ww:text-muted-foreground hover:ww:text-foreground hover:ww:bg-foreground/5 ww:transition-colors ww:cursor-pointer"
+			>
+				<PlusIcon />
+			</button>
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				title="Thread history"
+				aria-label="Thread history"
+				aria-expanded={open}
+				className="ww:p-1.5 ww:rounded-md ww:text-muted-foreground hover:ww:text-foreground hover:ww:bg-foreground/5 ww:transition-colors ww:cursor-pointer"
+			>
+				<HistoryIcon />
+			</button>
+			{open && (
+				<div
+					role="menu"
+					className="ww:absolute ww:right-0 ww:top-full ww:mt-1 ww:w-72 ww:max-h-80 ww:overflow-y-auto ww:rounded-lg ww:border ww:border-border ww:bg-background ww:shadow-lg ww:z-50"
+				>
+					{visible.length === 0 && (
+						<div className="ww:px-3 ww:py-3 ww:text-xs ww:text-muted-foreground">
+							No previous chats yet.
+						</div>
+					)}
+					{visible.map((thread) => {
+						const isActive = thread.threadId === activeThreadId;
+						return (
+							<div
+								key={thread.threadId}
+								className={`ww:flex ww:items-center ww:gap-2 ww:px-3 ww:py-2 ww:text-xs hover:ww:bg-foreground/5 ${
+									isActive ? "ww:bg-foreground/5" : ""
+								}`}
+							>
+								<button
+									type="button"
+									onClick={() => {
+										onSelectThread(thread.threadId);
+										setOpen(false);
+									}}
+									className="ww:flex-1 ww:min-w-0 ww:text-left ww:cursor-pointer"
+								>
+									<div className="ww:truncate ww:text-foreground ww:font-medium">
+										{thread.title}
+									</div>
+									<div className="ww:text-[10px] ww:text-muted-foreground">
+										{formatRelative(thread.updatedAt)}
+									</div>
+								</button>
+								<button
+									type="button"
+									onClick={(e) => {
+										e.stopPropagation();
+										onDeleteThread(thread.threadId);
+									}}
+									title="Delete thread"
+									aria-label="Delete thread"
+									className="ww:p-1 ww:rounded ww:text-muted-foreground hover:ww:text-foreground hover:ww:bg-foreground/10 ww:transition-colors ww:cursor-pointer"
+								>
+									<TrashIcon />
+								</button>
+							</div>
+						);
+					})}
+					{hidden > 0 && (
+						<div className="ww:px-3 ww:py-2 ww:text-[10px] ww:text-muted-foreground ww:border-t ww:border-border">
+							{hidden} older thread{hidden === 1 ? "" : "s"} hidden
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -80,6 +80,55 @@ describe("resolveConfig — programmatic", () => {
 	});
 });
 
+describe("resolveConfig — enableThreadHistory", () => {
+	test("programmatic false disables thread history", () => {
+		const config = resolveConfig({ token: "tok", enableThreadHistory: false });
+		expect(config.enableThreadHistory).toBe(false);
+	});
+
+	test("programmatic true enables thread history", () => {
+		const config = resolveConfig({ token: "tok", enableThreadHistory: true });
+		expect(config.enableThreadHistory).toBe(true);
+	});
+
+	test("undefined when unspecified — consumers default to enabled", () => {
+		const config = resolveConfig({ token: "tok" });
+		expect(config.enableThreadHistory).toBeUndefined();
+	});
+
+	test("data-enable-thread-history attribute parses 'false' as false", async () => {
+		const { parseConfigFromScript } = await import(
+			`../config?t=${Date.now()}-${Math.random()}`
+		);
+		const fakeScript = {
+			getAttribute(name: string) {
+				if (name === "data-token") {
+					return "tok";
+				}
+				if (name === "data-enable-thread-history") {
+					return "false";
+				}
+				return null;
+			},
+		};
+		const prevDocument = g.document;
+		const prevHtmlScriptElement = g.HTMLScriptElement;
+		g.HTMLScriptElement = class {};
+		Object.setPrototypeOf(fakeScript, g.HTMLScriptElement.prototype);
+		g.document = {
+			currentScript: fakeScript,
+			querySelectorAll: () => [],
+		};
+		try {
+			const cfg = parseConfigFromScript();
+			expect(cfg.enableThreadHistory).toBe(false);
+		} finally {
+			g.document = prevDocument;
+			g.HTMLScriptElement = prevHtmlScriptElement;
+		}
+	});
+});
+
 describe("resolveConfig — validation", () => {
 	test("throws when token missing", () => {
 		expect(() => resolveConfig({})).toThrow("Missing required config: `token`");

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -57,7 +57,7 @@ export interface EmbedConfig {
 	css?: string;
 	/**
 	 * Persist conversations across page reloads using IndexedDB so users can
-	 * resume previous threads. Defaults to `true`.
+	 * resume previous threads. Defaults to `false` — opt in explicitly.
 	 */
 	enableThreadHistory?: boolean;
 	/** Theme overrides applied to the ChatCard. */

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -55,6 +55,11 @@ export interface EmbedConfig {
 	height?: number;
 	/** URL to a custom stylesheet injected into the shadow root. */
 	css?: string;
+	/**
+	 * Persist conversations across page reloads using IndexedDB so users can
+	 * resume previous threads. Defaults to `true`.
+	 */
+	enableThreadHistory?: boolean;
 	/** Theme overrides applied to the ChatCard. */
 	theme?: {
 		primaryColor?: string;
@@ -119,6 +124,21 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 		}
 		const n = Number(raw);
 		return Number.isFinite(n) ? n : undefined;
+	};
+
+	const bool = (attr: string): boolean | undefined => {
+		const raw = el.getAttribute(attr);
+		if (raw == null) {
+			return undefined;
+		}
+		const lowered = raw.trim().toLowerCase();
+		if (lowered === "true" || lowered === "1" || lowered === "") {
+			return true;
+		}
+		if (lowered === "false" || lowered === "0") {
+			return false;
+		}
+		return undefined;
 	};
 
 	const config: Partial<EmbedConfig> = {};
@@ -196,6 +216,11 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 	const height = num("data-height");
 	if (height) {
 		config.height = height;
+	}
+
+	const enableThreadHistory = bool("data-enable-thread-history");
+	if (enableThreadHistory !== undefined) {
+		config.enableThreadHistory = enableThreadHistory;
 	}
 
 	// Theme from individual data attributes

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -366,6 +366,7 @@ export const FloatingChat = forwardRef<FloatingChatHandle, FloatingChatProps>(
 							suggestions={
 								config.suggestions ? { initial: config.suggestions } : undefined
 							}
+							enableThreadHistory={config.enableThreadHistory}
 							onResponseReceived={handleResponseReceived}
 							width="100%"
 							height="100%"

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -79,6 +79,7 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 			suggestions: config.suggestions
 				? { initial: config.suggestions }
 				: undefined,
+			enableThreadHistory: config.enableThreadHistory,
 		};
 
 		const layout = config.layout ?? "card";

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -14,6 +14,7 @@ interface RemoteConfigResponse {
 	title: string | null;
 	placeholder: string | null;
 	suggestions: string[] | null;
+	enableThreadHistory?: boolean | null;
 }
 
 /**
@@ -72,6 +73,9 @@ function remoteToConfigPartial(
 	}
 	if (data.suggestions != null && data.suggestions.length > 0) {
 		out.suggestions = data.suggestions;
+	}
+	if (typeof data.enableThreadHistory === "boolean") {
+		out.enableThreadHistory = data.enableThreadHistory;
 	}
 	return out;
 }

--- a/src/chat/web/hooks/use-chat-engine.test.tsx
+++ b/src/chat/web/hooks/use-chat-engine.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { IDBFactory, IDBKeyRange } from "fake-indexeddb";
 import { Window } from "happy-dom";
+
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).indexedDB = new IDBFactory();
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).IDBKeyRange = IDBKeyRange;
 
 // ---------------------------------------------------------------------------
 // Set up DOM globals before importing React
@@ -70,6 +76,18 @@ mock.module("@ai-sdk/react", () => ({
 			setMessages: mockSetMessages,
 			status: useChatStatus,
 		};
+	},
+}));
+
+// Capture transport body callback so we can inspect resolvedBody without
+// actually firing a network request through the real DefaultChatTransport.
+let capturedTransportBody: (() => Record<string, unknown>) | undefined;
+// @ts-expect-error -- bun:test `mock.module` exists at runtime but has no TS type
+mock.module("../lib/lenient-chat-transport", () => ({
+	LenientChatTransport: class {
+		constructor(opts: { body?: () => Record<string, unknown> }) {
+			capturedTransportBody = opts.body;
+		}
 	},
 }));
 
@@ -229,5 +247,57 @@ describe("useChatEngine – sendMessageAndWait deferred resolution", () => {
 		});
 
 		expect(true).toBe(true);
+	});
+});
+
+async function flushAsync() {
+	await act(async () => {
+		await new Promise((r) => setTimeout(r, 30));
+	});
+}
+
+describe("useChatEngine – thread history", () => {
+	test("resolvedBody.threadId is set after the first send", async () => {
+		const engine = hookRef.current;
+		if (!engine) {
+			throw new Error("Engine not mounted");
+		}
+		// Wait for visitor context + thread history load to settle
+		await flushAsync();
+		act(() => {
+			root.render(createElement(Harness, { resultRef: hookRef }));
+		});
+
+		expect(capturedTransportBody).toBeDefined();
+		const body = capturedTransportBody?.();
+		expect(typeof body?.threadId).toBe("string");
+		expect((body?.threadId as string).length).toBeGreaterThan(5);
+	});
+
+	test("startNewThread clears messages and creates a new threadId", async () => {
+		await flushAsync();
+		const engine = hookRef.current;
+		if (!engine) {
+			throw new Error("Engine not mounted");
+		}
+
+		// Force-create the first thread by invoking the body builder.
+		const firstBody = capturedTransportBody?.();
+		const firstThreadId = firstBody?.threadId as string;
+		expect(typeof firstThreadId).toBe("string");
+
+		mockSetMessages.mockClear();
+		let nextId: string | undefined;
+		act(() => {
+			nextId = engine.startNewThread();
+		});
+
+		expect(typeof nextId).toBe("string");
+		expect(nextId).not.toBe(firstThreadId);
+		expect(mockSetMessages).toHaveBeenCalled();
+
+		// Body builder now uses the new threadId
+		const secondBody = capturedTransportBody?.();
+		expect(secondBody?.threadId).toBe(nextId);
 	});
 });

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import type { FileUIPart } from "ai";
+import type { FileUIPart, UIMessage } from "ai";
 import { nanoid } from "nanoid";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ModelContextUpdate } from "../../../shared/model-context";
@@ -9,10 +9,34 @@ import { hasModelContext } from "../../../shared/model-context";
 import type { ChatBaseProps } from "../@types";
 import type { PromptInputMessage } from "../ai-elements/prompt-input";
 import { LenientChatTransport } from "../lib/lenient-chat-transport";
+import {
+	deleteThread as deleteThreadFromStore,
+	deriveThreadTitle,
+	getActiveThreadId,
+	listThreads,
+	loadThread,
+	type StoredThread,
+	upsertThread,
+} from "../lib/thread-store";
 import type { VisitorContext } from "../lib/visitor-context";
 import { collectVisitorContext } from "../lib/visitor-context";
 
 const SESSION_HEADER_NAME = "x-session-id";
+const THREAD_PERSIST_DEBOUNCE_MS = 250;
+
+function generateThreadId(): string {
+	if (
+		typeof crypto !== "undefined" &&
+		typeof crypto.randomUUID === "function"
+	) {
+		return crypto.randomUUID();
+	}
+	return nanoid();
+}
+
+function nowIso(): string {
+	return new Date().toISOString();
+}
 
 function normalizeSessionId(value: unknown): string | undefined {
 	if (typeof value !== "string") {
@@ -94,6 +118,9 @@ export function useChatEngine(props: ChatBaseProps) {
 		body,
 		onMessageSent,
 		onResponseReceived,
+		enableThreadHistory = true,
+		activeThreadId: controlledThreadId,
+		onThreadChange,
 	} = props;
 
 	const headersRef = useRef(userHeaders);
@@ -106,6 +133,44 @@ export function useChatEngine(props: ChatBaseProps) {
 		undefined,
 	);
 	const sessionIdRef = useRef<string | undefined>(sessionId);
+
+	const [activeThreadId, setActiveThreadIdState] = useState<string | undefined>(
+		controlledThreadId,
+	);
+	const activeThreadIdRef = useRef<string | undefined>(activeThreadId);
+	const [threads, setThreads] = useState<StoredThread[]>([]);
+	const [isThreadHistoryReady, setIsThreadHistoryReady] = useState(
+		!enableThreadHistory,
+	);
+	const threadCreatedAtRef = useRef<string | undefined>(undefined);
+	const threadTitleRef = useRef<string | undefined>(undefined);
+	const persistTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
+	const onThreadChangeRef = useRef(onThreadChange);
+	useEffect(() => {
+		onThreadChangeRef.current = onThreadChange;
+	}, [onThreadChange]);
+
+	const setActiveThreadId = useCallback((next: string | undefined) => {
+		activeThreadIdRef.current = next;
+		setActiveThreadIdState(next);
+		if (next) {
+			onThreadChangeRef.current?.(next);
+		}
+	}, []);
+
+	const refreshThreads = useCallback(async () => {
+		if (!enableThreadHistory) {
+			return;
+		}
+		const memoryUserId = visitorContextRef.current?.memoryUserId;
+		if (!memoryUserId) {
+			return;
+		}
+		const list = await listThreads(memoryUserId);
+		setThreads(list);
+	}, [enableThreadHistory]);
 
 	const getSessionId = useCallback((): string | undefined => {
 		return sessionIdRef.current;
@@ -137,14 +202,62 @@ export function useChatEngine(props: ChatBaseProps) {
 		bodyRef.current = body;
 	}, [body]);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: load once on mount
 	useEffect(() => {
-		collectVisitorContext()
-			.then((ctx) => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const ctx = await collectVisitorContext();
+				if (cancelled) {
+					return;
+				}
 				visitorContextRef.current = ctx;
-			})
-			.catch(() => {
+			} catch {
 				// Best-effort — silently ignore failures
-			});
+			}
+
+			if (!enableThreadHistory) {
+				return;
+			}
+			const memoryUserId = visitorContextRef.current?.memoryUserId;
+			if (!memoryUserId) {
+				setIsThreadHistoryReady(true);
+				return;
+			}
+
+			try {
+				const targetId =
+					controlledThreadId ?? (await getActiveThreadId(memoryUserId));
+				if (cancelled) {
+					return;
+				}
+				if (targetId) {
+					const stored = await loadThread(targetId);
+					if (cancelled) {
+						return;
+					}
+					if (stored && stored.memoryUserId === memoryUserId) {
+						activeThreadIdRef.current = stored.threadId;
+						setActiveThreadIdState(stored.threadId);
+						threadCreatedAtRef.current = stored.createdAt;
+						threadTitleRef.current = stored.title;
+						if (stored.sessionId) {
+							sessionIdRef.current = stored.sessionId;
+							setSessionIdState(stored.sessionId);
+						}
+						setMessages(stored.messages);
+					}
+				}
+				await refreshThreads();
+			} finally {
+				if (!cancelled) {
+					setIsThreadHistoryReady(true);
+				}
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
 	}, []);
 
 	const transportRef = useRef(
@@ -204,6 +317,22 @@ export function useChatEngine(props: ChatBaseProps) {
 							memoryUserId: vc.memoryUserId,
 						},
 					};
+				}
+
+				if (enableThreadHistory) {
+					const hasExplicitThreadId = Object.hasOwn(resolvedBody, "threadId");
+					if (!hasExplicitThreadId) {
+						let tid = activeThreadIdRef.current;
+						if (!tid) {
+							tid = generateThreadId();
+							threadCreatedAtRef.current = nowIso();
+							threadTitleRef.current = undefined;
+							setActiveThreadId(tid);
+						}
+						resolvedBody.threadId = tid;
+					} else if (typeof resolvedBody.threadId === "string") {
+						activeThreadIdRef.current = resolvedBody.threadId;
+					}
 				}
 
 				return resolvedBody;
@@ -272,6 +401,11 @@ export function useChatEngine(props: ChatBaseProps) {
 			}
 		},
 	});
+
+	const messagesRef = useRef<UIMessage[]>(messages);
+	useEffect(() => {
+		messagesRef.current = messages;
+	}, [messages]);
 
 	// Resolve sendMessageAndWait only after React has committed the messages
 	// state update. `onFinish` fires before the re-render, so resolving there
@@ -381,6 +515,139 @@ export function useChatEngine(props: ChatBaseProps) {
 		void refreshToolDefinitions();
 	}, [setMessages, clearSessionId, refreshToolDefinitions]);
 
+	const persistActiveThread = useCallback(async () => {
+		if (!enableThreadHistory) {
+			return;
+		}
+		const memoryUserId = visitorContextRef.current?.memoryUserId;
+		const threadId = activeThreadIdRef.current;
+		const msgs = messagesRef.current;
+		if (!memoryUserId || !threadId || msgs.length === 0) {
+			return;
+		}
+		if (!threadCreatedAtRef.current) {
+			threadCreatedAtRef.current = nowIso();
+		}
+		if (!threadTitleRef.current) {
+			const firstUser = msgs.find((m) => m.role === "user");
+			const firstUserText = firstUser
+				? firstUser.parts
+						.map((p) =>
+							"text" in p && typeof p.text === "string" ? p.text : "",
+						)
+						.join(" ")
+				: "";
+			threadTitleRef.current = deriveThreadTitle(firstUserText);
+		}
+		const stored: StoredThread = {
+			threadId,
+			memoryUserId,
+			title: threadTitleRef.current,
+			messages: msgs,
+			sessionId: sessionIdRef.current,
+			createdAt: threadCreatedAtRef.current,
+			updatedAt: nowIso(),
+		};
+		await upsertThread(stored);
+		await refreshThreads();
+	}, [enableThreadHistory, refreshThreads]);
+
+	useEffect(() => {
+		if (!enableThreadHistory) {
+			return;
+		}
+		if (!isThreadHistoryReady) {
+			return;
+		}
+		if (status === "submitted" || status === "streaming") {
+			return;
+		}
+		if (messages.length === 0) {
+			return;
+		}
+		if (persistTimerRef.current) {
+			clearTimeout(persistTimerRef.current);
+		}
+		persistTimerRef.current = setTimeout(() => {
+			void persistActiveThread();
+		}, THREAD_PERSIST_DEBOUNCE_MS);
+		return () => {
+			if (persistTimerRef.current) {
+				clearTimeout(persistTimerRef.current);
+			}
+		};
+	}, [
+		enableThreadHistory,
+		isThreadHistoryReady,
+		messages,
+		status,
+		persistActiveThread,
+	]);
+
+	const startNewThread = useCallback(() => {
+		if (persistTimerRef.current) {
+			clearTimeout(persistTimerRef.current);
+			persistTimerRef.current = undefined;
+		}
+		setMessages([]);
+		setQueuedMessages([]);
+		clearSessionId();
+		setText("");
+		const nextId = generateThreadId();
+		threadCreatedAtRef.current = nowIso();
+		threadTitleRef.current = undefined;
+		setActiveThreadId(nextId);
+		void refreshThreads();
+		return nextId;
+	}, [setMessages, clearSessionId, setActiveThreadId, refreshThreads]);
+
+	const switchThread = useCallback(
+		async (threadId: string) => {
+			if (persistTimerRef.current) {
+				clearTimeout(persistTimerRef.current);
+				persistTimerRef.current = undefined;
+			}
+			const stored = await loadThread(threadId);
+			if (!stored) {
+				return;
+			}
+			setActiveThreadId(stored.threadId);
+			threadCreatedAtRef.current = stored.createdAt;
+			threadTitleRef.current = stored.title;
+			if (stored.sessionId) {
+				sessionIdRef.current = stored.sessionId;
+				setSessionIdState(stored.sessionId);
+			} else {
+				clearSessionId();
+			}
+			setMessages(stored.messages);
+			setQueuedMessages([]);
+			setText("");
+		},
+		[setMessages, clearSessionId, setActiveThreadId],
+	);
+
+	const deleteThread = useCallback(
+		async (threadId: string) => {
+			await deleteThreadFromStore(threadId);
+			await refreshThreads();
+			if (activeThreadIdRef.current === threadId) {
+				if (persistTimerRef.current) {
+					clearTimeout(persistTimerRef.current);
+					persistTimerRef.current = undefined;
+				}
+				setMessages([]);
+				clearSessionId();
+				setText("");
+				activeThreadIdRef.current = undefined;
+				setActiveThreadIdState(undefined);
+				threadCreatedAtRef.current = undefined;
+				threadTitleRef.current = undefined;
+			}
+		},
+		[setMessages, clearSessionId, refreshThreads],
+	);
+
 	const handleTextChange = useCallback(
 		(e: React.ChangeEvent<HTMLTextAreaElement>) => {
 			setText(e.target.value);
@@ -419,5 +686,11 @@ export function useChatEngine(props: ChatBaseProps) {
 		sessionId,
 		toolDefinitions,
 		refreshToolDefinitions,
+		threads,
+		activeThreadId,
+		isThreadHistoryReady,
+		startNewThread,
+		switchThread,
+		deleteThread,
 	};
 }

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -187,6 +187,23 @@ export function useChatEngine(props: ChatBaseProps) {
 						referrer: vc.referrer,
 						visitorId: vc.visitorId,
 					};
+					const existingVisitor =
+						typeof resolvedBody.visitor === "object" &&
+						resolvedBody.visitor !== null
+							? (resolvedBody.visitor as Record<string, unknown>)
+							: {};
+					const existingClient =
+						typeof existingVisitor.client === "object" &&
+						existingVisitor.client !== null
+							? (existingVisitor.client as Record<string, unknown>)
+							: {};
+					resolvedBody.visitor = {
+						...existingVisitor,
+						client: {
+							...existingClient,
+							memoryUserId: vc.memoryUserId,
+						},
+					};
 				}
 
 				return resolvedBody;

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -125,6 +125,10 @@ export function useChatEngine(props: ChatBaseProps) {
 
 	const headersRef = useRef(userHeaders);
 	const bodyRef = useRef(body);
+	const enableThreadHistoryRef = useRef(enableThreadHistory);
+	useEffect(() => {
+		enableThreadHistoryRef.current = enableThreadHistory;
+	}, [enableThreadHistory]);
 	const pendingModelContextRef = useRef<ModelContextUpdate | undefined>(
 		undefined,
 	);
@@ -319,7 +323,7 @@ export function useChatEngine(props: ChatBaseProps) {
 					};
 				}
 
-				if (enableThreadHistory) {
+				if (enableThreadHistoryRef.current) {
 					const hasExplicitThreadId = Object.hasOwn(resolvedBody, "threadId");
 					if (!hasExplicitThreadId) {
 						let tid = activeThreadIdRef.current;
@@ -584,11 +588,20 @@ export function useChatEngine(props: ChatBaseProps) {
 		persistActiveThread,
 	]);
 
-	const startNewThread = useCallback(() => {
-		if (persistTimerRef.current) {
-			clearTimeout(persistTimerRef.current);
-			persistTimerRef.current = undefined;
+	const flushPendingPersist = useCallback(() => {
+		if (!persistTimerRef.current) {
+			return undefined;
 		}
+		clearTimeout(persistTimerRef.current);
+		persistTimerRef.current = undefined;
+		return persistActiveThread();
+	}, [persistActiveThread]);
+
+	const startNewThread = useCallback(() => {
+		// Fire-and-forget: persistActiveThread snapshots refs synchronously
+		// before any await, so subsequent mutations below don't corrupt the
+		// write of the outgoing thread.
+		void flushPendingPersist();
 		setMessages([]);
 		setQueuedMessages([]);
 		clearSessionId();
@@ -599,14 +612,17 @@ export function useChatEngine(props: ChatBaseProps) {
 		setActiveThreadId(nextId);
 		void refreshThreads();
 		return nextId;
-	}, [setMessages, clearSessionId, setActiveThreadId, refreshThreads]);
+	}, [
+		setMessages,
+		clearSessionId,
+		setActiveThreadId,
+		refreshThreads,
+		flushPendingPersist,
+	]);
 
 	const switchThread = useCallback(
 		async (threadId: string) => {
-			if (persistTimerRef.current) {
-				clearTimeout(persistTimerRef.current);
-				persistTimerRef.current = undefined;
-			}
+			await flushPendingPersist();
 			const stored = await loadThread(threadId);
 			if (!stored) {
 				return;
@@ -624,18 +640,20 @@ export function useChatEngine(props: ChatBaseProps) {
 			setQueuedMessages([]);
 			setText("");
 		},
-		[setMessages, clearSessionId, setActiveThreadId],
+		[setMessages, clearSessionId, setActiveThreadId, flushPendingPersist],
 	);
 
 	const deleteThread = useCallback(
 		async (threadId: string) => {
+			// Drop any pending persist for the thread we're deleting — flushing
+			// would resurrect the row right after `deleteThreadFromStore`.
+			if (activeThreadIdRef.current === threadId && persistTimerRef.current) {
+				clearTimeout(persistTimerRef.current);
+				persistTimerRef.current = undefined;
+			}
 			await deleteThreadFromStore(threadId);
 			await refreshThreads();
 			if (activeThreadIdRef.current === threadId) {
-				if (persistTimerRef.current) {
-					clearTimeout(persistTimerRef.current);
-					persistTimerRef.current = undefined;
-				}
 				setMessages([]);
 				clearSessionId();
 				setText("");
@@ -647,6 +665,31 @@ export function useChatEngine(props: ChatBaseProps) {
 		},
 		[setMessages, clearSessionId, refreshThreads],
 	);
+
+	// Sync controlled `activeThreadId` after mount. The mount effect seeds
+	// the initial value; this effect handles parent-driven changes
+	// afterwards by switching threads. Gated on `isThreadHistoryReady` so it
+	// runs only once the mount load has settled.
+	useEffect(() => {
+		if (!enableThreadHistory) {
+			return;
+		}
+		if (!isThreadHistoryReady) {
+			return;
+		}
+		if (controlledThreadId === undefined) {
+			return;
+		}
+		if (controlledThreadId === activeThreadIdRef.current) {
+			return;
+		}
+		void switchThread(controlledThreadId);
+	}, [
+		controlledThreadId,
+		enableThreadHistory,
+		isThreadHistoryReady,
+		switchThread,
+	]);
 
 	const handleTextChange = useCallback(
 		(e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -118,7 +118,7 @@ export function useChatEngine(props: ChatBaseProps) {
 		body,
 		onMessageSent,
 		onResponseReceived,
-		enableThreadHistory = true,
+		enableThreadHistory = false,
 		activeThreadId: controlledThreadId,
 		onThreadChange,
 	} = props;

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -155,6 +155,11 @@ export function useChatEngine(props: ChatBaseProps) {
 	// can await an already-fired persist and avoid resurrect-after-delete
 	// races, which `clearTimeout` alone cannot.
 	const persistInflightRef = useRef<Promise<void> | undefined>(undefined);
+	// Monotonic epoch invalidator for `switchThread`. Any concurrent
+	// `startNewThread` / `switchThread` / `deleteThread` (on the active
+	// thread) bumps this so a slower in-flight `loadThread` can't clobber
+	// a newer thread's state when it eventually resolves.
+	const switchEpochRef = useRef(0);
 	const onThreadChangeRef = useRef(onThreadChange);
 	useEffect(() => {
 		onThreadChangeRef.current = onThreadChange;
@@ -213,6 +218,10 @@ export function useChatEngine(props: ChatBaseProps) {
 	// biome-ignore lint/correctness/useExhaustiveDependencies: load once on mount
 	useEffect(() => {
 		let cancelled = false;
+		// Snapshot epoch at mount. Any user action (startNewThread,
+		// switchThread, deleteThread on active) bumps it; we then skip
+		// applying the stale mount-load result.
+		const mountEpoch = switchEpochRef.current;
 		(async () => {
 			try {
 				const ctx = await collectVisitorContext();
@@ -236,12 +245,12 @@ export function useChatEngine(props: ChatBaseProps) {
 			try {
 				const targetId =
 					controlledThreadId ?? (await getActiveThreadId(memoryUserId));
-				if (cancelled) {
+				if (cancelled || mountEpoch !== switchEpochRef.current) {
 					return;
 				}
 				if (targetId) {
 					const stored = await loadThread(targetId);
-					if (cancelled) {
+					if (cancelled || mountEpoch !== switchEpochRef.current) {
 						return;
 					}
 					if (stored && stored.memoryUserId === memoryUserId) {
@@ -523,15 +532,20 @@ export function useChatEngine(props: ChatBaseProps) {
 		void refreshToolDefinitions();
 	}, [setMessages, clearSessionId, refreshToolDefinitions]);
 
-	const persistActiveThread = useCallback(async () => {
-		if (!enableThreadHistory) {
-			return;
+	// Build a `StoredThread` from current refs synchronously. Callers that
+	// need to flush before mutating thread state (startNewThread,
+	// switchThread, deleteThread) must snapshot here *before* any `await`
+	// or ref mutation, so the write describes the outgoing thread, not a
+	// half-mutated mix of old + new.
+	const buildPersistSnapshot = useCallback((): StoredThread | undefined => {
+		if (!enableThreadHistoryRef.current) {
+			return undefined;
 		}
 		const memoryUserId = visitorContextRef.current?.memoryUserId;
 		const threadId = activeThreadIdRef.current;
 		const msgs = messagesRef.current;
 		if (!memoryUserId || !threadId || msgs.length === 0) {
-			return;
+			return undefined;
 		}
 		if (!threadCreatedAtRef.current) {
 			threadCreatedAtRef.current = nowIso();
@@ -547,7 +561,7 @@ export function useChatEngine(props: ChatBaseProps) {
 				: "";
 			threadTitleRef.current = deriveThreadTitle(firstUserText);
 		}
-		const stored: StoredThread = {
+		return {
 			threadId,
 			memoryUserId,
 			title: threadTitleRef.current,
@@ -556,9 +570,16 @@ export function useChatEngine(props: ChatBaseProps) {
 			createdAt: threadCreatedAtRef.current,
 			updatedAt: nowIso(),
 		};
-		await upsertThread(stored);
+	}, []);
+
+	const persistActiveThread = useCallback(async () => {
+		const snap = buildPersistSnapshot();
+		if (!snap) {
+			return;
+		}
+		await upsertThread(snap);
 		await refreshThreads();
-	}, [enableThreadHistory, refreshThreads]);
+	}, [buildPersistSnapshot, refreshThreads]);
 
 	useEffect(() => {
 		if (!enableThreadHistory) {
@@ -598,24 +619,36 @@ export function useChatEngine(props: ChatBaseProps) {
 		persistActiveThread,
 	]);
 
-	const flushPendingPersist = useCallback(async () => {
-		// Drain an already-fired persist first so writes settle in order.
+	// Flush in-flight + pending persist. The snapshot is captured *now*
+	// (synchronously) so callers can mutate thread refs immediately after
+	// invoking this without tainting the outgoing write — even when an
+	// in-flight persist forces the async tail to yield first.
+	const flushPendingPersist = useCallback((): Promise<void> => {
 		const inflight = persistInflightRef.current;
-		if (inflight) {
-			await inflight;
+		const timer = persistTimerRef.current;
+		const snap = timer ? buildPersistSnapshot() : undefined;
+		if (timer) {
+			clearTimeout(timer);
+			persistTimerRef.current = undefined;
 		}
-		if (!persistTimerRef.current) {
-			return;
-		}
-		clearTimeout(persistTimerRef.current);
-		persistTimerRef.current = undefined;
-		await persistActiveThread();
-	}, [persistActiveThread]);
+		return (async () => {
+			if (inflight) {
+				await inflight;
+			}
+			if (snap) {
+				await upsertThread(snap);
+				await refreshThreads();
+			}
+		})();
+	}, [buildPersistSnapshot, refreshThreads]);
 
 	const startNewThread = useCallback(() => {
-		// Fire-and-forget: persistActiveThread snapshots refs synchronously
-		// before any await, so subsequent mutations below don't corrupt the
-		// write of the outgoing thread.
+		// Bump epoch first so any in-flight `switchThread` load knows it's
+		// been invalidated and skips its setters when it eventually resolves.
+		switchEpochRef.current += 1;
+		// Fire-and-forget: `flushPendingPersist` snapshots synchronously
+		// before any await, so subsequent ref mutations below don't taint
+		// the outgoing write.
 		void flushPendingPersist();
 		setMessages([]);
 		setQueuedMessages([]);
@@ -637,8 +670,16 @@ export function useChatEngine(props: ChatBaseProps) {
 
 	const switchThread = useCallback(
 		async (threadId: string) => {
+			switchEpochRef.current += 1;
+			const epoch = switchEpochRef.current;
 			await flushPendingPersist();
+			if (epoch !== switchEpochRef.current) {
+				return;
+			}
 			const stored = await loadThread(threadId);
+			if (epoch !== switchEpochRef.current) {
+				return;
+			}
 			if (!stored) {
 				return;
 			}
@@ -664,6 +705,8 @@ export function useChatEngine(props: ChatBaseProps) {
 			// deleting — otherwise an already-fired `upsertThread` can settle
 			// after `deleteThreadFromStore` and resurrect the row.
 			if (activeThreadIdRef.current === threadId) {
+				// Invalidate any in-flight `switchThread` targeting this thread.
+				switchEpochRef.current += 1;
 				if (persistTimerRef.current) {
 					clearTimeout(persistTimerRef.current);
 					persistTimerRef.current = undefined;

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -720,6 +720,7 @@ export function useChatEngine(props: ChatBaseProps) {
 			await refreshThreads();
 			if (activeThreadIdRef.current === threadId) {
 				setMessages([]);
+				setQueuedMessages([]);
 				clearSessionId();
 				setText("");
 				activeThreadIdRef.current = undefined;

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -151,6 +151,10 @@ export function useChatEngine(props: ChatBaseProps) {
 	const persistTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
 		undefined,
 	);
+	// In-flight `upsertThread` promise. Tracked so callers (delete, flush)
+	// can await an already-fired persist and avoid resurrect-after-delete
+	// races, which `clearTimeout` alone cannot.
+	const persistInflightRef = useRef<Promise<void> | undefined>(undefined);
 	const onThreadChangeRef = useRef(onThreadChange);
 	useEffect(() => {
 		onThreadChangeRef.current = onThreadChange;
@@ -573,7 +577,13 @@ export function useChatEngine(props: ChatBaseProps) {
 			clearTimeout(persistTimerRef.current);
 		}
 		persistTimerRef.current = setTimeout(() => {
-			void persistActiveThread();
+			persistTimerRef.current = undefined;
+			const p = persistActiveThread().finally(() => {
+				if (persistInflightRef.current === p) {
+					persistInflightRef.current = undefined;
+				}
+			});
+			persistInflightRef.current = p;
 		}, THREAD_PERSIST_DEBOUNCE_MS);
 		return () => {
 			if (persistTimerRef.current) {
@@ -588,13 +598,18 @@ export function useChatEngine(props: ChatBaseProps) {
 		persistActiveThread,
 	]);
 
-	const flushPendingPersist = useCallback(() => {
+	const flushPendingPersist = useCallback(async () => {
+		// Drain an already-fired persist first so writes settle in order.
+		const inflight = persistInflightRef.current;
+		if (inflight) {
+			await inflight;
+		}
 		if (!persistTimerRef.current) {
-			return undefined;
+			return;
 		}
 		clearTimeout(persistTimerRef.current);
 		persistTimerRef.current = undefined;
-		return persistActiveThread();
+		await persistActiveThread();
 	}, [persistActiveThread]);
 
 	const startNewThread = useCallback(() => {
@@ -645,11 +660,18 @@ export function useChatEngine(props: ChatBaseProps) {
 
 	const deleteThread = useCallback(
 		async (threadId: string) => {
-			// Drop any pending persist for the thread we're deleting — flushing
-			// would resurrect the row right after `deleteThreadFromStore`.
-			if (activeThreadIdRef.current === threadId && persistTimerRef.current) {
-				clearTimeout(persistTimerRef.current);
-				persistTimerRef.current = undefined;
+			// Drop pending + await in-flight persist for the thread we're
+			// deleting — otherwise an already-fired `upsertThread` can settle
+			// after `deleteThreadFromStore` and resurrect the row.
+			if (activeThreadIdRef.current === threadId) {
+				if (persistTimerRef.current) {
+					clearTimeout(persistTimerRef.current);
+					persistTimerRef.current = undefined;
+				}
+				const inflight = persistInflightRef.current;
+				if (inflight) {
+					await inflight;
+				}
 			}
 			await deleteThreadFromStore(threadId);
 			await refreshThreads();

--- a/src/chat/web/layouts/chat-card.tsx
+++ b/src/chat/web/layouts/chat-card.tsx
@@ -51,7 +51,7 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 			triggerEvent = "triggerDemoRequest",
 			api,
 			debug,
-			enableThreadHistory = true,
+			enableThreadHistory = false,
 		} = props;
 
 		const effectiveApi = api ?? "/api/waniwani";

--- a/src/chat/web/layouts/chat-card.tsx
+++ b/src/chat/web/layouts/chat-card.tsx
@@ -25,6 +25,7 @@ import { ChatQueue } from "../components/chat-queue";
 import { ExportSessionButton } from "../components/export-session";
 import { MessageList } from "../components/message-list";
 import { Suggestions } from "../components/suggestions";
+import { ThreadMenu } from "../components/thread-menu";
 import { useCallTool } from "../hooks/use-call-tool";
 import { useChatEngine } from "../hooks/use-chat-engine";
 import { useConfig } from "../hooks/use-config";
@@ -50,6 +51,7 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 			triggerEvent = "triggerDemoRequest",
 			api,
 			debug,
+			enableThreadHistory = true,
 		} = props;
 
 		const effectiveApi = api ?? "/api/waniwani";
@@ -195,18 +197,33 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 			>
 				{/* Header */}
 				<div
-					className="ww:shrink-0 ww:flex ww:items-center ww:px-6 ww:py-3"
+					className="ww:shrink-0 ww:flex ww:items-center ww:gap-2 ww:px-6 ww:py-3"
 					style={{
 						backgroundColor: resolvedTheme.headerBackgroundColor,
 						color: resolvedTheme.headerTextColor,
 					}}
 				>
-					<div className="ww:text-sm ww:font-semibold ww:truncate">{title}</div>
+					<div className="ww:text-sm ww:font-semibold ww:truncate ww:flex-1 ww:min-w-0">
+						{title}
+					</div>
 					<ExportSessionButton
 						messages={engine.messages}
 						evalEnabled={config.eval}
 						api={effectiveApi}
 					/>
+					{enableThreadHistory && (
+						<ThreadMenu
+							threads={engine.threads}
+							activeThreadId={engine.activeThreadId}
+							onNewThread={engine.startNewThread}
+							onSelectThread={(id) => {
+								void engine.switchThread(id);
+							}}
+							onDeleteThread={(id) => {
+								void engine.deleteThread(id);
+							}}
+						/>
+					)}
 				</div>
 
 				{/* Messages */}

--- a/src/chat/web/lib/__tests__/memory-user-id.test.ts
+++ b/src/chat/web/lib/__tests__/memory-user-id.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+
+const win = new Window({ url: "https://localhost" });
+for (const key of [
+	"document",
+	"navigator",
+	"localStorage",
+	"indexedDB",
+	"IDBKeyRange",
+] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any)[key] = (win as any)[key];
+}
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).window = win;
+
+async function freshModule() {
+	const mod = await import(
+		`../memory-user-id?t=${Date.now()}-${Math.random()}`
+	);
+	return mod as typeof import("../memory-user-id");
+}
+
+beforeEach(() => {
+	try {
+		localStorage.clear();
+	} catch {
+		// ignore
+	}
+});
+
+describe("getOrCreateMemoryUserId", () => {
+	test("generates and persists a UUID on first call", async () => {
+		const mod = await freshModule();
+		const id = await mod.getOrCreateMemoryUserId();
+		expect(typeof id).toBe("string");
+		expect(id.length).toBeGreaterThan(10);
+	});
+
+	test("returns the same UUID on subsequent calls in the same session", async () => {
+		const mod = await freshModule();
+		const a = await mod.getOrCreateMemoryUserId();
+		const b = await mod.getOrCreateMemoryUserId();
+		expect(a).toBe(b);
+	});
+
+	test("falls back to localStorage when indexedDB is unavailable", async () => {
+		const realIdb = (globalThis as unknown as { indexedDB: unknown }).indexedDB;
+		// biome-ignore lint/suspicious/noExplicitAny: test setup
+		(globalThis as any).indexedDB = undefined;
+		try {
+			const mod = await freshModule();
+			const id = await mod.getOrCreateMemoryUserId();
+			expect(typeof id).toBe("string");
+			expect(localStorage.getItem("waniwani-memory-user-id")).toBe(id);
+		} finally {
+			// biome-ignore lint/suspicious/noExplicitAny: test setup
+			(globalThis as any).indexedDB = realIdb;
+		}
+	});
+
+	test("returns in-memory UUID when both storage layers fail", async () => {
+		const realIdb = (globalThis as unknown as { indexedDB: unknown }).indexedDB;
+		const realLs = (globalThis as unknown as { localStorage: unknown })
+			.localStorage;
+		// biome-ignore lint/suspicious/noExplicitAny: test setup
+		(globalThis as any).indexedDB = undefined;
+		const throwingStorage = {
+			getItem: () => {
+				throw new Error("blocked");
+			},
+			setItem: () => {
+				throw new Error("blocked");
+			},
+			removeItem: () => {},
+			clear: () => {},
+			key: () => null,
+			length: 0,
+		};
+		// biome-ignore lint/suspicious/noExplicitAny: test setup
+		(globalThis as any).localStorage = throwingStorage;
+		try {
+			const mod = await freshModule();
+			const a = await mod.getOrCreateMemoryUserId();
+			const b = await mod.getOrCreateMemoryUserId();
+			expect(typeof a).toBe("string");
+			expect(a).toBe(b);
+		} finally {
+			// biome-ignore lint/suspicious/noExplicitAny: test setup
+			(globalThis as any).indexedDB = realIdb;
+			// biome-ignore lint/suspicious/noExplicitAny: test setup
+			(globalThis as any).localStorage = realLs;
+		}
+	});
+});

--- a/src/chat/web/lib/__tests__/thread-store.test.ts
+++ b/src/chat/web/lib/__tests__/thread-store.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+import { IDBFactory, IDBKeyRange } from "fake-indexeddb";
+import { Window } from "happy-dom";
+import type { StoredThread } from "../thread-store";
+
+const win = new Window({ url: "https://localhost" });
+for (const key of ["document", "navigator", "localStorage"] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any)[key] = (win as any)[key];
+}
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).window = win;
+// biome-ignore lint/suspicious/noExplicitAny: test setup — install fake IDB regardless of suite ordering
+(globalThis as any).indexedDB = new IDBFactory();
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).IDBKeyRange = IDBKeyRange;
+
+beforeEach(() => {
+	// biome-ignore lint/suspicious/noExplicitAny: test setup — full reset between cases
+	(globalThis as any).indexedDB = new IDBFactory();
+});
+
+async function importThreadStore() {
+	return (await import(
+		`../thread-store?t=${Date.now()}-${Math.random()}`
+	)) as typeof import("../thread-store");
+}
+
+async function importMemoryUserId() {
+	return (await import(
+		`../memory-user-id?t=${Date.now()}-${Math.random()}`
+	)) as typeof import("../memory-user-id");
+}
+
+function makeMessage(id: string, text: string): UIMessage {
+	return {
+		id,
+		role: "user",
+		parts: [{ type: "text", text }],
+	};
+}
+
+function makeThread(overrides: Partial<StoredThread> = {}): StoredThread {
+	const now = new Date().toISOString();
+	return {
+		threadId: overrides.threadId ?? "thread-1",
+		memoryUserId: overrides.memoryUserId ?? "user-1",
+		title: overrides.title ?? "Test thread",
+		messages: overrides.messages ?? [makeMessage("m1", "hello")],
+		sessionId: overrides.sessionId,
+		createdAt: overrides.createdAt ?? now,
+		updatedAt: overrides.updatedAt ?? now,
+	};
+}
+
+describe("thread-store", () => {
+	test("upsert + load round-trips a thread", async () => {
+		const store = await importThreadStore();
+		const t = makeThread();
+		await store.upsertThread(t);
+		const loaded = await store.loadThread(t.threadId);
+		expect(loaded).not.toBeNull();
+		expect(loaded?.title).toBe("Test thread");
+		expect(loaded?.messages.length).toBe(1);
+	});
+
+	test("listThreads filters by memoryUserId, newest first", async () => {
+		const store = await importThreadStore();
+		const t1 = makeThread({
+			threadId: "a",
+			memoryUserId: "u1",
+			updatedAt: "2026-04-01T00:00:00.000Z",
+		});
+		const t2 = makeThread({
+			threadId: "b",
+			memoryUserId: "u1",
+			updatedAt: "2026-04-02T00:00:00.000Z",
+		});
+		const tOther = makeThread({ threadId: "c", memoryUserId: "u2" });
+		await store.upsertThread(t1);
+		await store.upsertThread(t2);
+		await store.upsertThread(tOther);
+
+		const list = await store.listThreads("u1");
+		expect(list.map((t) => t.threadId)).toEqual(["b", "a"]);
+	});
+
+	test("upsert overwrites and bumps updatedAt", async () => {
+		const store = await importThreadStore();
+		const t = makeThread({
+			updatedAt: "2026-04-01T00:00:00.000Z",
+		});
+		await store.upsertThread(t);
+		const updated = {
+			...t,
+			messages: [makeMessage("m1", "hello"), makeMessage("m2", "again")],
+			updatedAt: "2026-04-05T00:00:00.000Z",
+		};
+		await store.upsertThread(updated);
+		const loaded = await store.loadThread(t.threadId);
+		expect(loaded?.messages.length).toBe(2);
+		expect(loaded?.updatedAt).toBe("2026-04-05T00:00:00.000Z");
+	});
+
+	test("deleteThread removes the row", async () => {
+		const store = await importThreadStore();
+		const t = makeThread();
+		await store.upsertThread(t);
+		await store.deleteThread(t.threadId);
+		const loaded = await store.loadThread(t.threadId);
+		expect(loaded).toBeNull();
+	});
+
+	test("getActiveThreadId returns most-recently-updated thread", async () => {
+		const store = await importThreadStore();
+		await store.upsertThread(
+			makeThread({
+				threadId: "old",
+				memoryUserId: "u1",
+				updatedAt: "2026-04-01T00:00:00.000Z",
+			}),
+		);
+		await store.upsertThread(
+			makeThread({
+				threadId: "new",
+				memoryUserId: "u1",
+				updatedAt: "2026-04-10T00:00:00.000Z",
+			}),
+		);
+
+		const active = await store.getActiveThreadId("u1");
+		expect(active).toBe("new");
+	});
+
+	test("two memoryUserIds see independent thread sets", async () => {
+		const store = await importThreadStore();
+		await store.upsertThread(makeThread({ threadId: "a", memoryUserId: "u1" }));
+		await store.upsertThread(makeThread({ threadId: "b", memoryUserId: "u2" }));
+
+		const u1 = await store.listThreads("u1");
+		const u2 = await store.listThreads("u2");
+		expect(u1.map((t) => t.threadId)).toEqual(["a"]);
+		expect(u2.map((t) => t.threadId)).toEqual(["b"]);
+	});
+
+	test("upgrade path v1 → v2 preserves the ids store", async () => {
+		// Open as v1 with only the legacy `ids` store, write a memoryUserId.
+		await new Promise<void>((resolve, reject) => {
+			const req = indexedDB.open("waniwani-memory", 1);
+			req.onupgradeneeded = () => {
+				const db = req.result;
+				if (!db.objectStoreNames.contains("ids")) {
+					db.createObjectStore("ids");
+				}
+			};
+			req.onsuccess = () => {
+				const db = req.result;
+				const tx = db.transaction("ids", "readwrite");
+				tx.objectStore("ids").put("legacy-user", "memoryUserId");
+				tx.oncomplete = () => {
+					db.close();
+					resolve();
+				};
+				tx.onerror = () => reject(tx.error);
+			};
+			req.onerror = () => reject(req.error);
+		});
+
+		// Re-open via the SDK helper which now requests v2; threads store must exist
+		// AND the legacy id must still be readable.
+		const memMod = await importMemoryUserId();
+		const id = await memMod.getOrCreateMemoryUserId();
+		expect(id).toBe("legacy-user");
+
+		const store = await importThreadStore();
+		await store.upsertThread(makeThread({ memoryUserId: "legacy-user" }));
+		const list = await store.listThreads("legacy-user");
+		expect(list.length).toBe(1);
+	});
+});

--- a/src/chat/web/lib/memory-user-id.ts
+++ b/src/chat/web/lib/memory-user-id.ts
@@ -1,5 +1,11 @@
-const DB_NAME = "waniwani-memory";
-const STORE_NAME = "ids";
+export const DB_NAME = "waniwani-memory";
+export const DB_VERSION = 2;
+export const IDS_STORE = "ids";
+export const THREADS_STORE = "threads";
+export const THREADS_BY_USER_INDEX = "by_memoryUserId";
+export const THREADS_BY_UPDATED_INDEX = "by_updatedAt";
+
+const STORE_NAME = IDS_STORE;
 const KEY = "memoryUserId";
 const LOCAL_STORAGE_KEY = "waniwani-memory-user-id";
 
@@ -20,18 +26,43 @@ function generateUuid(): string {
 	});
 }
 
-async function openDb(): Promise<IDBDatabase> {
+export function applyMemoryDbUpgrade(
+	db: IDBDatabase,
+	oldVersion: number,
+): void {
+	if (oldVersion < 1) {
+		if (!db.objectStoreNames.contains(IDS_STORE)) {
+			db.createObjectStore(IDS_STORE);
+		}
+	}
+	if (oldVersion < 2) {
+		if (!db.objectStoreNames.contains(THREADS_STORE)) {
+			const threads = db.createObjectStore(THREADS_STORE, {
+				keyPath: "threadId",
+			});
+			threads.createIndex(THREADS_BY_USER_INDEX, "memoryUserId", {
+				unique: false,
+			});
+			threads.createIndex(THREADS_BY_UPDATED_INDEX, "updatedAt", {
+				unique: false,
+			});
+		}
+	}
+}
+
+export async function openMemoryDb(): Promise<IDBDatabase> {
 	return new Promise((resolve, reject) => {
-		const req = indexedDB.open(DB_NAME, 1);
-		req.onupgradeneeded = () => {
-			const db = req.result;
-			if (!db.objectStoreNames.contains(STORE_NAME)) {
-				db.createObjectStore(STORE_NAME);
-			}
+		const req = indexedDB.open(DB_NAME, DB_VERSION);
+		req.onupgradeneeded = (event) => {
+			applyMemoryDbUpgrade(req.result, event.oldVersion);
 		};
 		req.onsuccess = () => resolve(req.result);
 		req.onerror = () => reject(req.error);
 	});
+}
+
+async function openDb(): Promise<IDBDatabase> {
+	return openMemoryDb();
 }
 
 async function idbGet(db: IDBDatabase): Promise<string | null> {

--- a/src/chat/web/lib/memory-user-id.ts
+++ b/src/chat/web/lib/memory-user-id.ts
@@ -1,0 +1,109 @@
+const DB_NAME = "waniwani-memory";
+const STORE_NAME = "ids";
+const KEY = "memoryUserId";
+const LOCAL_STORAGE_KEY = "waniwani-memory-user-id";
+
+let inMemoryFallbackId: string | null = null;
+
+function generateUuid(): string {
+	if (
+		typeof crypto !== "undefined" &&
+		typeof crypto.randomUUID === "function"
+	) {
+		return crypto.randomUUID();
+	}
+	// Fallback for environments without crypto.randomUUID
+	return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+		const r = (Math.random() * 16) | 0;
+		const v = c === "x" ? r : (r & 0x3) | 0x8;
+		return v.toString(16);
+	});
+}
+
+async function openDb(): Promise<IDBDatabase> {
+	return new Promise((resolve, reject) => {
+		const req = indexedDB.open(DB_NAME, 1);
+		req.onupgradeneeded = () => {
+			const db = req.result;
+			if (!db.objectStoreNames.contains(STORE_NAME)) {
+				db.createObjectStore(STORE_NAME);
+			}
+		};
+		req.onsuccess = () => resolve(req.result);
+		req.onerror = () => reject(req.error);
+	});
+}
+
+async function idbGet(db: IDBDatabase): Promise<string | null> {
+	return new Promise((resolve, reject) => {
+		const tx = db.transaction(STORE_NAME, "readonly");
+		const store = tx.objectStore(STORE_NAME);
+		const req = store.get(KEY);
+		req.onsuccess = () =>
+			resolve(typeof req.result === "string" ? req.result : null);
+		req.onerror = () => reject(req.error);
+	});
+}
+
+async function idbPut(db: IDBDatabase, value: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const tx = db.transaction(STORE_NAME, "readwrite");
+		const store = tx.objectStore(STORE_NAME);
+		const req = store.put(value, KEY);
+		req.onsuccess = () => resolve();
+		req.onerror = () => reject(req.error);
+	});
+}
+
+async function tryIndexedDb(): Promise<string | null> {
+	if (typeof indexedDB === "undefined") {
+		return null;
+	}
+	try {
+		const db = await openDb();
+		try {
+			const existing = await idbGet(db);
+			if (existing) {
+				return existing;
+			}
+			const next = generateUuid();
+			await idbPut(db, next);
+			return next;
+		} finally {
+			db.close();
+		}
+	} catch {
+		return null;
+	}
+}
+
+function tryLocalStorage(): string | null {
+	try {
+		const existing = localStorage.getItem(LOCAL_STORAGE_KEY);
+		if (existing) {
+			return existing;
+		}
+		const next = generateUuid();
+		localStorage.setItem(LOCAL_STORAGE_KEY, next);
+		return next;
+	} catch {
+		return null;
+	}
+}
+
+export async function getOrCreateMemoryUserId(): Promise<string> {
+	const fromIdb = await tryIndexedDb();
+	if (fromIdb) {
+		return fromIdb;
+	}
+
+	const fromLs = tryLocalStorage();
+	if (fromLs) {
+		return fromLs;
+	}
+
+	if (!inMemoryFallbackId) {
+		inMemoryFallbackId = generateUuid();
+	}
+	return inMemoryFallbackId;
+}

--- a/src/chat/web/lib/thread-store.ts
+++ b/src/chat/web/lib/thread-store.ts
@@ -1,0 +1,170 @@
+import type { UIMessage } from "ai";
+import {
+	openMemoryDb,
+	THREADS_BY_USER_INDEX,
+	THREADS_STORE,
+} from "./memory-user-id";
+
+export interface StoredThread {
+	threadId: string;
+	memoryUserId: string;
+	title: string;
+	messages: UIMessage[];
+	sessionId?: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export const MAX_THREADS_PER_USER = 50;
+export const MAX_MESSAGES_PER_THREAD = 1000;
+
+function isStoredThread(value: unknown): value is StoredThread {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+	const v = value as Record<string, unknown>;
+	return (
+		typeof v.threadId === "string" &&
+		typeof v.memoryUserId === "string" &&
+		typeof v.title === "string" &&
+		Array.isArray(v.messages) &&
+		typeof v.createdAt === "string" &&
+		typeof v.updatedAt === "string"
+	);
+}
+
+async function withDb<T>(
+	fn: (db: IDBDatabase) => Promise<T>,
+): Promise<T | null> {
+	if (typeof indexedDB === "undefined") {
+		return null;
+	}
+	let db: IDBDatabase | null = null;
+	try {
+		db = await openMemoryDb();
+		return await fn(db);
+	} catch {
+		return null;
+	} finally {
+		try {
+			db?.close();
+		} catch {
+			// ignore
+		}
+	}
+}
+
+function promisifyRequest<T>(req: IDBRequest<T>): Promise<T> {
+	return new Promise((resolve, reject) => {
+		req.onsuccess = () => resolve(req.result);
+		req.onerror = () => reject(req.error);
+	});
+}
+
+export async function listThreads(
+	memoryUserId: string,
+): Promise<StoredThread[]> {
+	const result = await withDb(async (db) => {
+		const tx = db.transaction(THREADS_STORE, "readonly");
+		const store = tx.objectStore(THREADS_STORE);
+		const index = store.index(THREADS_BY_USER_INDEX);
+		const all = await promisifyRequest(index.getAll(memoryUserId));
+		const threads = (all ?? []).filter(isStoredThread);
+		threads.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+		return threads;
+	});
+	return result ?? [];
+}
+
+export async function loadThread(
+	threadId: string,
+): Promise<StoredThread | null> {
+	const result = await withDb(async (db) => {
+		const tx = db.transaction(THREADS_STORE, "readonly");
+		const store = tx.objectStore(THREADS_STORE);
+		const value = await promisifyRequest(store.get(threadId));
+		return isStoredThread(value) ? value : null;
+	});
+	return result ?? null;
+}
+
+export async function upsertThread(thread: StoredThread): Promise<void> {
+	if (!isStoredThread(thread)) {
+		return;
+	}
+	const trimmed: StoredThread =
+		thread.messages.length > MAX_MESSAGES_PER_THREAD
+			? {
+					...thread,
+					messages: thread.messages.slice(
+						thread.messages.length - MAX_MESSAGES_PER_THREAD,
+					),
+				}
+			: thread;
+
+	await withDb(async (db) => {
+		await new Promise<void>((resolve, reject) => {
+			const tx = db.transaction(THREADS_STORE, "readwrite");
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+			tx.onabort = () => reject(tx.error);
+			const store = tx.objectStore(THREADS_STORE);
+			store.put(trimmed);
+		});
+
+		// Evict oldest threads beyond the per-user cap.
+		const tx2 = db.transaction(THREADS_STORE, "readwrite");
+		const store2 = tx2.objectStore(THREADS_STORE);
+		const index = store2.index(THREADS_BY_USER_INDEX);
+		const all = await promisifyRequest(index.getAll(trimmed.memoryUserId));
+		const userThreads = (all ?? []).filter(isStoredThread);
+		if (userThreads.length > MAX_THREADS_PER_USER) {
+			userThreads.sort((a, b) => (a.updatedAt < b.updatedAt ? -1 : 1));
+			const toEvict = userThreads.slice(
+				0,
+				userThreads.length - MAX_THREADS_PER_USER,
+			);
+			for (const t of toEvict) {
+				store2.delete(t.threadId);
+			}
+		}
+		await new Promise<void>((resolve, reject) => {
+			tx2.oncomplete = () => resolve();
+			tx2.onerror = () => reject(tx2.error);
+			tx2.onabort = () => reject(tx2.error);
+		});
+		return null;
+	});
+}
+
+export async function deleteThread(threadId: string): Promise<void> {
+	await withDb(async (db) => {
+		await new Promise<void>((resolve, reject) => {
+			const tx = db.transaction(THREADS_STORE, "readwrite");
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+			tx.onabort = () => reject(tx.error);
+			tx.objectStore(THREADS_STORE).delete(threadId);
+		});
+		return null;
+	});
+}
+
+export async function getActiveThreadId(
+	memoryUserId: string,
+): Promise<string | null> {
+	const threads = await listThreads(memoryUserId);
+	return threads[0]?.threadId ?? null;
+}
+
+export function deriveThreadTitle(text: string): string {
+	const trimmed = text.trim();
+	if (!trimmed) {
+		return `Conversation on ${new Date().toISOString().slice(0, 10)}`;
+	}
+	const firstLine = trimmed.split(/\r?\n/, 1)[0] ?? trimmed;
+	if (firstLine.length <= 60) {
+		return firstLine;
+	}
+	return `${firstLine.slice(0, 60).trimEnd()}…`;
+}

--- a/src/chat/web/lib/visitor-context.ts
+++ b/src/chat/web/lib/visitor-context.ts
@@ -1,3 +1,5 @@
+import { getOrCreateMemoryUserId } from "./memory-user-id";
+
 const VISITOR_ID_KEY = "waniwani-visitor-id";
 
 // ============================================================================
@@ -22,6 +24,7 @@ export interface VisitorContext {
 	connectionType: string;
 	referrer: string;
 	visitorId: string;
+	memoryUserId: string;
 }
 
 // ============================================================================
@@ -148,7 +151,10 @@ async function computeVisitorId(): Promise<string> {
 
 export async function collectVisitorContext(): Promise<VisitorContext> {
 	const ua = navigator.userAgent;
-	const visitorId = await computeVisitorId();
+	const [visitorId, memoryUserId] = await Promise.all([
+		computeVisitorId(),
+		getOrCreateMemoryUserId(),
+	]);
 
 	return {
 		userAgent: ua,
@@ -169,5 +175,6 @@ export async function collectVisitorContext(): Promise<VisitorContext> {
 		connectionType: (navigator as any).connection?.effectiveType ?? "unknown",
 		referrer: document.referrer,
 		visitorId,
+		memoryUserId,
 	};
 }


### PR DESCRIPTION
## Summary
- Persist chat conversations per `memoryUserId` in IndexedDB (DB v2, new `threads` store with by-user/by-updatedAt indexes); reload resumes most recent thread automatically.
- Expose `threads`, `activeThreadId`, `startNewThread`, `switchThread`, `deleteThread` from `useChatEngine`; add `enableThreadHistory`, `activeThreadId`, `onThreadChange` props to `ChatBaseProps`.
- New `ThreadMenu` in the `ChatCard` header (new chat + history dropdown with delete) and `threadId` automatically threaded into the chat request body.
- Embed plumbing: thread `memoryUserId` through embed request body, generalize iframe init (rename `initialize-chat-gpt` → `initialize-next-in-iframe`), and support widget resource proxy.

## Test plan
- [x] `bun biome check . --fix`
- [ ] Verify thread persistence + switch + delete in browser embed
- [ ] Verify embed `memoryUserId` reaches server in request body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds opt-in client-side persistence and thread management logic that affects message/session state and request payloads; risk is mainly around race conditions and storage/compatibility edge cases (IndexedDB availability, cross-tab behavior).
> 
> **Overview**
> Adds **opt-in thread history** to the chat UI (`enableThreadHistory`) by persisting conversations to IndexedDB, restoring the most-recent thread on mount, and auto-including a `threadId` (plus `visitor.client.memoryUserId`) in outgoing chat request bodies.
> 
> Extends `useChatEngine` and `ChatBaseProps` with thread controls (`threads`, `activeThreadId`, `startNewThread`, `switchThread`, `deleteThread`, `onThreadChange`) and surfaces a new `ThreadMenu` in the `ChatCard` header to create/switch/delete threads.
> 
> Updates embed configuration and remote-config parsing to support `enableThreadHistory` via `data-enable-thread-history` and server-provided config, adjusts MCP iframe URL construction to preserve pre-existing query params, and adds IndexedDB-focused tests using `fake-indexeddb`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870fe0a3c5d7aa34970da3fe3c6d4e43e7ba77ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->