### PR TITLE
refactor: lazy funnel sync via tool call metadata

### DIFF
--- a/src/mcp/server/with-waniwani/__test__/funnel-sync.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/funnel-sync.test.ts
@@ -1,10 +1,6 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { FlowGraph } from "../../flows/@types.js";
-import { syncFlowGraphs } from "../funnel-sync.js";
-
-const SYNC_CACHE_KEY = "__waniwani_funnel_sync_cache__";
-
-const mockFetch = mock(async () => new Response(null, { status: 200 }));
+import { prepareFunnelSyncPayload } from "../funnel-sync.js";
 
 const GRAPH_A: FlowGraph = {
 	flowId: "flow-a",
@@ -23,95 +19,31 @@ const GRAPH_B: FlowGraph = {
 	edges: [],
 };
 
-beforeEach(() => {
-	mockFetch.mockClear();
-	globalThis.fetch = mockFetch as unknown as typeof fetch;
-	// Clear the sync cache between tests
-	delete (globalThis as Record<string, unknown>)[SYNC_CACHE_KEY];
-});
-
-afterEach(() => {
-	delete (globalThis as Record<string, unknown>)[SYNC_CACHE_KEY];
-});
-
-describe("syncFlowGraphs", () => {
-	test("skips sync when composite hash matches cached value", async () => {
-		await syncFlowGraphs([GRAPH_A], "https://api.test", "key-1");
-		// Allow the fire-and-forget fetch + .then() to settle
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(1);
-
-		// Second call with identical graphs should be skipped
-		await syncFlowGraphs([GRAPH_A], "https://api.test", "key-1");
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(1);
+describe("prepareFunnelSyncPayload", () => {
+	test("returns null for empty flow graphs", async () => {
+		const result = await prepareFunnelSyncPayload([]);
+		expect(result).toBeNull();
 	});
 
-	test("syncs again when graphs change", async () => {
-		await syncFlowGraphs([GRAPH_A], "https://api.test", "key-1");
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(1);
-
-		// Different graph should trigger a new sync
-		await syncFlowGraphs([GRAPH_B], "https://api.test", "key-1");
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(2);
-	});
-
-	test("does not cache on fetch failure — retries on next call", async () => {
-		mockFetch.mockImplementationOnce(async () => {
-			throw new Error("network error");
-		});
-
-		await syncFlowGraphs([GRAPH_A], "https://api.test", "key-1");
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(1);
-
-		// Same graphs, but previous call failed so should retry
-		mockFetch.mockImplementationOnce(
-			async () => new Response(null, { status: 200 }),
-		);
-		await syncFlowGraphs([GRAPH_A], "https://api.test", "key-1");
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(2);
-	});
-
-	test("uses separate cache slots for different API keys", async () => {
-		await syncFlowGraphs([GRAPH_A], "https://api.test", "key-1");
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(1);
-
-		// Same graph but different API key should still sync
-		await syncFlowGraphs([GRAPH_A], "https://api.test", "key-2");
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(2);
-	});
-
-	test("skips sync for empty flow graphs", async () => {
-		await syncFlowGraphs([], "https://api.test", "key-1");
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(0);
+	test("returns composite hash and per-flow hashes", async () => {
+		const result = await prepareFunnelSyncPayload([GRAPH_A]);
+		expect(result).not.toBeNull();
+		expect(result?.compositeHash).toBeTypeOf("string");
+		expect(result?.compositeHash.length).toBeGreaterThan(0);
+		expect(result?.flows).toHaveLength(1);
+		expect(result?.flows[0].flowId).toBe("flow-a");
+		expect(result?.flows[0].configHash).toBeTypeOf("string");
 	});
 
 	test("produces deterministic hash regardless of graph order", async () => {
-		await syncFlowGraphs([GRAPH_A, GRAPH_B], "https://api.test", "key-1");
-		await new Promise((r) => setTimeout(r, 10));
+		const resultAB = await prepareFunnelSyncPayload([GRAPH_A, GRAPH_B]);
+		const resultBA = await prepareFunnelSyncPayload([GRAPH_B, GRAPH_A]);
+		expect(resultAB?.compositeHash).toBe(resultBA?.compositeHash);
+	});
 
-		expect(mockFetch).toHaveBeenCalledTimes(1);
-
-		// Same graphs in reverse order should hit the cache
-		await syncFlowGraphs([GRAPH_B, GRAPH_A], "https://api.test", "key-1");
-		await new Promise((r) => setTimeout(r, 10));
-
-		expect(mockFetch).toHaveBeenCalledTimes(1);
+	test("produces different hash for different graphs", async () => {
+		const resultA = await prepareFunnelSyncPayload([GRAPH_A]);
+		const resultB = await prepareFunnelSyncPayload([GRAPH_B]);
+		expect(resultA?.compositeHash).not.toBe(resultB?.compositeHash);
 	});
 });

--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -53,6 +53,20 @@ function mockClient() {
 	};
 }
 
+function mockClientWithApiKey() {
+	const base = mockClient();
+	return {
+		...base,
+		client: {
+			...base.client,
+			_config: {
+				...base.client._config,
+				apiKey: "wwk_test",
+			},
+		},
+	};
+}
+
 type Handler = (input: unknown, extra: unknown) => Promise<unknown>;
 type RegisterToolArgs = [string, Record<string, unknown>, Handler];
 type RegisteredToolEntry = {
@@ -158,13 +172,13 @@ describe("withWaniwani", () => {
 		});
 	});
 
-	test("prevents double wrapping", () => {
+	test("prevents double wrapping", async () => {
 		const { server } = mockServer();
 
-		const wrapped1 = withWaniwani(server, {
+		const wrapped1 = await withWaniwani(server, {
 			client: mockClient().client,
 		});
-		const wrapped2 = withWaniwani(wrapped1, {
+		const wrapped2 = await withWaniwani(wrapped1, {
 			client: mockClient().client,
 		});
 
@@ -714,6 +728,67 @@ describe("withWaniwani", () => {
 			latitude: "40.4",
 			longitude: "-3.7",
 		});
+	});
+
+	test("attaches funnelSync metadata when flow graphs are registered", async () => {
+		const { client, tracked } = mockClientWithApiKey();
+		const mock = mockServer();
+
+		mock.registerTool(
+			"flow-tool",
+			{
+				description: "A flow tool",
+				_meta: {
+					_flowGraph: {
+						flowId: "onboarding",
+						title: "Onboarding Flow",
+						nodes: [
+							{ id: "n1", type: "widget", label: "Welcome" },
+							{ id: "n2", type: "action", label: "Complete" },
+						],
+						edges: [{ from: "n1", to: "n2", type: "direct" }],
+					},
+				},
+			},
+			async () => ({ content: [] }),
+		);
+
+		await withWaniwani(mock.server, { client });
+
+		const handler = mock._registeredTools["flow-tool"]?.handler;
+		await handler?.({}, {});
+
+		expect(tracked).toHaveLength(1);
+		const metadata = tracked[0]?.metadata as Record<string, unknown>;
+		expect(metadata.funnelSync).toBeDefined();
+
+		const funnelSync = metadata.funnelSync as {
+			compositeHash: string;
+			flows: Array<{ flowId: string; configHash: string }>;
+		};
+		expect(funnelSync.compositeHash).toBeTypeOf("string");
+		expect(funnelSync.compositeHash.length).toBeGreaterThan(0);
+		expect(funnelSync.flows).toHaveLength(1);
+		expect(funnelSync.flows[0].flowId).toBe("onboarding");
+		expect(funnelSync.flows[0].configHash).toBeTypeOf("string");
+	});
+
+	test("does not attach funnelSync metadata when no flow graphs are registered", async () => {
+		const { client, tracked } = mockClientWithApiKey();
+		const mock = mockServer();
+
+		mock.registerTool("plain-tool", { description: "No flows" }, async () => ({
+			content: [],
+		}));
+
+		await withWaniwani(mock.server, { client });
+
+		const handler = mock._registeredTools["plain-tool"]?.handler;
+		await handler?.({}, {});
+
+		expect(tracked).toHaveLength(1);
+		const metadata = tracked[0]?.metadata as Record<string, unknown>;
+		expect(metadata.funnelSync).toBeUndefined();
 	});
 
 	test("auto-redacts stateUpdates fields listed in tool definition _meta", async () => {

--- a/src/mcp/server/with-waniwani/funnel-sync.ts
+++ b/src/mcp/server/with-waniwani/funnel-sync.ts
@@ -21,34 +21,30 @@ function hashGraph(graph: FlowGraph): Promise<string> {
 	return hashData(JSON.stringify({ nodes: graph.nodes, edges: graph.edges }));
 }
 
-// ---------------------------------------------------------------------------
-// globalThis-based cache so the sync HTTP call is made at most once per
-// cold start per Lambda/serverless instance. Same pattern as project-config.ts.
-// ---------------------------------------------------------------------------
+export type FunnelSyncFlow = {
+	flowId: string;
+	title: string;
+	configHash: string;
+	nodes: FlowGraph["nodes"];
+	edges: FlowGraph["edges"];
+};
 
-const SYNC_CACHE_KEY = "__waniwani_funnel_sync_cache__" as const;
+export type FunnelSyncPayload = {
+	compositeHash: string;
+	flows: FunnelSyncFlow[];
+};
 
-function getSyncCache(): Map<string, string> {
-	const g = globalThis as Record<string, unknown>;
-	if (!g[SYNC_CACHE_KEY]) {
-		g[SYNC_CACHE_KEY] = new Map<string, string>();
-	}
-	return g[SYNC_CACHE_KEY] as Map<string, string>;
-}
-
-export async function syncFlowGraphs(
+export async function prepareFunnelSyncPayload(
 	flowGraphs: FlowGraph[],
-	apiUrl: string,
-	apiKey: string,
-): Promise<void> {
+): Promise<FunnelSyncPayload | null> {
 	if (flowGraphs.length === 0) {
-		return;
+		return null;
 	}
 
-	// Composite hash of all graphs sorted by flowId for determinism.
 	const sorted = [...flowGraphs].sort((a, b) =>
 		a.flowId.localeCompare(b.flowId),
 	);
+
 	const compositeHash = await hashData(
 		JSON.stringify(
 			sorted.map((fg) => ({
@@ -59,33 +55,15 @@ export async function syncFlowGraphs(
 		),
 	);
 
-	const cache = getSyncCache();
-	if (cache.get(apiKey) === compositeHash) {
-		return;
-	}
-
 	const flows = await Promise.all(
 		flowGraphs.map(async (fg) => ({
-			...fg,
+			flowId: fg.flowId,
+			title: fg.title,
 			configHash: await hashGraph(fg),
+			nodes: fg.nodes,
+			edges: fg.edges,
 		})),
 	);
 
-	const payload = JSON.stringify({ flows });
-
-	try {
-		const url = `${apiUrl}/api/mcp/funnel/sync`;
-		fetch(url, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${apiKey}`,
-			},
-			body: payload,
-		})
-			.then(() => {
-				cache.set(apiKey, compositeHash);
-			})
-			.catch(() => {});
-	} catch {}
+	return { compositeHash, flows };
 }

--- a/src/mcp/server/with-waniwani/helpers.ts
+++ b/src/mcp/server/with-waniwani/helpers.ts
@@ -5,6 +5,7 @@ import type {
 import type { WaniWaniClient } from "../../../types.js";
 import { extractSessionId, extractSource } from "../utils.js";
 import type { WidgetTokenCache } from "../widget-token.js";
+import type { FunnelSyncPayload } from "./funnel-sync.js";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -106,6 +107,7 @@ export function buildTrackInput(
 		metadata?: UnknownRecord;
 		stripLocationFields?: readonly string[];
 		redactInput?: (input: unknown) => unknown;
+		funnelSync?: FunnelSyncPayload | null;
 	},
 	timing?: { durationMs: number; status: string; errorMessage?: string },
 	clientInfo?: { name: string; version: string },
@@ -152,6 +154,7 @@ export function buildTrackInput(
 		metadata: {
 			...(options.metadata ?? {}),
 			...(clientInfo && { clientInfo }),
+			...(options.funnelSync && { funnelSync: options.funnelSync }),
 		},
 	};
 }

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -175,7 +175,11 @@ function createWrappedHandler(
 		extra: unknown,
 	) => {
 		const effectiveOpts = stateUpdateRedactor
-			? { ...opts, redactInput: stateUpdateRedactor, funnelSync: ctx.funnelSync }
+			? {
+					...opts,
+					redactInput: stateUpdateRedactor,
+					funnelSync: ctx.funnelSync,
+				}
 			: { ...opts, funnelSync: ctx.funnelSync };
 		// Inject scoped client into extra so createTool/flows can surface it
 		const meta = extractMeta(extra) ?? {};

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -170,14 +170,13 @@ function createWrappedHandler(
 		opts.applyFieldRedactions === true
 			? buildStateUpdateRedactor(definitionMeta)
 			: undefined;
-	const effectiveOpts = stateUpdateRedactor
-		? { ...opts, redactInput: stateUpdateRedactor }
-		: opts;
-
 	const wrappedHandler: MaybeWrappedHandler = async (
 		input: unknown,
 		extra: unknown,
 	) => {
+		const effectiveOpts = stateUpdateRedactor
+			? { ...opts, redactInput: stateUpdateRedactor, funnelSync: ctx.funnelSync }
+			: { ...opts, funnelSync: ctx.funnelSync };
 		// Inject scoped client into extra so createTool/flows can surface it
 		const meta = extractMeta(extra) ?? {};
 
@@ -233,7 +232,7 @@ function createWrappedHandler(
 				buildTrackInput(
 					toolName,
 					extra,
-					{ ...effectiveOpts, funnelSync: ctx.funnelSync },
+					effectiveOpts,
 					{
 						durationMs,
 						status: isErrorResult ? "error" : "ok",
@@ -278,7 +277,7 @@ function createWrappedHandler(
 				buildTrackInput(
 					toolName,
 					extra,
-					{ ...effectiveOpts, funnelSync: ctx.funnelSync },
+					effectiveOpts,
 					{
 						durationMs,
 						status: "error",

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -7,7 +7,8 @@ import { createScopedClient, SCOPED_CLIENT_KEY } from "../scoped-client.js";
 import type { McpServer } from "../tools/types";
 import { extractSessionId } from "../utils.js";
 import { WidgetTokenCache } from "../widget-token.js";
-import { syncFlowGraphs } from "./funnel-sync.js";
+import type { FunnelSyncPayload } from "./funnel-sync.js";
+import { prepareFunnelSyncPayload } from "./funnel-sync.js";
 import {
 	buildTrackInput,
 	extractErrorText,
@@ -152,6 +153,7 @@ type WrapContext = {
 	opts: WithWaniwaniOptions;
 	tokenCache: WidgetTokenCache | null;
 	injectToken: boolean;
+	funnelSync: FunnelSyncPayload | null;
 };
 
 type UnknownRecordOrUndefined = UnknownRecord | undefined;
@@ -231,7 +233,7 @@ function createWrappedHandler(
 				buildTrackInput(
 					toolName,
 					extra,
-					effectiveOpts,
+					{ ...effectiveOpts, funnelSync: ctx.funnelSync },
 					{
 						durationMs,
 						status: isErrorResult ? "error" : "ok",
@@ -276,7 +278,7 @@ function createWrappedHandler(
 				buildTrackInput(
 					toolName,
 					extra,
-					effectiveOpts,
+					{ ...effectiveOpts, funnelSync: ctx.funnelSync },
 					{
 						durationMs,
 						status: "error",
@@ -321,10 +323,10 @@ function createWrappedHandler(
  * result's `_meta`, so chat UIs that only see tool results (and not
  * `tools/list`) can still render widgets. Handler-set keys take precedence.
  */
-export function withWaniwani(
+export async function withWaniwani(
 	server: McpServer,
 	options?: WithWaniwaniOptions,
-): McpServer {
+): Promise<McpServer> {
 	const wrappedServer = server as WrappedServer;
 	if (wrappedServer.__waniwaniWrapped) {
 		return wrappedServer;
@@ -349,6 +351,7 @@ export function withWaniwani(
 		opts,
 		tokenCache,
 		injectToken,
+		funnelSync: null,
 	};
 
 	const originalRegisterTool = server.registerTool.bind(server) as (
@@ -446,11 +449,7 @@ export function withWaniwani(
 		}
 
 		if (flowGraphs.length > 0) {
-			syncFlowGraphs(
-				flowGraphs,
-				tracker._config.apiUrl ?? DEFAULT_BASE_URL,
-				tracker._config.apiKey,
-			);
+			ctx.funnelSync = await prepareFunnelSyncPayload(flowGraphs);
 		}
 	}
 


### PR DESCRIPTION
Replace fire-and-forget HTTP POST at startup with precomputed hash attached to every tool.called event metadata. The app-side batch endpoint detects the payload and upserts funnel_configs only when the hash differs from what's in DB.