### PR TITLE
feat: remove trackFunnel, emit events for all nodes

### DIFF
--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -323,7 +323,7 @@ export type Edge<TState> =
 	| { type: "conditional"; condition: ConditionFn<TState> };
 
 export type NodeOptions = {
-	/** Human-readable label for this node (used in funnel visualization). */
+	/** Human-readable label for this node (used in funnel visualization and Graphs). */
 	label: string;
 	/** When true, this node is excluded from funnel analytics. */
 	hideFromFunnel?: boolean;

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -323,13 +323,17 @@ export type Edge<TState> =
 	| { type: "conditional"; condition: ConditionFn<TState> };
 
 export type NodeOptions = {
-	trackLabel?: string;
+	/** Human-readable label for this node (used in funnel visualization). */
+	label: string;
+	/** When true, this node is excluded from funnel analytics. */
+	hideFromFunnel?: boolean;
 };
 
 export type FlowGraphNode = {
 	id: string;
 	type: "widget" | "interrupt" | "action";
-	trackLabel?: string;
+	label: string;
+	hideFromFunnel?: boolean;
 };
 
 export type FlowGraphEdge =

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -323,13 +323,13 @@ export type Edge<TState> =
 	| { type: "conditional"; condition: ConditionFn<TState> };
 
 export type NodeOptions = {
-	trackFunnel?: true | string;
+	trackFunnel?: string;
 };
 
 export type FlowGraphNode = {
 	id: string;
 	type: "widget" | "interrupt" | "action";
-	trackFunnel: false | true | string;
+	trackFunnel: false | string;
 };
 
 export type FlowGraphEdge =

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -323,13 +323,13 @@ export type Edge<TState> =
 	| { type: "conditional"; condition: ConditionFn<TState> };
 
 export type NodeOptions = {
-	trackFunnel?: string;
+	trackLabel?: string;
 };
 
 export type FlowGraphNode = {
 	id: string;
 	type: "widget" | "interrupt" | "action";
-	trackFunnel: false | string;
+	trackLabel?: string;
 };
 
 export type FlowGraphEdge =

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -129,7 +129,6 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				validators,
 				meta,
 				waniwani,
-				input.nodeOptions,
 				config.id,
 			);
 		}
@@ -203,7 +202,6 @@ export function compileFlow<TState extends Record<string, unknown>>(
 					validators,
 					meta,
 					waniwani,
-					input.nodeOptions,
 					config.id,
 				);
 			}
@@ -219,7 +217,6 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				validators,
 				meta,
 				waniwani,
-				input.nodeOptions,
 				config.id,
 			);
 		}
@@ -288,7 +285,6 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				validators,
 				meta,
 				waniwani,
-				input.nodeOptions,
 				config.id,
 			);
 		}

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -129,6 +129,7 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				validators,
 				meta,
 				waniwani,
+				input.nodeOptions,
 				config.id,
 			);
 		}
@@ -202,6 +203,7 @@ export function compileFlow<TState extends Record<string, unknown>>(
 					validators,
 					meta,
 					waniwani,
+					input.nodeOptions,
 					config.id,
 				);
 			}
@@ -217,6 +219,7 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				validators,
 				meta,
 				waniwani,
+				input.nodeOptions,
 				config.id,
 			);
 		}
@@ -285,6 +288,7 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				validators,
 				meta,
 				waniwani,
+				input.nodeOptions,
 				config.id,
 			);
 		}

--- a/src/mcp/server/flows/execute.ts
+++ b/src/mcp/server/flows/execute.ts
@@ -5,7 +5,6 @@ import type {
 	InterruptQuestionData,
 	MaybePromise,
 	NodeHandler,
-	NodeOptions,
 } from "./@types";
 import { END, interrupt, isInterrupt, isWidget, showWidget } from "./@types";
 import { deepMerge, deleteNestedValue, getNestedValue } from "./nested";
@@ -109,7 +108,6 @@ export async function executeFrom<TState extends Record<string, unknown>>(
 	validators: Map<string, ValidateFn>,
 	meta?: Record<string, unknown>,
 	waniwani?: ScopedWaniWaniClient,
-	nodeOptions?: Map<string, NodeOptions>,
 	flowId?: string,
 ): Promise<ExecutionResult> {
 	let currentNode = startNodeName;

--- a/src/mcp/server/flows/execute.ts
+++ b/src/mcp/server/flows/execute.ts
@@ -138,8 +138,7 @@ export async function executeFrom<TState extends Record<string, unknown>>(
 			};
 		}
 
-		const opts = nodeOptions?.get(currentNode);
-		if (opts?.trackFunnel && waniwani) {
+		if (waniwani) {
 			waniwani
 				.track({
 					event: "flow.node_reached",

--- a/src/mcp/server/flows/execute.ts
+++ b/src/mcp/server/flows/execute.ts
@@ -5,6 +5,7 @@ import type {
 	InterruptQuestionData,
 	MaybePromise,
 	NodeHandler,
+	NodeOptions,
 } from "./@types";
 import { END, interrupt, isInterrupt, isWidget, showWidget } from "./@types";
 import { deepMerge, deleteNestedValue, getNestedValue } from "./nested";
@@ -108,6 +109,7 @@ export async function executeFrom<TState extends Record<string, unknown>>(
 	validators: Map<string, ValidateFn>,
 	meta?: Record<string, unknown>,
 	waniwani?: ScopedWaniWaniClient,
+	nodeOptions?: Map<string, NodeOptions>,
 	flowId?: string,
 ): Promise<ExecutionResult> {
 	let currentNode = startNodeName;
@@ -136,7 +138,7 @@ export async function executeFrom<TState extends Record<string, unknown>>(
 			};
 		}
 
-		if (waniwani) {
+		if (waniwani && !nodeOptions?.get(currentNode)?.hideFromFunnel) {
 			waniwani
 				.track({
 					event: "flow.node_reached",

--- a/src/mcp/server/flows/graph-extract.ts
+++ b/src/mcp/server/flows/graph-extract.ts
@@ -57,7 +57,7 @@ export function extractFlowGraph<TState extends Record<string, unknown>>(
 		graphNodes.push({
 			id,
 			type: classifyNode(handler),
-			trackFunnel: opts?.trackFunnel ?? false,
+			...(opts?.trackLabel ? { trackLabel: opts.trackLabel } : {}),
 		});
 	}
 

--- a/src/mcp/server/flows/graph-extract.ts
+++ b/src/mcp/server/flows/graph-extract.ts
@@ -57,7 +57,8 @@ export function extractFlowGraph<TState extends Record<string, unknown>>(
 		graphNodes.push({
 			id,
 			type: classifyNode(handler),
-			...(opts?.trackLabel ? { trackLabel: opts.trackLabel } : {}),
+			label: opts?.label ?? id,
+			...(opts?.hideFromFunnel ? { hideFromFunnel: true } : {}),
 		});
 	}
 


### PR DESCRIPTION
## Summary

- Remove `trackFunnel` from `FlowGraphNode` type and `NodeOptions`
- Stop filtering `flow.node_reached` events — emit for all nodes during flow execution
- Graph extraction no longer includes `trackFunnel` in synced payload

This is the SDK-side of the funnel V1 redesign. Funnel configuration moves from the SDK to the WaniWani app, where product teams configure which nodes to track and how to group them into steps.

## Test plan

- [ ] `bun run build` passes
- [ ] `bun test` passes (186 tests)
- [ ] Backward compatible: old SDK clients with `trackFunnel` still work (backend ignores the field)
- [ ] Verify `flow.node_reached` events are emitted for every node during flow execution