### PR TITLE
fix(embed): inline mount fills min-height containers

### DIFF
--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -113,18 +113,24 @@ function mountInline(
 
 	// Create shadow DOM inside the target container. Stretch to fill the
 	// parent so the embedder's sizing (e.g. `h-[640px]`) drives the chat.
+	// Grid + `min-height: inherit` so containers sized via `min-height`
+	// (not `height`) still propagate a definite size — `height: 100%`
+	// alone collapses against `min-height` parents.
 	hostElement = document.createElement("div");
 	hostElement.id = "waniwani-chat-embed";
 	hostElement.style.width = "100%";
 	hostElement.style.height = "100%";
+	hostElement.style.minHeight = "inherit";
+	hostElement.style.display = "grid";
+	hostElement.style.gridTemplateRows = "1fr";
 	container.appendChild(hostElement);
 
 	const shadowRoot = hostElement.attachShadow({ mode: "open" });
 	injectStyles(shadowRoot, config);
 
 	const mountContainer = document.createElement("div");
-	mountContainer.style.width = "100%";
-	mountContainer.style.height = "100%";
+	mountContainer.style.minHeight = "0";
+	mountContainer.style.minWidth = "0";
 	shadowRoot.appendChild(mountContainer);
 
 	const inlineRef = React.createRef<InlineChatHandle>();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk styling-only change to the inline embed mount; main risk is unintended layout/scroll behavior regressions in some host pages.
> 
> **Overview**
> Fixes inline embed sizing when the host container is defined via `min-height` (not `height`).
> 
> The inline mount wrapper now uses `display: grid` with `min-height: inherit` to propagate a definite height, and the shadow mount container uses `min-width/min-height: 0` to avoid overflow while letting the React app fill available space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe38f4c11239c53379e774e37ca010f565c159fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->