### PR TITLE
feat(chat/server): add express-js adapter, deprecate next-js handler

### DIFF
--- a/docs/setup/installation.mdx
+++ b/docs/setup/installation.mdx
@@ -122,6 +122,6 @@ const result = await wani.shutdown({ timeoutMs: 5000 });
 ## Also supported
 
 - **Project config file.** Create a `waniwani.config.ts` with `defineConfig({ ... })` from `@waniwani/sdk`, then import it once at startup. Subsequent calls to `waniwani()` pick up the registered config.
-- **Framework adapters.** Pass the client to `toNextJsHandler(wani, { ... })` from `@waniwani/sdk/next-js` for Next.js route handlers.
+- **Framework adapters.** Pass the client to `toExpressJsHandler(wani, { ... })` from `@waniwani/sdk/express-js` for Express middleware. The legacy `toNextJsHandler` from `@waniwani/sdk/next-js` is deprecated and will be removed in a follow-up release.
 
 Next: [get your API key](/setup/api-key), then [wrap your MCP server](/setup/wrap-server).

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       "import": "./dist/chat/next-js/index.js",
       "default": "./dist/chat/next-js/index.js"
     },
+    "./express-js": {
+      "types": "./dist/chat/express-js/index.d.ts",
+      "import": "./dist/chat/express-js/index.js",
+      "default": "./dist/chat/express-js/index.js"
+    },
     "./kb": {
       "types": "./dist/kb/index.d.ts",
       "import": "./dist/kb/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.11.0",
+  "version": "0.11.1-beta.0",
   "description": "WaniWani SDK - MCP event tracking, widget framework, and tools",
   "type": "module",
   "exports": {

--- a/src/chat/server/@types.ts
+++ b/src/chat/server/@types.ts
@@ -64,6 +64,48 @@ export interface WebSearchConfig {
 }
 
 // ============================================================================
+// Chat Options (namespaced under `chat` in framework adapters)
+// ============================================================================
+
+export interface ChatOptions {
+	/**
+	 * System prompt for the assistant.
+	 * Can be overridden per-request via `beforeRequest`.
+	 */
+	systemPrompt?: string;
+
+	/**
+	 * Maximum number of tool call steps. Defaults to 5.
+	 */
+	maxSteps?: number;
+
+	/**
+	 * Hook called before each request is forwarded to the WaniWani API.
+	 * - Return void to use defaults.
+	 * - Return an object to override messages, systemPrompt, or sessionId.
+	 * - Throw to reject the request (the error message is returned as JSON).
+	 */
+	beforeRequest?: (
+		context: BeforeRequestContext,
+	) =>
+		| Promise<BeforeRequestResult | undefined>
+		| BeforeRequestResult
+		| undefined;
+
+	/**
+	 * Override the MCP server URL directly, bypassing config resolution.
+	 * Useful for development/testing when pointing to a local MCP server.
+	 */
+	mcpServerUrl?: string;
+
+	/**
+	 * Enable web search as an additional tool alongside MCP tools.
+	 * Pass `true` to enable with defaults, or a config object to restrict domains.
+	 */
+	webSearch?: boolean | WebSearchConfig;
+}
+
+// ============================================================================
 // API Handler Options
 // ============================================================================
 

--- a/src/chat/server/express-js/@types.ts
+++ b/src/chat/server/express-js/@types.ts
@@ -1,6 +1,6 @@
 // WaniWani SDK - Express Adapter Types
 
-import type { ChatOptions } from "../next-js/@types.js";
+import type { ChatOptions } from "../@types.js";
 
 export type { ChatOptions };
 

--- a/src/chat/server/express-js/@types.ts
+++ b/src/chat/server/express-js/@types.ts
@@ -1,0 +1,74 @@
+// WaniWani SDK - Express Adapter Types
+
+import type { ChatOptions } from "../next-js/@types.js";
+
+export type { ChatOptions };
+
+// ============================================================================
+// Express Handler Options
+// ============================================================================
+
+export interface ExpressJsHandlerOptions {
+	/** Chat handler configuration */
+	chat?: ChatOptions;
+
+	/**
+	 * Identifies this chatbar instance in analytics.
+	 * Use a descriptive name like "hamilton-support" or "pricing-page".
+	 * Shows up as `source` on tracked events.
+	 */
+	source: string;
+
+	/**
+	 * Enable verbose debug logging for all handler steps.
+	 * Logs request details, response codes, resolved URLs, and caught errors.
+	 */
+	debug?: boolean;
+}
+
+// ============================================================================
+// Express Handler Result
+// ============================================================================
+
+/**
+ * Express middleware signatures. Typed against `unknown` to avoid forcing
+ * `@types/express` on consumers that don't use Express. Cast at the call site
+ * if your IDE doesn't infer correctly.
+ */
+export type ExpressMiddleware = (
+	req: ExpressLikeRequest,
+	res: ExpressLikeResponse,
+	next: (err?: unknown) => void,
+) => void;
+
+/** Subset of Express's Request that the adapter actually reads. */
+export interface ExpressLikeRequest {
+	method: string;
+	url: string;
+	originalUrl?: string;
+	headers: Record<string, string | string[] | undefined>;
+	protocol?: string;
+	get?: (name: string) => string | undefined;
+	on: (event: string, listener: (...args: unknown[]) => void) => void;
+}
+
+/** Subset of Express's Response that the adapter actually writes to. */
+export interface ExpressLikeResponse {
+	statusCode: number;
+	setHeader: (name: string, value: string | number | readonly string[]) => void;
+	status: (code: number) => ExpressLikeResponse;
+	end: (chunk?: unknown, encoding?: BufferEncoding) => void;
+	write: (chunk: unknown, encoding?: BufferEncoding) => boolean;
+	on: (event: string, listener: (...args: unknown[]) => void) => void;
+}
+
+export interface ExpressJsHandlerResult {
+	/** GET handler: routes sub-paths (e.g. /resource for MCP widget content) */
+	get: ExpressMiddleware;
+	/** POST handler: proxies chat messages to the WaniWani API */
+	post: ExpressMiddleware;
+	/** PATCH handler: routes updates (e.g. /scenarios/:id) */
+	patch: ExpressMiddleware;
+	/** OPTIONS handler: CORS preflight (no `next` argument needed) */
+	options: (req: ExpressLikeRequest, res: ExpressLikeResponse) => void;
+}

--- a/src/chat/server/express-js/__tests__/to-express-js-handler.test.ts
+++ b/src/chat/server/express-js/__tests__/to-express-js-handler.test.ts
@@ -1,0 +1,405 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { PassThrough, Readable } from "node:stream";
+
+// ---------------------------------------------------------------------------
+// Mocks for the underlying createApiHandler
+// ---------------------------------------------------------------------------
+//
+// `toExpressJsHandler` calls `createApiHandler` once at construction time and
+// dispatches its `route*` methods. We mock the module so each test controls
+// what those methods return.
+
+type RouteFn = (request: Request) => Promise<Response>;
+
+interface MockApiHandler {
+	routeGet: RouteFn;
+	routePost: RouteFn;
+	routePatch: RouteFn;
+	handleOptions: () => Response;
+}
+
+let nextHandler: MockApiHandler;
+const createApiHandlerMock = mock(() => nextHandler);
+
+// @ts-expect-error -- bun:test `mock.module` exists at runtime but has no TS type
+mock.module("../../api-handler.js", () => ({
+	createApiHandler: createApiHandlerMock,
+}));
+
+const { toExpressJsHandler } = await import("../index");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeClient() {
+	// Minimal shape: only `_config` is read by the adapter.
+	return {
+		_config: { apiKey: "test-key", apiUrl: "https://test.waniwani.ai" },
+	} as unknown as Parameters<typeof toExpressJsHandler>[0];
+}
+
+interface FakeReqOptions {
+	method: string;
+	url?: string;
+	headers?: Record<string, string | string[] | undefined>;
+	body?: Buffer | string | null;
+}
+
+function makeReq({
+	method,
+	url = "/api/waniwani",
+	headers = {},
+	body = null,
+}: FakeReqOptions) {
+	const stream = new Readable({
+		read() {
+			if (body !== null) {
+				this.push(body);
+			}
+			this.push(null);
+		},
+	});
+	const merged = { host: "localhost:3000", ...headers };
+	// Express's `get(name)` is case-insensitive lookup of the header map.
+	(stream as unknown as { method: string }).method = method;
+	(stream as unknown as { url: string }).url = url;
+	(stream as unknown as { originalUrl: string }).originalUrl = url;
+	(stream as unknown as { headers: typeof merged }).headers = merged;
+	(stream as unknown as { protocol: string }).protocol = "http";
+	(stream as unknown as { get: (n: string) => string | undefined }).get = (
+		name: string,
+	) => {
+		const v = merged[name.toLowerCase() as keyof typeof merged];
+		return Array.isArray(v) ? v[0] : (v as string | undefined);
+	};
+	return stream as unknown as Parameters<
+		ReturnType<typeof toExpressJsHandler>["post"]
+	>[0];
+}
+
+interface FakeRes {
+	statusCode: number;
+	headers: Record<string, string>;
+	chunks: Buffer[];
+	ended: boolean;
+	statusMock: ReturnType<typeof mock>;
+	setHeaderMock: ReturnType<typeof mock>;
+	endMock: ReturnType<typeof mock>;
+	writeMock: ReturnType<typeof mock>;
+	stream: PassThrough;
+	awaitEnd(): Promise<void>;
+}
+
+function makeRes(): FakeRes {
+	const stream = new PassThrough();
+	const chunks: Buffer[] = [];
+	stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+	const headers: Record<string, string> = {};
+	const state = { statusCode: 200, ended: false };
+
+	const ended = new Promise<void>((resolve) => {
+		stream.on("end", () => resolve());
+		stream.on("finish", () => resolve());
+	});
+
+	const writeMock = mock((...args: unknown[]) => {
+		stream.write(args[0] as Buffer);
+		return true;
+	});
+	const endMock = mock((...args: unknown[]) => {
+		state.ended = true;
+		if (args[0] !== undefined) {
+			stream.write(args[0] as Buffer);
+		}
+		stream.end();
+	});
+	const setHeaderMock = mock((...args: unknown[]) => {
+		const [name, value] = args as [string, unknown];
+		headers[name.toLowerCase()] = String(value);
+	});
+	const statusMock = mock((...args: unknown[]) => {
+		state.statusCode = args[0] as number;
+		return res as unknown;
+	});
+
+	const res = {
+		get statusCode() {
+			return state.statusCode;
+		},
+		set statusCode(v: number) {
+			state.statusCode = v;
+		},
+		setHeader: setHeaderMock,
+		status: statusMock,
+		end: endMock,
+		write: writeMock,
+		on: stream.on.bind(stream),
+	};
+
+	return {
+		get statusCode() {
+			return state.statusCode;
+		},
+		set statusCode(v: number) {
+			state.statusCode = v;
+		},
+		headers,
+		chunks,
+		get ended() {
+			return state.ended;
+		},
+		statusMock,
+		setHeaderMock,
+		endMock,
+		writeMock,
+		stream,
+		awaitEnd: () => ended,
+	} as FakeRes & { _passthrough: typeof res };
+}
+
+// Make TypeScript happy: the FakeRes's underlying object satisfies the
+// adapter's ExpressLikeResponse shape. We expose it via a thin wrapper.
+function asResponse(fr: FakeRes) {
+	return {
+		get statusCode() {
+			return fr.statusCode;
+		},
+		set statusCode(v: number) {
+			fr.statusCode = v;
+		},
+		setHeader: fr.setHeaderMock,
+		status: fr.statusMock,
+		end: fr.endMock,
+		write: fr.writeMock,
+		on: fr.stream.on.bind(fr.stream),
+	} as unknown as Parameters<ReturnType<typeof toExpressJsHandler>["post"]>[1];
+}
+
+// ---------------------------------------------------------------------------
+// Default mock state
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+	nextHandler = {
+		routeGet: async () => new Response("ok", { status: 200 }),
+		routePost: async () => new Response("ok", { status: 200 }),
+		routePatch: async () => new Response("ok", { status: 200 }),
+		handleOptions: () => new Response(null, { status: 204 }),
+	};
+	createApiHandlerMock.mockClear();
+});
+
+afterEach(() => {
+	createApiHandlerMock.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("toExpressJsHandler", () => {
+	test("returns { get, post, patch, options } and nothing else", () => {
+		const handler = toExpressJsHandler(makeClient(), { source: "test" });
+		expect(typeof handler.get).toBe("function");
+		expect(typeof handler.post).toBe("function");
+		expect(typeof handler.patch).toBe("function");
+		expect(typeof handler.options).toBe("function");
+		expect(Object.keys(handler).sort()).toEqual([
+			"get",
+			"options",
+			"patch",
+			"post",
+		]);
+	});
+
+	test("forwards client config and source to createApiHandler", () => {
+		toExpressJsHandler(makeClient(), {
+			source: "my-app",
+			chat: { mcpServerUrl: "https://example.com/mcp" },
+		});
+		expect(createApiHandlerMock).toHaveBeenCalledTimes(1);
+		const args = createApiHandlerMock.mock.calls[0]?.[0] as Record<
+			string,
+			unknown
+		>;
+		expect(args.apiKey).toBe("test-key");
+		expect(args.apiUrl).toBe("https://test.waniwani.ai");
+		expect(args.source).toBe("my-app");
+		expect(args.mcpServerUrl).toBe("https://example.com/mcp");
+	});
+
+	test("OPTIONS preflight: status 204, ends without next()", async () => {
+		const handler = toExpressJsHandler(makeClient(), { source: "test" });
+		const fr = makeRes();
+		const next = mock(() => {});
+		handler.options(makeReq({ method: "OPTIONS" }), asResponse(fr));
+		await fr.awaitEnd();
+		expect(fr.statusCode).toBe(204);
+		expect(fr.endMock).toHaveBeenCalled();
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	test("streaming POST: chunks arrive in order", async () => {
+		const chunks = ["chunk-one\n", "chunk-two\n", "chunk-three\n"];
+		nextHandler.routePost = async () => {
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					const enc = new TextEncoder();
+					for (const c of chunks) {
+						controller.enqueue(enc.encode(c));
+					}
+					controller.close();
+				},
+			});
+			return new Response(stream, {
+				status: 200,
+				headers: { "content-type": "text/plain" },
+			});
+		};
+
+		const handler = toExpressJsHandler(makeClient(), { source: "test" });
+		const fr = makeRes();
+		const next = mock(() => {});
+
+		await new Promise<void>((resolve, reject) => {
+			fr.stream.on("end", () => resolve());
+			fr.stream.on("error", reject);
+			handler.post(
+				makeReq({ method: "POST", body: Buffer.from("{}") }),
+				asResponse(fr),
+				next,
+			);
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(fr.statusCode).toBe(200);
+		expect(fr.headers["content-type"]).toBe("text/plain");
+		const body = Buffer.concat(fr.chunks).toString("utf-8");
+		expect(body).toBe(chunks.join(""));
+	});
+
+	test("propagates response headers verbatim", async () => {
+		nextHandler.routeGet = async () =>
+			new Response("hello", {
+				status: 200,
+				headers: {
+					"content-type": "text/html; charset=utf-8",
+					"x-foo": "bar",
+				},
+			});
+
+		const handler = toExpressJsHandler(makeClient(), { source: "test" });
+		const fr = makeRes();
+		const next = mock(() => {});
+
+		await new Promise<void>((resolve, reject) => {
+			fr.stream.on("end", resolve);
+			fr.stream.on("error", reject);
+			handler.get(makeReq({ method: "GET" }), asResponse(fr), next);
+		});
+
+		expect(fr.headers["content-type"]).toBe("text/html; charset=utf-8");
+		expect(fr.headers["x-foo"]).toBe("bar");
+	});
+
+	test("forwards Express request body as Web Request body", async () => {
+		const captured: { request?: Request; bodyText?: string } = {};
+		nextHandler.routePost = async (request) => {
+			captured.request = request;
+			captured.bodyText = await request.text();
+			return new Response("ok", { status: 200 });
+		};
+
+		const handler = toExpressJsHandler(makeClient(), { source: "test" });
+		const fr = makeRes();
+		const next = mock(() => {});
+		const payload = JSON.stringify({ hello: "world" });
+
+		await new Promise<void>((resolve, reject) => {
+			fr.stream.on("end", resolve);
+			fr.stream.on("error", reject);
+			handler.post(
+				makeReq({
+					method: "POST",
+					url: "/api/waniwani",
+					headers: { "content-type": "application/json" },
+					body: Buffer.from(payload),
+				}),
+				asResponse(fr),
+				next,
+			);
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(captured.bodyText).toBe(payload);
+		expect(captured.request?.method).toBe("POST");
+		expect(captured.request?.headers.get("content-type")).toBe(
+			"application/json",
+		);
+	});
+
+	test("error path: thrown error invokes next(err) and does not end response", async () => {
+		const boom = new Error("boom");
+		nextHandler.routePost = async () => {
+			throw boom;
+		};
+
+		const handler = toExpressJsHandler(makeClient(), { source: "test" });
+		const fr = makeRes();
+		const next = mock(() => {});
+
+		await Promise.resolve(
+			handler.post(
+				makeReq({ method: "POST", body: Buffer.from("{}") }),
+				asResponse(fr),
+				next,
+			),
+		);
+		// Adapter is async — give microtasks a chance to flush.
+		await new Promise((r) => setImmediate(r));
+
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(next.mock.calls[0]?.[0]).toBe(boom);
+		expect(fr.endMock).not.toHaveBeenCalled();
+	});
+
+	test("method dispatch: get/post/patch each call the matching route", async () => {
+		const calls: string[] = [];
+		nextHandler.routeGet = async () => {
+			calls.push("get");
+			return new Response("g", { status: 200 });
+		};
+		nextHandler.routePost = async () => {
+			calls.push("post");
+			return new Response("p", { status: 200 });
+		};
+		nextHandler.routePatch = async () => {
+			calls.push("patch");
+			return new Response("a", { status: 200 });
+		};
+
+		const handler = toExpressJsHandler(makeClient(), { source: "test" });
+
+		const drive = (
+			method: "get" | "post" | "patch",
+			body: Buffer | null = null,
+		) =>
+			new Promise<void>((resolve, reject) => {
+				const fr = makeRes();
+				fr.stream.on("end", resolve);
+				fr.stream.on("error", reject);
+				handler[method](
+					makeReq({ method: method.toUpperCase(), body }),
+					asResponse(fr),
+					() => reject(new Error("unexpected next()")),
+				);
+			});
+
+		await drive("get");
+		await drive("post", Buffer.from("{}"));
+		await drive("patch", Buffer.from("{}"));
+
+		expect(calls).toEqual(["get", "post", "patch"]);
+	});
+});

--- a/src/chat/server/express-js/index.ts
+++ b/src/chat/server/express-js/index.ts
@@ -1,0 +1,175 @@
+// WaniWani SDK - Express Adapter
+
+import { Readable } from "node:stream";
+import type { WaniWaniClient } from "../../../types.js";
+import { createApiHandler } from "../api-handler.js";
+import type {
+	ExpressJsHandlerOptions,
+	ExpressJsHandlerResult,
+	ExpressLikeRequest,
+	ExpressLikeResponse,
+} from "./@types.js";
+
+export type {
+	ChatOptions,
+	ExpressJsHandlerOptions,
+	ExpressJsHandlerResult,
+	ExpressLikeRequest,
+	ExpressLikeResponse,
+	ExpressMiddleware,
+} from "./@types.js";
+
+/**
+ * Create Express middleware from a WaniWani client.
+ *
+ * Returns `{ get, post, patch, options }` — each is an Express-compatible
+ * middleware (`(req, res, next) => void`). Mount on a router/path of your choice:
+ *
+ * ```ts
+ * import express from "express";
+ * import { waniwani } from "@waniwani/sdk";
+ * import { toExpressJsHandler } from "@waniwani/sdk/express-js";
+ *
+ * const wani = waniwani();
+ * const handler = toExpressJsHandler(wani, {
+ *   source: "my-app",
+ *   chat: { mcpServerUrl: process.env.MCP_SERVER_URL },
+ * });
+ *
+ * const app = express();
+ * // IMPORTANT: do NOT use express.json() on these routes — the adapter reads
+ * // the raw request body stream itself.
+ * app.get("/api/waniwani/*", handler.get);
+ * app.post("/api/waniwani", handler.post);
+ * app.patch("/api/waniwani/*", handler.patch);
+ * app.options("/api/waniwani/*", handler.options);
+ * ```
+ */
+export function toExpressJsHandler(
+	client: WaniWaniClient,
+	options: ExpressJsHandlerOptions,
+): ExpressJsHandlerResult {
+	const { apiKey, apiUrl } = client._config;
+	const debugEnabled = options?.debug ?? process.env.WANIWANI_DEBUG === "1";
+
+	const handler = createApiHandler({
+		...options?.chat,
+		apiKey,
+		apiUrl,
+		source: options?.source,
+		debug: debugEnabled,
+	});
+
+	return {
+		get: (req, res, next) => adapt(handler.routeGet, req, res, next),
+		post: (req, res, next) => adapt(handler.routePost, req, res, next),
+		patch: (req, res, next) => adapt(handler.routePatch, req, res, next),
+		options: (_req, res) => {
+			void sendWebResponse(handler.handleOptions(), res).catch((err) => {
+				console.error("[waniwani:express] OPTIONS handler error:", err);
+			});
+		},
+	};
+}
+
+async function adapt(
+	fn: (request: Request) => Promise<Response>,
+	req: ExpressLikeRequest,
+	res: ExpressLikeResponse,
+	next: (err?: unknown) => void,
+): Promise<void> {
+	try {
+		const webRequest = expressToWebRequest(req);
+		const webResponse = await fn(webRequest);
+		await sendWebResponse(webResponse, res);
+	} catch (err) {
+		next(err);
+	}
+}
+
+/**
+ * Build a Web `Request` from an Express request, preserving method, headers,
+ * URL, and body stream. Body is exposed as a `ReadableStream` so the underlying
+ * handlers can call `await request.text()` / `.json()` / pipe through.
+ */
+export function expressToWebRequest(req: ExpressLikeRequest): Request {
+	const protocol =
+		req.protocol ??
+		(typeof req.get === "function"
+			? req.get("x-forwarded-proto")
+			: undefined) ??
+		"http";
+	const host =
+		(typeof req.get === "function"
+			? req.get("host")
+			: (req.headers.host as string | undefined)) ?? "localhost";
+	const path = req.originalUrl ?? req.url;
+	const url = new URL(path, `${protocol}://${host}`).toString();
+
+	const headers = new Headers();
+	for (const [key, value] of Object.entries(req.headers)) {
+		if (value === undefined) {
+			continue;
+		}
+		if (Array.isArray(value)) {
+			for (const v of value) {
+				headers.append(key, v);
+			}
+		} else {
+			headers.set(key, value);
+		}
+	}
+
+	const init: RequestInit = { method: req.method, headers };
+
+	const method = req.method.toUpperCase();
+	if (method !== "GET" && method !== "HEAD") {
+		// Convert Node Readable → Web ReadableStream so fetch's Request can
+		// consume it. Cast to Node Readable: ExpressLikeRequest's `on` matches.
+		const nodeStream = req as unknown as Readable;
+		init.body = Readable.toWeb(
+			nodeStream,
+		) as unknown as ReadableStream<Uint8Array>;
+		// Fetch spec requires duplex: 'half' when sending a streaming body.
+		(init as RequestInit & { duplex: "half" }).duplex = "half";
+	}
+
+	return new Request(url, init);
+}
+
+/**
+ * Pipe a Web `Response` to an Express response. Status, headers, and body
+ * (including streaming bodies) are forwarded. Resolves once the body has been
+ * fully written and the response ended.
+ */
+export async function sendWebResponse(
+	webRes: Response,
+	res: ExpressLikeResponse,
+): Promise<void> {
+	res.statusCode = webRes.status;
+	webRes.headers.forEach((value, key) => {
+		res.setHeader(key, value);
+	});
+
+	if (!webRes.body) {
+		res.end();
+		return;
+	}
+
+	const nodeReadable = Readable.fromWeb(
+		webRes.body as unknown as import("node:stream/web").ReadableStream<Uint8Array>,
+	);
+
+	await new Promise<void>((resolve, reject) => {
+		nodeReadable.on("data", (chunk: Uint8Array | Buffer | string) => {
+			res.write(chunk);
+		});
+		nodeReadable.on("end", () => {
+			res.end();
+			resolve();
+		});
+		nodeReadable.on("error", (err) => {
+			reject(err);
+		});
+	});
+}

--- a/src/chat/server/next-js/@types.ts
+++ b/src/chat/server/next-js/@types.ts
@@ -1,52 +1,8 @@
 // WaniWani SDK - Next.js Adapter Types
 
-import type {
-	BeforeRequestContext,
-	BeforeRequestResult,
-	WebSearchConfig,
-} from "../@types.js";
+import type { ChatOptions } from "../@types.js";
 
-// ============================================================================
-// Chat Options (namespaced under `chat`)
-// ============================================================================
-
-export interface ChatOptions {
-	/**
-	 * System prompt for the assistant.
-	 * Can be overridden per-request via `beforeRequest`.
-	 */
-	systemPrompt?: string;
-
-	/**
-	 * Maximum number of tool call steps. Defaults to 5.
-	 */
-	maxSteps?: number;
-
-	/**
-	 * Hook called before each request is forwarded to the WaniWani API.
-	 * - Return void to use defaults.
-	 * - Return an object to override messages, systemPrompt, or sessionId.
-	 * - Throw to reject the request (the error message is returned as JSON).
-	 */
-	beforeRequest?: (
-		context: BeforeRequestContext,
-	) =>
-		| Promise<BeforeRequestResult | undefined>
-		| BeforeRequestResult
-		| undefined;
-
-	/**
-	 * Override the MCP server URL directly, bypassing config resolution.
-	 * Useful for development/testing when pointing to a local MCP server.
-	 */
-	mcpServerUrl?: string;
-
-	/**
-	 * Enable web search as an additional tool alongside MCP tools.
-	 * Pass `true` to enable with defaults, or a config object to restrict domains.
-	 */
-	webSearch?: boolean | WebSearchConfig;
-}
+export type { ChatOptions };
 
 // ============================================================================
 // Next.js Handler Options

--- a/src/chat/server/next-js/index.ts
+++ b/src/chat/server/next-js/index.ts
@@ -6,6 +6,8 @@ import type { NextJsHandlerOptions, NextJsHandlerResult } from "./@types.js";
 
 export type { NextJsHandlerOptions, NextJsHandlerResult } from "./@types.js";
 
+let deprecationWarned = false;
+
 /**
  * Create Next.js route handlers from a WaniWani client.
  *
@@ -14,6 +16,10 @@ export type { NextJsHandlerOptions, NextJsHandlerResult } from "./@types.js";
  *
  * - `POST /api/waniwani`              → chat (proxied to WaniWani API)
  * - `GET  /api/waniwani/resource?uri=…` → MCP resource content
+ *
+ * @deprecated Use `toExpressJsHandler` from `@waniwani/sdk/express-js` instead.
+ *   The Next.js-specific wrapper will be removed in a follow-up release. Both
+ *   adapters share the same underlying `createApiHandler`, so behavior is identical.
  *
  * @example
  * ```typescript
@@ -35,6 +41,13 @@ export function toNextJsHandler(
 	client: WaniWaniClient,
 	options: NextJsHandlerOptions,
 ): NextJsHandlerResult {
+	if (!deprecationWarned && process.env.NODE_ENV !== "test") {
+		console.warn(
+			"[waniwani-sdk] toNextJsHandler is deprecated; switch to toExpressJsHandler from @waniwani/sdk/express-js. It will be removed in a follow-up release.",
+		);
+		deprecationWarned = true;
+	}
+
 	const { apiKey, apiUrl } = client._config;
 
 	const debugEnabled = options?.debug ?? process.env.WANIWANI_DEBUG === "1";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -114,6 +114,24 @@ export default defineConfig([
 			"@modelcontextprotocol/sdk",
 		],
 	},
+	// Express adapter
+	{
+		entry: { "chat/express-js/index": "src/chat/server/express-js/index.ts" },
+		format: ["esm"],
+		target: "node20",
+		dts: true,
+		clean: false,
+		shims: true,
+		splitting: true,
+		sourcemap: true,
+		minify: true,
+		outDir: "dist",
+		external: [
+			"ai",
+			"@ai-sdk/mcp",
+			"@modelcontextprotocol/sdk",
+		],
+	},
 	// Knowledge Base (Node.js, server-side)
 	{
 		entry: { "kb/index": "src/kb/index.ts" },


### PR DESCRIPTION
## Summary
- New `toExpressJsHandler` export at `@waniwani/sdk/express-js` for Express middleware
- Marks `toNextJsHandler` deprecated with one-time runtime warning; behavior unchanged
- Adds tsup build entry, package export, and updates installation docs

## Test plan
- [ ] `bun run build` produces `dist/chat/express-js/`
- [ ] Existing next-js consumers still work and emit deprecation warning once

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new HTTP adaptation code that handles request/response streaming and raw bodies in Express, which can affect production routing/IO behavior if misused. Existing Next.js behavior should be unchanged aside from an added deprecation warning.
> 
> **Overview**
> Adds a new `@waniwani/sdk/express-js` entrypoint that wraps the existing `createApiHandler` in Express-compatible middleware (`get`/`post`/`patch`/`options`), including conversion between Express request/response streams and Web `Request`/`Response` (with streaming support) plus a Bun test suite covering routing, headers, body forwarding, streaming, and error propagation.
> 
> Refactors adapter typing by moving `ChatOptions` into `src/chat/server/@types.ts` and re-exporting it from the Next.js adapter, and marks `toNextJsHandler` as *deprecated* with a one-time `console.warn` (suppressed in tests). Updates package exports/build (new tsup entry, `package.json` export, version `0.11.1-beta.0`) and installation docs to recommend the Express adapter and note Next.js deprecation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ddee94aab29d69e2babc05f12e5a5fe9270a77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->