### PR TITLE
feat(flows): support object form for addNode, deprecate positional

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,6 +70,12 @@
               "flows/register",
               "flows/examples"
             ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "migration"
+            ]
           }
         ]
       }

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -1,0 +1,75 @@
+---
+title: Migration
+description: "Upgrade paths for breaking and deprecated APIs across SDK versions."
+---
+
+This page tracks API changes that require code updates, organized by the version that introduced them. Deprecations are safe to ignore short-term — the old shape keeps working until the removal version listed in the deprecation notice.
+
+## Deprecations at a glance
+
+| API | Status | Since | Removed in |
+| --- | --- | --- | --- |
+| `.addNode(id, run, options?)` (positional) | Deprecated | 0.12.0 | 0.13.0 |
+
+<Tip>
+TypeScript will strike through deprecated signatures in your IDE — hover for the replacement.
+</Tip>
+
+---
+
+## 0.12.0 — `addNode` object form
+
+The positional `.addNode(id, run, options?)` signature is deprecated in favor of an options-bag form. Metadata sits at the top of the call where the eye lands, the handler is a named field, and future options can be added without widening a positional signature.
+
+### Before
+
+```ts
+flow
+  .addNode("ask_family_details", ({ interrupt }) => {
+    return interrupt({
+      partnerName: { question: "What is your partner's name?" },
+      numKids: { question: "How many children do you have?" },
+    });
+  }, { label: "Ask family details" });
+```
+
+### After
+
+```ts
+flow.addNode({
+  id: "ask_family_details",
+  label: "Ask family details",
+  run: ({ interrupt }) =>
+    interrupt({
+      partnerName: { question: "What is your partner's name?" },
+      numKids: { question: "How many children do you have?" },
+    }),
+});
+```
+
+### What changed
+
+- `id` replaces the first positional argument.
+- `run` replaces the second positional argument (the handler).
+- `label` and `hideFromFunnel` move from the third `options` argument onto the same config object.
+- `label` is now optional — when omitted, it defaults to `id`. The positional form required `label` whenever you passed an `options` object.
+
+### Compatibility
+
+Both signatures are supported. The positional form is marked `@deprecated` and will be removed in **0.13.0**. You can mix the two within the same flow during the transition — there is no functional difference between the two shapes.
+
+### Type export
+
+A new `AddNodeConfig<TState, TName>` type is exported from `@waniwani/sdk/mcp` if you need to type a config object outside the call site.
+
+```ts
+import type { AddNodeConfig } from "@waniwani/sdk/mcp";
+
+const askEmail: AddNodeConfig<MyState, "ask_email"> = {
+  id: "ask_email",
+  run: ({ interrupt }) =>
+    interrupt({ email: { question: "What's your email?" } }),
+};
+
+flow.addNode(askEmail);
+```

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -12,6 +12,7 @@ export type {
 } from "./react/widgets/widget-client";
 // Flow framework
 export type {
+	AddNodeConfig,
 	ConditionFn,
 	FlowConfig,
 	FlowTestResult,

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -329,6 +329,23 @@ export type NodeOptions = {
 	hideFromFunnel?: boolean;
 };
 
+/**
+ * Config for the object form of `.addNode({ id, run, label?, hideFromFunnel? })`.
+ *
+ * Preferred over the positional form `.addNode(id, run, options?)` — metadata
+ * sits at the top where the eye lands, and the handler is a named field.
+ */
+export type AddNodeConfig<TState, TName extends string = string> = {
+	/** Unique node id within the flow. */
+	id: TName;
+	/** Node handler — receives ctx, returns state updates or a signal. */
+	run: NodeHandler<TState>;
+	/** Human-readable label for funnel visualization and graphs. Defaults to `id`. */
+	label?: string;
+	/** When true, this node is excluded from funnel analytics. */
+	hideFromFunnel?: boolean;
+};
+
 export type FlowGraphNode = {
 	id: string;
 	type: "widget" | "interrupt" | "action";

--- a/src/mcp/server/flows/__tests__/compile.test.ts
+++ b/src/mcp/server/flows/__tests__/compile.test.ts
@@ -2140,3 +2140,65 @@ describe("nodesVisited flow path tracking", () => {
 		});
 	});
 });
+
+describe("addNode object form", () => {
+	test("accepts { id, run, label, hideFromFunnel } and behaves identically to positional form", async () => {
+		const store = new TestFlowStateStore();
+		const flow = createFlow({
+			id: "object_form_flow",
+			title: "Object Form",
+			description: "Test the object-form addNode signature.",
+			state: {
+				computed: z.string().describe("Computed"),
+				name: z.string().describe("Name"),
+			},
+		})
+			.addNode({
+				id: "hidden_compute",
+				run: () => ({ computed: "done" }),
+				label: "Hidden Compute",
+				hideFromFunnel: true,
+			})
+			.addNode({
+				id: "ask_name",
+				run: ({ interrupt }) => interrupt({ name: { question: "Name?" } }),
+			})
+			.addEdge(START, "hidden_compute")
+			.addEdge("hidden_compute", "ask_name")
+			.addEdge("ask_name", END)
+			.compile({ store });
+
+		const { server, registered } = mockServer();
+		await flow.register(server);
+		const handler = registered[0]?.[2];
+
+		const result = (await handler?.(startInput(), TEST_EXTRA)) as Record<
+			string,
+			unknown
+		>;
+		const meta = result._meta as Record<string, unknown>;
+
+		expect(meta[FLOW_META_KEY]).toEqual({
+			flowId: "object_form_flow",
+			nodesVisited: ["ask_name"],
+		});
+	});
+
+	test("object form without label defaults label to id", () => {
+		const flow = createFlow({
+			id: "default_label_flow",
+			title: "Default Label",
+			description: "Label defaults to id when omitted.",
+			state: { v: z.string() },
+		})
+			.addNode({
+				id: "first",
+				run: () => ({ v: "ok" }),
+			})
+			.addEdge(START, "first")
+			.addEdge("first", END);
+
+		const graphMd = flow.graph();
+		expect(graphMd).toContain("first[first]");
+	});
+});

