### PR TITLE
fix(react): only rewrite relative fetches inside widget iframe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.11.1",
+  "version": "0.11.1-cors-fix",
   "description": "WaniWani SDK - MCP event tracking, widget framework, and tools",
   "type": "module",
   "exports": {

--- a/skills/waniwani-sdk/references/widget-react-hooks.md
+++ b/skills/waniwani-sdk/references/widget-react-hooks.md
@@ -52,7 +52,7 @@ Patches Next.js so the app works correctly inside a cross-origin iframe (ChatGPT
 
 **What it patches:**
 - `history.pushState` / `replaceState` -- prevents cross-origin URL errors in sandboxed iframes
-- `window.fetch` -- rewrites same-origin requests to the widget's real `baseUrl` so relative `/api/...` calls don't 404
+- `window.fetch` -- rewrites *relative* same-origin requests to the widget's real `baseUrl` so relative `/api/...` calls don't 404. Absolute URLs (string with scheme, `URL`, `Request`) are left alone, so SDK transports can hit the WaniWani API even when it shares an origin with the iframe.
 - `<html>` attribute observer -- strips host-injected attributes while preserving `class`/`style`/`lang`
 
 ```tsx
@@ -63,10 +63,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <head>
-        <InitializeNextJsInIframe
-          baseUrl={process.env.NEXT_PUBLIC_BASE_URL!}
-          passthroughOrigins={[process.env.NEXT_PUBLIC_WANIWANI_API_URL ?? "https://app.waniwani.ai"]}
-        />
+        <InitializeNextJsInIframe baseUrl={process.env.NEXT_PUBLIC_BASE_URL!} />
       </head>
       <body>{children}</body>
     </html>
@@ -79,7 +76,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 | Prop | Type | Required | Description |
 |------|------|----------|-------------|
 | `baseUrl` | `string` | Yes | The widget app's canonical URL (e.g. `https://my-app.com`) |
-| `passthroughOrigins` | `string[]` | No | Origins whose fetches skip the rewrite (e.g. WaniWani API origin when widget shares origin with a proxy) |
+| `passthroughOrigins` | `string[]` | No | Origins whose *relative-URL* fetches skip the rewrite. Absolute URLs are never rewritten, so most callers don't need this. |
 
 ## Hooks Reference
 

--- a/src/mcp/react/components/__tests__/initialize-next-in-iframe.test.ts
+++ b/src/mcp/react/components/__tests__/initialize-next-in-iframe.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
+
+import { applyIframePatches } from "../initialize-next-in-iframe";
+
+const IFRAME_ORIGIN = "http://iframe-host:3000";
+const APP_ORIGIN = "http://app-host:3001";
+const WANIWANI_ORIGIN = "http://api-host:3000";
+
+let win: InstanceType<typeof GlobalWindow>;
+let originalFetch: ReturnType<typeof mock>;
+
+function setup(passthroughOrigins: string[] = []) {
+	win = new GlobalWindow({ url: `${IFRAME_ORIGIN}/widget` });
+	globalThis.window = win as unknown as typeof globalThis.window;
+	globalThis.document = win.document as unknown as typeof globalThis.document;
+	globalThis.history = win.history as unknown as typeof globalThis.history;
+	globalThis.MutationObserver =
+		win.MutationObserver as unknown as typeof globalThis.MutationObserver;
+
+	// Force `window.self !== window.top` so the patch installs the fetch wrapper.
+	Object.defineProperty(win, "top", { value: {}, writable: true });
+
+	(win as unknown as { innerBaseUrl: string }).innerBaseUrl = APP_ORIGIN;
+	(
+		win as unknown as { __wwPassthroughOrigins: string[] }
+	).__wwPassthroughOrigins = passthroughOrigins;
+
+	originalFetch = mock(() =>
+		Promise.resolve(new Response("{}", { status: 200 })),
+	);
+	(win as unknown as { fetch: typeof fetch }).fetch =
+		originalFetch as unknown as typeof fetch;
+
+	applyIframePatches();
+}
+
+afterEach(() => {
+	originalFetch.mockClear();
+	win.close();
+});
+
+describe("applyIframePatches fetch wrapper", () => {
+	test("rewrites relative URL to baseUrl", async () => {
+		setup();
+
+		await win.fetch("/api/upload");
+
+		expect(originalFetch).toHaveBeenCalledTimes(1);
+		const [url, init] = originalFetch.mock.calls[0];
+		expect(url).toBe(`${APP_ORIGIN}/api/upload`);
+		expect((init as RequestInit | undefined)?.mode).toBe("cors");
+	});
+
+	test("does NOT rewrite absolute URL pointing at iframe origin (the key fix)", async () => {
+		setup();
+
+		const target = `${IFRAME_ORIGIN}/api/mcp/events/v2/batch`;
+		await win.fetch(target);
+
+		expect(originalFetch).toHaveBeenCalledTimes(1);
+		const [url] = originalFetch.mock.calls[0];
+		expect(url).toBe(target);
+	});
+
+	test("does NOT rewrite absolute URL to a third-party origin", async () => {
+		setup();
+
+		const target = `${WANIWANI_ORIGIN}/api/mcp/events/v2/batch`;
+		await win.fetch(target);
+
+		expect(originalFetch).toHaveBeenCalledTimes(1);
+		const [url] = originalFetch.mock.calls[0];
+		expect(url).toBe(target);
+	});
+
+	test("absolute URL matching appOrigin gets mode:cors but URL unchanged", async () => {
+		setup();
+
+		const target = `${APP_ORIGIN}/api/something`;
+		await win.fetch(target);
+
+		expect(originalFetch).toHaveBeenCalledTimes(1);
+		const [url, init] = originalFetch.mock.calls[0];
+		expect(url).toBe(target);
+		expect((init as RequestInit | undefined)?.mode).toBe("cors");
+	});
+
+	test("URL instance is never rewritten, even for same-origin path", async () => {
+		setup();
+
+		const target = new URL("/api/upload", IFRAME_ORIGIN);
+		await win.fetch(target);
+
+		expect(originalFetch).toHaveBeenCalledTimes(1);
+		const [url] = originalFetch.mock.calls[0];
+		expect(String(url)).toBe(target.toString());
+	});
+
+	test("protocol-relative URL is treated as absolute", async () => {
+		setup();
+
+		const target = "//api-host:3000/track";
+		await win.fetch(target);
+
+		expect(originalFetch).toHaveBeenCalledTimes(1);
+		const [url] = originalFetch.mock.calls[0];
+		expect(url).toBe(target);
+	});
+
+	test("relative URL whose origin is in passthroughOrigins skips rewrite", async () => {
+		setup([IFRAME_ORIGIN]);
+
+		await win.fetch("/api/upload");
+
+		expect(originalFetch).toHaveBeenCalledTimes(1);
+		const [url, init] = originalFetch.mock.calls[0];
+		expect(url).toBe("/api/upload");
+		expect((init as RequestInit | undefined)?.mode).toBeUndefined();
+	});
+
+	test("relative URL with query and hash is preserved when rewritten", async () => {
+		setup();
+
+		await win.fetch("/api/items?page=2#top");
+
+		expect(originalFetch).toHaveBeenCalledTimes(1);
+		const [url] = originalFetch.mock.calls[0];
+		expect(url).toBe(`${APP_ORIGIN}/api/items?page=2#top`);
+	});
+});

--- a/src/mcp/react/components/initialize-next-in-iframe.tsx
+++ b/src/mcp/react/components/initialize-next-in-iframe.tsx
@@ -1,22 +1,193 @@
 /**
+ * Patches `history`, `<html>` mutations and `window.fetch` so a Next.js
+ * widget can run inside a cross-origin iframe host. Reads its config from
+ * `window.innerBaseUrl` and `window.__wwPassthroughOrigins`, which the
+ * surrounding `<script>` tags set before this runs.
+ *
+ * Exported so tests can drive it directly. Production code never imports
+ * it — the component below stringifies it into the SSR HTML.
+ */
+export function applyIframePatches(): void {
+	const baseUrl = window.innerBaseUrl;
+	const passthroughOrigins: string[] =
+		(window as unknown as { __wwPassthroughOrigins: string[] })
+			.__wwPassthroughOrigins ?? [];
+	const htmlElement = document.documentElement;
+	const observer = new MutationObserver((mutations) => {
+		mutations.forEach((mutation) => {
+			if (mutation.type === "attributes" && mutation.target === htmlElement) {
+				const attrName = mutation.attributeName;
+				// Preserve class/style for theming (html.dark) and lang for i18n
+				if (
+					attrName &&
+					attrName !== "suppresshydrationwarning" &&
+					attrName !== "lang" &&
+					attrName !== "class" &&
+					attrName !== "style"
+				) {
+					htmlElement.removeAttribute(attrName);
+				}
+			}
+		});
+	});
+	observer.observe(htmlElement, {
+		attributes: true,
+		attributeOldValue: true,
+	});
+
+	const originalReplaceState = history.replaceState.bind(history);
+	history.replaceState = (
+		_s: unknown,
+		unused: string,
+		url?: string | URL | null,
+	) => {
+		try {
+			const u = new URL(String(url ?? ""), window.location.href);
+			originalReplaceState(null, unused, u.pathname + u.search + u.hash);
+		} catch {
+			/* SecurityError in sandboxed iframe */
+		}
+	};
+
+	const originalPushState = history.pushState.bind(history);
+	history.pushState = (
+		_s: unknown,
+		unused: string,
+		url?: string | URL | null,
+	) => {
+		try {
+			const u = new URL(String(url ?? ""), window.location.href);
+			originalPushState(null, unused, u.pathname + u.search + u.hash);
+		} catch {
+			/* SecurityError in sandboxed iframe */
+		}
+	};
+
+	const appOrigin = new URL(baseUrl).origin;
+	const isInIframe = window.self !== window.top;
+
+	window.addEventListener(
+		"click",
+		(e) => {
+			const a = (e?.target as HTMLElement)?.closest("a");
+			if (!a || !a.href) {
+				return;
+			}
+			const url = new URL(a.href, window.location.href);
+			if (url.origin !== window.location.origin && url.origin !== appOrigin) {
+				try {
+					if (window.openai) {
+						window.openai?.openExternal({ href: a.href });
+						e.preventDefault();
+					}
+				} catch {
+					console.warn("openExternal failed, likely not in OpenAI client");
+				}
+			}
+		},
+		true,
+	);
+
+	if (isInIframe && window.location.origin !== appOrigin) {
+		const originalFetch = window.fetch;
+
+		(window as { fetch: typeof window.fetch }).fetch = ((
+			input: URL | RequestInfo,
+			init?: RequestInit,
+		): Promise<Response> => {
+			// Only string inputs without a scheme (or `//host`) are treated
+			// as relative. URL/Request instances are always absolute, so
+			// the caller already chose the target host.
+			const isRelativeString =
+				typeof input === "string" &&
+				!/^[a-z][a-z0-9+.-]*:/i.test(input) &&
+				!input.startsWith("//");
+
+			let url: URL;
+			if (typeof input === "string" || input instanceof URL) {
+				url = new URL(input, window.location.href);
+			} else {
+				url = new URL(input.url, window.location.href);
+			}
+
+			if (url.origin === appOrigin) {
+				if (typeof input === "string" || input instanceof URL) {
+					input = url.toString();
+				} else {
+					input = new Request(url.toString(), input);
+				}
+
+				return originalFetch.call(window, input, {
+					...init,
+					mode: "cors",
+				});
+			}
+
+			if (passthroughOrigins.indexOf(url.origin) !== -1) {
+				return originalFetch.call(window, input, init);
+			}
+
+			// Rewrite *relative* same-origin requests to the widget's real
+			// `baseUrl`. Absolute URLs are left alone — they're the
+			// caller's explicit target (e.g. SDK transport posting to the
+			// WaniWani API on the same origin as the iframe).
+			if (isRelativeString && url.origin === window.location.origin) {
+				const newUrl = new URL(baseUrl);
+				newUrl.pathname = url.pathname;
+				newUrl.search = url.search;
+				newUrl.hash = url.hash;
+				url = newUrl;
+				input = url.toString();
+
+				return originalFetch.call(window, input, {
+					...init,
+					mode: "cors",
+				});
+			}
+
+			return originalFetch.call(window, input, init);
+		}) as typeof window.fetch;
+
+		const wsAppOrigin = appOrigin.replace(/^http/, "ws");
+		const OriginalWebSocket = window.WebSocket;
+		const PatchedWebSocket = function (
+			url: string | URL,
+			protocols?: string | string[],
+		) {
+			const parsed = new URL(String(url), window.location.href);
+			if (
+				parsed.origin === window.location.origin ||
+				parsed.origin === window.location.origin.replace(/^http/, "ws")
+			) {
+				const rewritten = new URL(wsAppOrigin);
+				rewritten.pathname = parsed.pathname;
+				rewritten.search = parsed.search;
+				rewritten.hash = parsed.hash;
+				return new OriginalWebSocket(rewritten.toString(), protocols);
+			}
+			return new OriginalWebSocket(url, protocols);
+		} as unknown as typeof WebSocket;
+		PatchedWebSocket.prototype = OriginalWebSocket.prototype;
+		Object.assign(PatchedWebSocket, {
+			CONNECTING: OriginalWebSocket.CONNECTING,
+			OPEN: OriginalWebSocket.OPEN,
+			CLOSING: OriginalWebSocket.CLOSING,
+			CLOSED: OriginalWebSocket.CLOSED,
+		});
+		(window as { WebSocket: typeof WebSocket }).WebSocket = PatchedWebSocket;
+	}
+}
+
+const PATCH_SCRIPT = `(${applyIframePatches.toString()})()`;
+
+/**
  * Initializes & patches Next.js functionality so an app can run as a
  * widget inside a cross-origin iframe. Used by every MCP widget host —
  * ChatGPT's sandbox, the embed's `/api/mcp/chat/resource` proxy, and any
  * future host that renders the widget on a domain other than its own
  * `baseUrl`.
  *
- * What it patches:
- * - `history.pushState` / `history.replaceState` — prevents full-origin
- *   URLs from ending up in the iframe's history (browsers reject cross-
- *   origin pushes in sandboxed iframes).
- * - `window.fetch` — rewrites same-origin requests to the widget's real
- *   `baseUrl`. Without this, relative `/api/...` calls from the widget
- *   hit the host's origin (ChatGPT sandbox, WaniWani embed proxy, etc.)
- *   and 404. `passthroughOrigins` opts specific origins out of the
- *   rewrite (see prop doc).
- * - `<html>` attribute observer — strips attributes the host injects
- *   after hydration (ChatGPT mutates `<html>` for theming), while
- *   preserving `class` / `style` / `lang`.
+ * See `applyIframePatches` for the patch behavior.
  *
  * More background on the ChatGPT case:
  * https://vercel.com/blog/running-next-js-inside-chatgpt-a-deep-dive-into-native-app-integration
@@ -27,12 +198,10 @@ export function InitializeNextJsInIframe({
 }: {
 	baseUrl: string;
 	/**
-	 * Origins whose fetches should skip the same-origin → baseUrl rewrite.
-	 * Set this to the WaniWani API origin when the widget is loaded through
-	 * a proxy that shares origin with the API (e.g. the embed's
-	 * `/api/mcp/chat/resource` route on `app.waniwani.ai`). Without this,
-	 * widget tracking calls to the WaniWani API get rewritten to the
-	 * widget's own host and 404.
+	 * Origins whose fetches should skip the relative same-origin → baseUrl
+	 * rewrite. Only needed for relative-URL calls that resolve to an
+	 * origin you do not want forwarded to `baseUrl` — absolute URLs are
+	 * never rewritten regardless of this list.
 	 */
 	passthroughOrigins?: string[];
 }) {
@@ -42,161 +211,7 @@ export function InitializeNextJsInIframe({
 			<script>{`window.innerBaseUrl = ${JSON.stringify(baseUrl)}`}</script>
 			<script>{`window.__wwPassthroughOrigins = ${JSON.stringify(passthroughOrigins ?? [])}`}</script>
 			<script>{`window.__isChatGptApp = typeof window.openai !== "undefined";`}</script>
-			<script>
-				{"(" +
-					(() => {
-						const baseUrl = window.innerBaseUrl;
-						const passthroughOrigins: string[] =
-							(window as unknown as { __wwPassthroughOrigins: string[] })
-								.__wwPassthroughOrigins ?? [];
-						const htmlElement = document.documentElement;
-						const observer = new MutationObserver((mutations) => {
-							mutations.forEach((mutation) => {
-								if (
-									mutation.type === "attributes" &&
-									mutation.target === htmlElement
-								) {
-									const attrName = mutation.attributeName;
-									// Preserve class/style for theming (html.dark) and lang for i18n
-									if (
-										attrName &&
-										attrName !== "suppresshydrationwarning" &&
-										attrName !== "lang" &&
-										attrName !== "class" &&
-										attrName !== "style"
-									) {
-										htmlElement.removeAttribute(attrName);
-									}
-								}
-							});
-						});
-						observer.observe(htmlElement, {
-							attributes: true,
-							attributeOldValue: true,
-						});
-
-						const originalReplaceState = history.replaceState.bind(history);
-						history.replaceState = (
-							_s: unknown,
-							unused: string,
-							url?: string | URL | null,
-						) => {
-							try {
-								const u = new URL(String(url ?? ""), window.location.href);
-								originalReplaceState(
-									null,
-									unused,
-									u.pathname + u.search + u.hash,
-								);
-							} catch {
-								/* SecurityError in sandboxed iframe */
-							}
-						};
-
-						const originalPushState = history.pushState.bind(history);
-						history.pushState = (
-							_s: unknown,
-							unused: string,
-							url?: string | URL | null,
-						) => {
-							try {
-								const u = new URL(String(url ?? ""), window.location.href);
-								originalPushState(null, unused, u.pathname + u.search + u.hash);
-							} catch {
-								/* SecurityError in sandboxed iframe */
-							}
-						};
-
-						const appOrigin = new URL(baseUrl).origin;
-						const isInIframe = window.self !== window.top;
-
-						window.addEventListener(
-							"click",
-							(e) => {
-								const a = (e?.target as HTMLElement)?.closest("a");
-								if (!a || !a.href) {
-									return;
-								}
-								const url = new URL(a.href, window.location.href);
-								if (
-									url.origin !== window.location.origin &&
-									url.origin !== appOrigin
-								) {
-									try {
-										if (window.openai) {
-											window.openai?.openExternal({ href: a.href });
-											e.preventDefault();
-										}
-									} catch {
-										console.warn(
-											"openExternal failed, likely not in OpenAI client",
-										);
-									}
-								}
-							},
-							true,
-						);
-
-						if (isInIframe && window.location.origin !== appOrigin) {
-							const originalFetch = window.fetch;
-
-							(window as { fetch: typeof window.fetch }).fetch = ((
-								input: URL | RequestInfo,
-								init?: RequestInit,
-							): Promise<Response> => {
-								let url: URL;
-								if (typeof input === "string" || input instanceof URL) {
-									url = new URL(input, window.location.href);
-								} else {
-									url = new URL(input.url, window.location.href);
-								}
-
-								if (url.origin === appOrigin) {
-									if (typeof input === "string" || input instanceof URL) {
-										input = url.toString();
-									} else {
-										input = new Request(url.toString(), input);
-									}
-
-									return originalFetch.call(window, input, {
-										...init,
-										mode: "cors",
-									});
-								}
-
-								// Explicit passthrough list — never rewrite these.
-								// Needed when the widget shares origin with a
-								// non-Next-app host (e.g. the WaniWani app serving the
-								// embed iframe + the tracking API from the same host).
-								if (passthroughOrigins.indexOf(url.origin) !== -1) {
-									return originalFetch.call(window, input, init);
-								}
-
-								if (url.origin === window.location.origin) {
-									const newUrl = new URL(baseUrl);
-									newUrl.pathname = url.pathname;
-									newUrl.search = url.search;
-									newUrl.hash = url.hash;
-									url = newUrl;
-
-									if (typeof input === "string" || input instanceof URL) {
-										input = url.toString();
-									} else {
-										input = new Request(url.toString(), input);
-									}
-
-									return originalFetch.call(window, input, {
-										...init,
-										mode: "cors",
-									});
-								}
-
-								return originalFetch.call(window, input, init);
-							}) as typeof window.fetch;
-						}
-					}).toString() +
-					")()"}
-			</script>
+			<script>{PATCH_SCRIPT}</script>
 		</>
 	);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes runtime network behavior (`window.fetch`/`WebSocket`) for widgets running in cross-origin iframes; a mistake could break API calls or dev/prod iframe hosting scenarios. Coverage is improved via new happy-dom tests, reducing regression risk.
> 
> **Overview**
> **Fixes cross-origin iframe networking for Next.js widgets.** The `InitializeNextJsInIframe` patch now rewrites only *relative string* `fetch` calls that would otherwise hit the iframe host, while leaving absolute URLs (including `URL`/`Request` inputs and protocol-relative strings) untouched; same-`appOrigin` requests still force `mode: "cors"`.
> 
> The patch logic is extracted into an exported `applyIframePatches()` (still injected via a single script string), adds a `WebSocket` origin rewrite alongside the existing history/html mutations, and introduces a focused test suite covering rewrite/passthrough edge cases. Docs are updated to reflect the new fetch behavior and simplified `InitializeNextJsInIframe` usage, and the package version is bumped to `0.11.1-cors-fix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c83aacfc42ad1cc3639e6a06bc650824b20a659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->