### PR TITLE
feat(react): opt-in toggles for noisy auto-capture events

### DIFF
--- a/src/mcp/react/hooks/auto-capture.ts
+++ b/src/mcp/react/hooks/auto-capture.ts
@@ -146,13 +146,23 @@ export function initAutoCapture(
 
 	// ── widget_click ───────────────────────────────────────────────────
 	// Opt-in. Even when enabled, skip when target sits inside a labelled
-	// element since the matching data-ww-step / data-ww-conversion handler
-	// already records a typed event.
+	// element with a non-empty parsed name, mirroring the typed handlers
+	// below. An empty `data-ww-conversion=""` falls through here so the
+	// click is not silently dropped.
 	if (config.capture?.click) {
 		const onClick = (ev: MouseEvent) => {
 			const target = ev.target as HTMLElement | null;
-			if (target?.closest?.("[data-ww-conversion],[data-ww-step]")) {
-				return;
+			const labelled = target?.closest?.(
+				"[data-ww-conversion],[data-ww-step]",
+			) as HTMLElement | null;
+			if (labelled) {
+				const raw =
+					labelled.getAttribute("data-ww-conversion") ??
+					labelled.getAttribute("data-ww-step") ??
+					"";
+				if (parseAttr(raw).name) {
+					return;
+				}
 			}
 			enqueue([
 				baseFields(config, "widget_click", {

--- a/src/mcp/react/hooks/auto-capture.ts
+++ b/src/mcp/react/hooks/auto-capture.ts
@@ -4,11 +4,26 @@ import type { WidgetEvent } from "./widget-transport";
 
 type Enqueue = (events: WidgetEvent[]) => void;
 
+/**
+ * Opt-in toggles for the noisy auto-capture event types. Each defaults to
+ * `false` so widget owners declare intent before the SDK starts emitting
+ * coarse, high-volume events. Always-on capture covers widget_render,
+ * widget_error, widget_link_click, and the labelled `data-ww-step` /
+ * `data-ww-conversion` clicks.
+ */
+export interface AutoCaptureToggles {
+	click?: boolean;
+	scroll?: boolean;
+	formField?: boolean;
+	formSubmit?: boolean;
+}
+
 interface AutoCaptureConfig {
 	sessionId?: string;
 	traceId?: string;
 	metadata?: Record<string, unknown>;
 	source?: string;
+	capture?: AutoCaptureToggles;
 }
 
 function eventId(): string {
@@ -130,24 +145,32 @@ export function initAutoCapture(
 	);
 
 	// ── widget_click ───────────────────────────────────────────────────
-	const onClick = (ev: MouseEvent) => {
-		const target = ev.target as HTMLElement | null;
-		enqueue([
-			baseFields(config, "widget_click", {
-				metadata: {
-					target_tag: target?.tagName?.toLowerCase() ?? "unknown",
-					target_id: target?.id || undefined,
-					target_class: target?.className || undefined,
-					click_x: ev.clientX,
-					click_y: ev.clientY,
-				},
-			}),
-		]);
-	};
-	document.addEventListener("click", onClick, { capture: true });
-	cleanups.push(() =>
-		document.removeEventListener("click", onClick, { capture: true }),
-	);
+	// Opt-in. Even when enabled, skip when target sits inside a labelled
+	// element since the matching data-ww-step / data-ww-conversion handler
+	// already records a typed event.
+	if (config.capture?.click) {
+		const onClick = (ev: MouseEvent) => {
+			const target = ev.target as HTMLElement | null;
+			if (target?.closest?.("[data-ww-conversion],[data-ww-step]")) {
+				return;
+			}
+			enqueue([
+				baseFields(config, "widget_click", {
+					metadata: {
+						target_tag: target?.tagName?.toLowerCase() ?? "unknown",
+						target_id: target?.id || undefined,
+						target_class: target?.className || undefined,
+						click_x: ev.clientX,
+						click_y: ev.clientY,
+					},
+				}),
+			]);
+		};
+		document.addEventListener("click", onClick, { capture: true });
+		cleanups.push(() =>
+			document.removeEventListener("click", onClick, { capture: true }),
+		);
+	}
 
 	// ── data-ww-conversion ────────────────────────────────────────────
 	// Format: "name key:value key:value ..."
@@ -235,124 +258,133 @@ export function initAutoCapture(
 	);
 
 	// ── widget_scroll ──────────────────────────────────────────────────
-	let scrollTimer: ReturnType<typeof setTimeout> | null = null;
-	let lastScrollY = window.scrollY || 0;
-	const onScroll = () => {
-		if (scrollTimer) {
-			return;
-		}
-		scrollTimer = setTimeout(() => {
-			scrollTimer = null;
-			const scrollTop = window.scrollY || document.documentElement.scrollTop;
-			const docHeight =
-				document.documentElement.scrollHeight -
-				document.documentElement.clientHeight;
-			const depthPct =
-				docHeight > 0 ? Math.round((scrollTop / docHeight) * 100) : 0;
-			const direction = scrollTop >= lastScrollY ? "down" : "up";
-			lastScrollY = scrollTop;
+	// Opt-in.
+	if (config.capture?.scroll) {
+		let scrollTimer: ReturnType<typeof setTimeout> | null = null;
+		let lastScrollY = window.scrollY || 0;
+		const onScroll = () => {
+			if (scrollTimer) {
+				return;
+			}
+			scrollTimer = setTimeout(() => {
+				scrollTimer = null;
+				const scrollTop = window.scrollY || document.documentElement.scrollTop;
+				const docHeight =
+					document.documentElement.scrollHeight -
+					document.documentElement.clientHeight;
+				const depthPct =
+					docHeight > 0 ? Math.round((scrollTop / docHeight) * 100) : 0;
+				const direction = scrollTop >= lastScrollY ? "down" : "up";
+				lastScrollY = scrollTop;
+				enqueue([
+					baseFields(config, "widget_scroll", {
+						metadata: {
+							scroll_depth_pct: depthPct,
+							scroll_direction: direction,
+							viewport_height: window.innerHeight,
+						},
+					}),
+				]);
+			}, 250);
+		};
+		window.addEventListener("scroll", onScroll, { passive: true });
+		cleanups.push(() => {
+			window.removeEventListener("scroll", onScroll);
+			if (scrollTimer) {
+				clearTimeout(scrollTimer);
+			}
+		});
+	}
+
+	// ── widget_form_field ──────────────────────────────────────────────
+	// Opt-in.
+	if (config.capture?.formField) {
+		const fieldTimers = new WeakMap<EventTarget, number>();
+
+		const onFocusIn = (ev: FocusEvent) => {
+			const target = ev.target as HTMLElement | null;
+			if (!target || !isFormField(target)) {
+				return;
+			}
+			fieldTimers.set(target, Date.now());
+		};
+		const onFocusOut = (ev: FocusEvent) => {
+			const target = ev.target as HTMLElement | null;
+			if (!target || !isFormField(target)) {
+				return;
+			}
+			const start = fieldTimers.get(target);
+			const timeInField = start ? Date.now() - start : 0;
+			const input = target as HTMLInputElement;
 			enqueue([
-				baseFields(config, "widget_scroll", {
+				baseFields(config, "widget_form_field", {
 					metadata: {
-						scroll_depth_pct: depthPct,
-						scroll_direction: direction,
-						viewport_height: window.innerHeight,
+						field_name: input.name || input.id || undefined,
+						field_type: input.type || target.tagName.toLowerCase(),
+						time_in_field_ms: timeInField,
+						filled: !!input.value,
 					},
 				}),
 			]);
-		}, 250);
-	};
-	window.addEventListener("scroll", onScroll, { passive: true });
-	cleanups.push(() => {
-		window.removeEventListener("scroll", onScroll);
-		if (scrollTimer) {
-			clearTimeout(scrollTimer);
-		}
-	});
-
-	// ── widget_form_field ──────────────────────────────────────────────
-	const fieldTimers = new WeakMap<EventTarget, number>();
-
-	const onFocusIn = (ev: FocusEvent) => {
-		const target = ev.target as HTMLElement | null;
-		if (!target || !isFormField(target)) {
-			return;
-		}
-		fieldTimers.set(target, Date.now());
-	};
-	const onFocusOut = (ev: FocusEvent) => {
-		const target = ev.target as HTMLElement | null;
-		if (!target || !isFormField(target)) {
-			return;
-		}
-		const start = fieldTimers.get(target);
-		const timeInField = start ? Date.now() - start : 0;
-		const input = target as HTMLInputElement;
-		enqueue([
-			baseFields(config, "widget_form_field", {
-				metadata: {
-					field_name: input.name || input.id || undefined,
-					field_type: input.type || target.tagName.toLowerCase(),
-					time_in_field_ms: timeInField,
-					filled: !!input.value,
-				},
-			}),
-		]);
-	};
-	document.addEventListener("focusin", onFocusIn, { capture: true });
-	document.addEventListener("focusout", onFocusOut, { capture: true });
-	cleanups.push(() => {
-		document.removeEventListener("focusin", onFocusIn, { capture: true });
-		document.removeEventListener("focusout", onFocusOut, { capture: true });
-	});
+		};
+		document.addEventListener("focusin", onFocusIn, { capture: true });
+		document.addEventListener("focusout", onFocusOut, { capture: true });
+		cleanups.push(() => {
+			document.removeEventListener("focusin", onFocusIn, { capture: true });
+			document.removeEventListener("focusout", onFocusOut, { capture: true });
+		});
+	}
 
 	// ── widget_form_submit ─────────────────────────────────────────────
-	const formStartTimes = new WeakMap<HTMLFormElement, number>();
-	const trackFormStart = (ev: FocusEvent) => {
-		const target = ev.target as HTMLElement | null;
-		const form = target?.closest?.("form");
-		if (form && !formStartTimes.has(form)) {
-			formStartTimes.set(form, Date.now());
-		}
-	};
-	document.addEventListener("focusin", trackFormStart, { capture: true });
-	cleanups.push(() =>
-		document.removeEventListener("focusin", trackFormStart, {
-			capture: true,
-		}),
-	);
+	// Opt-in.
+	if (config.capture?.formSubmit) {
+		const formStartTimes = new WeakMap<HTMLFormElement, number>();
+		const trackFormStart = (ev: FocusEvent) => {
+			const target = ev.target as HTMLElement | null;
+			const form = target?.closest?.("form");
+			if (form && !formStartTimes.has(form)) {
+				formStartTimes.set(form, Date.now());
+			}
+		};
+		document.addEventListener("focusin", trackFormStart, { capture: true });
+		cleanups.push(() =>
+			document.removeEventListener("focusin", trackFormStart, {
+				capture: true,
+			}),
+		);
 
-	const onSubmit = (ev: SubmitEvent) => {
-		const form = ev.target as HTMLFormElement | null;
-		const startTime = form ? formStartTimes.get(form) : undefined;
+		const onSubmit = (ev: SubmitEvent) => {
+			const form = ev.target as HTMLFormElement | null;
+			const startTime = form ? formStartTimes.get(form) : undefined;
 
-		let validationErrors = 0;
-		if (form) {
-			const fields = form.querySelectorAll("input, textarea, select");
-			for (const field of fields) {
-				const el = field as HTMLInputElement;
-				if (el.validity && !el.validity.valid) {
-					validationErrors++;
-				} else if (el.getAttribute("aria-invalid") === "true") {
-					validationErrors++;
+			let validationErrors = 0;
+			if (form) {
+				const fields = form.querySelectorAll("input, textarea, select");
+				for (const field of fields) {
+					const el = field as HTMLInputElement;
+					if (el.validity && !el.validity.valid) {
+						validationErrors++;
+					} else if (el.getAttribute("aria-invalid") === "true") {
+						validationErrors++;
+					}
 				}
 			}
-		}
 
-		enqueue([
-			baseFields(config, "widget_form_submit", {
-				metadata: {
-					form_id: form?.id || undefined,
-					time_to_submit_ms: startTime ? Date.now() - startTime : undefined,
-					validation_errors: validationErrors,
-				},
-			}),
-		]);
-	};
-	document.addEventListener("submit", onSubmit, { capture: true });
-	cleanups.push(() =>
-		document.removeEventListener("submit", onSubmit, { capture: true }),
-	);
+			enqueue([
+				baseFields(config, "widget_form_submit", {
+					metadata: {
+						form_id: form?.id || undefined,
+						time_to_submit_ms: startTime ? Date.now() - startTime : undefined,
+						validation_errors: validationErrors,
+					},
+				}),
+			]);
+		};
+		document.addEventListener("submit", onSubmit, { capture: true });
+		cleanups.push(() =>
+			document.removeEventListener("submit", onSubmit, { capture: true }),
+		);
+	}
 
 	return () => {
 		for (const cleanup of cleanups) {

--- a/src/mcp/react/hooks/use-waniwani.ts
+++ b/src/mcp/react/hooks/use-waniwani.ts
@@ -87,6 +87,7 @@ interface WidgetState {
 	widget: WaniwaniWidget;
 	cleanup: () => void;
 	config: WaniwaniConfig | null;
+	captureKey: string;
 }
 
 /** Module-level singleton — shared across all hook consumers. */
@@ -106,7 +107,24 @@ function normalizeString(value: unknown): string | undefined {
 }
 
 function createNoopState(): WidgetState {
-	return { widget: NOOP_WIDGET, cleanup: () => {}, config: null };
+	return {
+		widget: NOOP_WIDGET,
+		cleanup: () => {},
+		config: null,
+		captureKey: "",
+	};
+}
+
+function captureKeyOf(capture?: AutoCaptureToggles): string {
+	if (!capture) {
+		return "";
+	}
+	return [
+		capture.click ? "1" : "0",
+		capture.scroll ? "1" : "0",
+		capture.formField ? "1" : "0",
+		capture.formSubmit ? "1" : "0",
+	].join("");
 }
 
 /**
@@ -229,6 +247,7 @@ function createState(
 	}
 
 	return {
+		captureKey: captureKeyOf(capture),
 		widget: {
 			identify(id: string, traits?: Record<string, unknown>) {
 				userId = id;
@@ -325,6 +344,7 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 	metadataRef.current = options.metadata;
 	const captureRef = useRef(options.capture);
 	captureRef.current = options.capture;
+	const captureKey = captureKeyOf(options.capture);
 
 	// Track consumer mount/unmount for singleton lifecycle
 	useEffect(() => {
@@ -355,12 +375,15 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 			return;
 		}
 
-		if (!isSameConfig(state?.config, config)) {
+		if (
+			!isSameConfig(state?.config, config) ||
+			state?.captureKey !== captureKey
+		) {
 			state?.cleanup();
 			state = createState(config, metadataRef.current, captureRef.current);
 			setWidget(state.widget);
 		}
-	}, [config]);
+	}, [config, captureKey]);
 
 	return widget;
 }

--- a/src/mcp/react/hooks/use-waniwani.ts
+++ b/src/mcp/react/hooks/use-waniwani.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
-import { initAutoCapture } from "./auto-capture";
+import { type AutoCaptureToggles, initAutoCapture } from "./auto-capture";
 import { WidgetClientContext } from "./use-widget";
 import type { WidgetEvent } from "./widget-transport";
 import { WidgetTransport } from "./widget-transport";
@@ -50,6 +50,15 @@ export interface UseWaniwaniOptions {
 	 * Additional metadata to include with every tracked event.
 	 */
 	metadata?: Record<string, unknown>;
+	/**
+	 * Opt-in toggles for noisy auto-capture event types. Default: all off.
+	 * Always-on capture: widget_render, widget_error, widget_link_click,
+	 * `data-ww-step` / `data-ww-conversion` clicks.
+	 *
+	 * @example
+	 * useWaniwani({ capture: { click: true, scroll: true } });
+	 */
+	capture?: AutoCaptureToggles;
 }
 
 /**
@@ -179,6 +188,7 @@ function useContextConfig(
 function createState(
 	config: WaniwaniConfig,
 	metadata?: Record<string, unknown>,
+	capture?: AutoCaptureToggles,
 ): WidgetState {
 	const sessionId = config.sessionId ?? crypto.randomUUID();
 	const traceId = crypto.randomUUID();
@@ -198,7 +208,7 @@ function createState(
 	const source = config.source ?? "widget";
 
 	const cleanupCapture = initAutoCapture(
-		{ sessionId, traceId, metadata, source },
+		{ sessionId, traceId, metadata, source, capture },
 		enqueue,
 	);
 
@@ -313,6 +323,8 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 	const [widget, setWidget] = useState<WaniwaniWidget>(NOOP_WIDGET);
 	const metadataRef = useRef(options.metadata);
 	metadataRef.current = options.metadata;
+	const captureRef = useRef(options.capture);
+	captureRef.current = options.capture;
 
 	// Track consumer mount/unmount for singleton lifecycle
 	useEffect(() => {
@@ -345,7 +357,7 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 
 		if (!isSameConfig(state?.config, config)) {
 			state?.cleanup();
-			state = createState(config, metadataRef.current);
+			state = createState(config, metadataRef.current, captureRef.current);
 			setWidget(state.widget);
 		}
 	}, [config]);


### PR DESCRIPTION
## Summary
- Add \`capture\` toggles to \`useWaniwani\` (click, scroll, formField, formSubmit). All default off.
- Always-on: \`widget_render\`, \`widget_error\`, \`widget_link_click\`, and labelled \`data-ww-step\` / \`data-ww-conversion\` clicks.
- When click capture is enabled, skip targets inside labelled elements to avoid duplicate events.

## Test plan
- [x] Verify no events fire by default beyond always-on set
- [x] Enable each toggle, confirm corresponding events fire
- [x] Confirm clicks inside \`data-ww-step\` / \`data-ww-conversion\` only emit typed event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes client-side event collection behavior and listener lifecycles; misconfiguration could lead to missing analytics or unexpected event volume.
> 
> **Overview**
> Adds a new `capture` option to `useWaniwani` (and `initAutoCapture`) so high-volume auto-capture events—`widget_click`, `widget_scroll`, `widget_form_field`, and `widget_form_submit`—are **disabled by default** and only enabled when explicitly toggled.
> 
> Updates click capture to avoid duplicate tracking by skipping generic `widget_click` events when the target is inside a labelled `data-ww-step`/`data-ww-conversion` element (unless the label is empty), and makes the singleton widget instance recreate when capture toggles change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2789785518e5756067706fd1bcf2d1064f5fc66c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->