--- a/src/mcp/server/flows/create-flow.ts
+++ b/src/mcp/server/flows/create-flow.ts
@@ -22,8 +22,14 @@ import { StateGraph } from "./state-graph";
  *     email: z.string().describe("The user's email address"),
  *   },
  * })
- *   .addNode("ask_name", () => interrupt({ question: "What's your name?", field: "name" }))
- *   .addNode("ask_email", () => interrupt({ question: "What's your email?", field: "email" }))
+ *   .addNode({
+ *     id: "ask_name",
+ *     run: () => interrupt({ question: "What's your name?", field: "name" }),
+ *   })
+ *   .addNode({
+ *     id: "ask_email",
+ *     run: () => interrupt({ question: "What's your email?", field: "email" }),
+ *   })
  *   .addEdge(START, "ask_name")
  *   .addEdge("ask_name", "ask_email")
  *   .addEdge("ask_email", END)

--- a/src/mcp/server/flows/index.ts
+++ b/src/mcp/server/flows/index.ts
@@ -1,6 +1,7 @@
 // Flow framework — LangGraph-inspired multi-step flows for MCP tools
 
 export type {
+	AddNodeConfig,
 	ConditionFn,
 	FlowConfig,
 	InferFlowState,

--- a/src/mcp/server/flows/state-graph.ts
+++ b/src/mcp/server/flows/state-graph.ts
@@ -1,4 +1,5 @@
 import type {
+	AddNodeConfig,
 	Edge,
 	FlowConfig,
 	NodeHandler,
@@ -39,8 +40,14 @@ function buildMermaidGraph(
  *   title: "User Onboarding",
  *   description: "Guides users through onboarding",
  * })
- *   .addNode("ask_name", ({ interrupt }) => interrupt({ question: "What's your name?", field: "name" }))
- *   .addNode("greet", ({ state }) => ({ greeting: `Hello ${state.name}!` }))
+ *   .addNode({
+ *     id: "ask_name",
+ *     run: ({ interrupt }) => interrupt({ question: "What's your name?", field: "name" }),
+ *   })
+ *   .addNode({
+ *     id: "greet",
+ *     run: ({ state }) => ({ greeting: `Hello ${state.name}!` }),
+ *   })
  *   .addEdge(START, "ask_name")
  *   .addEdge("ask_name", "greet")
  *   .addEdge("greet", END)
@@ -64,24 +71,58 @@ export class StateGraph<
 	 * Add a node with a handler.
 	 *
 	 * The handler receives a context object with `state`, `meta`, `interrupt`, and `showWidget`.
+	 *
+	 * @example
+	 * ```ts
+	 * .addNode({
+	 *   id: "ask_name",
+	 *   label: "Ask for name",
+	 *   run: ({ interrupt }) => interrupt({ question: "What's your name?", field: "name" }),
+	 * })
+	 * ```
+	 */
+	addNode<TName extends string>(
+		config: AddNodeConfig<TState, TName>,
+	): StateGraph<TState, TNodes | TName>;
+	/**
+	 * @deprecated Use the object form: `.addNode({ id, run, label? })`.
+	 * The positional form will be removed in v0.13.0
 	 */
 	addNode<TName extends string>(
 		name: TName,
 		handler: NodeHandler<TState>,
 		options?: NodeOptions,
+	): StateGraph<TState, TNodes | TName>;
+	addNode<TName extends string>(
+		configOrName: TName | AddNodeConfig<TState, TName>,
+		handler?: NodeHandler<TState>,
+		options?: NodeOptions,
 	): StateGraph<TState, TNodes | TName> {
-		if (name === START || name === END) {
+		const id =
+			typeof configOrName === "string" ? configOrName : configOrName.id;
+		const run =
+			typeof configOrName === "string"
+				? (handler as NodeHandler<TState>)
+				: configOrName.run;
+		const label =
+			typeof configOrName === "string" ? options?.label : configOrName.label;
+		const hideFromFunnel =
+			typeof configOrName === "string"
+				? options?.hideFromFunnel
+				: configOrName.hideFromFunnel;
+
+		if (id === START || id === END) {
 			throw new Error(
-				`"${name}" is a reserved name and cannot be used as a node name`,
+				`"${id}" is a reserved name and cannot be used as a node name`,
 			);
 		}
-		if (this.nodes.has(name)) {
-			throw new Error(`Node "${name}" already exists`);
+		if (this.nodes.has(id)) {
+			throw new Error(`Node "${id}" already exists`);
 		}
 
-		this.nodes.set(name, handler);
-		if (options) {
-			this.nodeOptions.set(name, options);
+		this.nodes.set(id, run);
+		if (label !== undefined || hideFromFunnel !== undefined) {
+			this.nodeOptions.set(id, { label: label ?? id, hideFromFunnel });
 		}
 		return this as unknown as StateGraph<TState, TNodes | TName>;
 	}


### PR DESCRIPTION
Adds .addNode({ id, run, label?, hideFromFunnel? }) alongside the existing .addNode(id, run, options?). Positional form is marked @deprecated with a 0.13.0 removal target. Exports a new AddNodeConfig type and adds a docs migration page.