### PR TITLE
fix(embed): size chat inside flex-column parents bounded by max-height

### DIFF
--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -50,6 +50,7 @@ interface EmbedInstance {
 let currentInstance: EmbedInstance | null = null;
 let reactRoot: ReactDOM.Root | null = null;
 let hostElement: HTMLElement | null = null;
+let containerResizeObserver: ResizeObserver | null = null;
 
 // ---------------------------------------------------------------------------
 // CSS injection helper
@@ -99,26 +100,71 @@ function mountInline(
 		);
 	}
 
-	// Size the chat against the customer's container in two ways at once:
+	// Size the chat against the customer's container in two complementary
+	// ways:
 	//
 	//   1. `height: 100%; max-height: inherit` — works when the customer's
 	//      container has a definite height. CSS inheritance reaches across
 	//      the shadow boundary via the composed tree.
 	//   2. `flex: 1 1 auto; min-height: 0` + `display: flex; flex-direction:
 	//      column` — works when the customer's container is a flex column
-	//      bounded only by `max-height` (no `height`). The host fills the
-	//      flex-resolved space; declaring the host itself as a flex column
-	//      lets the chat root become its flex child, which sidesteps a
-	//      shadow-DOM quirk where `height: 100%` on a mount inside the
-	//      shadow does not resolve against a flex-sized host. With
-	//      `display: contents` the mount drops out of layout so the chat
-	//      root sizes directly off the host's flex container.
+	//      bounded only by `max-height`. The host fills the flex-resolved
+	//      space; declaring the host itself as a flex column lets the chat
+	//      root become its flex child, which sidesteps a shadow-DOM quirk
+	//      where `height: 100%` on a mount inside the shadow does not
+	//      resolve against a flex-sized host. The mount uses `display:
+	//      contents` so it drops out of layout entirely.
+	//   3. A `ResizeObserver` reflects the container's *maximum* content
+	//      area onto the host as an inline `max-height`. `max-height:
+	//      inherit` copies the parent's value verbatim, so a `max-height:
+	//      800px; padding: 24px; box-sizing: border-box` parent lets the
+	//      chat overflow by the padding amount. Recomputing from the
+	//      parent's CSS each time it resizes closes that gap. We read
+	//      `max-height` / `height` (not the current `contentBoxSize`) to
+	//      avoid a feedback loop: when the chat is shorter than the
+	//      parent's bound, the parent's content-box shrinks to fit, and
+	//      mirroring that would lock the host at its current size.
 	hostElement = document.createElement("div");
 	hostElement.id = "waniwani-chat-embed";
 	hostElement.style.cssText =
 		"width:100%;height:100%;max-height:inherit;" +
 		"display:flex;flex-direction:column;flex:1 1 auto;min-height:0;";
 	container.appendChild(hostElement);
+
+	const host = hostElement;
+	const syncMaxHeight = () => {
+		const cs = getComputedStyle(container);
+		// Only mirror `max-height`. `getComputedStyle().height` returns the
+		// resolved size — when the parent is bounded by `max-height` alone
+		// and content is shorter, that resolved size shrinks to content,
+		// and using it would lock the host below the parent's true bound.
+		// When the parent uses an explicit `height`, the existing
+		// `height: 100%` chain already resolves correctly against its
+		// content box, so we leave the cap unset.
+		if (cs.maxHeight === "none") {
+			host.style.removeProperty("max-height");
+			return;
+		}
+		const outer = Number.parseFloat(cs.maxHeight);
+		if (!Number.isFinite(outer)) {
+			host.style.removeProperty("max-height");
+			return;
+		}
+		let inner = outer;
+		if (cs.boxSizing === "border-box") {
+			inner -=
+				(Number.parseFloat(cs.paddingTop) || 0) +
+				(Number.parseFloat(cs.paddingBottom) || 0) +
+				(Number.parseFloat(cs.borderTopWidth) || 0) +
+				(Number.parseFloat(cs.borderBottomWidth) || 0);
+		}
+		if (inner > 0) {
+			host.style.maxHeight = `${inner}px`;
+		}
+	};
+	syncMaxHeight();
+	containerResizeObserver = new ResizeObserver(syncMaxHeight);
+	containerResizeObserver.observe(container);
 
 	const shadowRoot = hostElement.attachShadow({ mode: "open" });
 	injectStyles(shadowRoot, config);
@@ -141,6 +187,8 @@ function mountInline(
 
 	return {
 		destroy: () => {
+			containerResizeObserver?.disconnect();
+			containerResizeObserver = null;
 			reactRoot?.unmount();
 			reactRoot = null;
 			hostElement?.remove();

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -99,22 +99,32 @@ function mountInline(
 		);
 	}
 
-	// Propagate the customer's height / max-height down to the chat root
-	// via a `height: 100%; max-height: inherit` chain that crosses the
-	// shadow boundary (CSS inherits through the composed tree, so
-	// `max-height: inherit` on a shadow-tree element copies the value
-	// from its shadow host). Both host and mountContainer are links in
-	// the chain.
+	// Size the chat against the customer's container in two ways at once:
+	//
+	//   1. `height: 100%; max-height: inherit` — works when the customer's
+	//      container has a definite height. CSS inheritance reaches across
+	//      the shadow boundary via the composed tree.
+	//   2. `flex: 1 1 auto; min-height: 0` + `display: flex; flex-direction:
+	//      column` — works when the customer's container is a flex column
+	//      bounded only by `max-height` (no `height`). The host fills the
+	//      flex-resolved space; declaring the host itself as a flex column
+	//      lets the chat root become its flex child, which sidesteps a
+	//      shadow-DOM quirk where `height: 100%` on a mount inside the
+	//      shadow does not resolve against a flex-sized host. With
+	//      `display: contents` the mount drops out of layout so the chat
+	//      root sizes directly off the host's flex container.
 	hostElement = document.createElement("div");
 	hostElement.id = "waniwani-chat-embed";
-	hostElement.style.cssText = "width:100%;height:100%;max-height:inherit;";
+	hostElement.style.cssText =
+		"width:100%;height:100%;max-height:inherit;" +
+		"display:flex;flex-direction:column;flex:1 1 auto;min-height:0;";
 	container.appendChild(hostElement);
 
 	const shadowRoot = hostElement.attachShadow({ mode: "open" });
 	injectStyles(shadowRoot, config);
 
 	const mountContainer = document.createElement("div");
-	mountContainer.style.cssText = "width:100%;height:100%;max-height:inherit;";
+	mountContainer.className = "ww:contents";
 	shadowRoot.appendChild(mountContainer);
 
 	const inlineRef = React.createRef<InlineChatHandle>();

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -141,7 +141,12 @@ function mountInline(
 		// When the parent uses an explicit `height`, the existing
 		// `height: 100%` chain already resolves correctly against its
 		// content box, so we leave the cap unset.
-		if (cs.maxHeight === "none") {
+		//
+		// Bail unless we get a concrete pixel value: percentages with an
+		// indefinite containing block come back as `"80%"`, which would
+		// otherwise be parsed as `80` pixels and severely shrink the chat.
+		// `max-height: inherit` on the host handles those cases natively.
+		if (!cs.maxHeight.endsWith("px")) {
 			host.style.removeProperty("max-height");
 			return;
 		}
@@ -160,6 +165,11 @@ function mountInline(
 		}
 		if (inner > 0) {
 			host.style.maxHeight = `${inner}px`;
+		} else {
+			// Padding + border exceed the parent's `max-height`. Clear any
+			// stale override so the host falls back to `max-height: inherit`
+			// rather than keeping a value from an earlier observation.
+			host.style.removeProperty("max-height");
 		}
 	};
 	syncMaxHeight();

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -32,13 +32,14 @@ import { Button } from "../ui/button";
 /**
  * Bring-your-own-backend chat with internal scroll.
  *
- * Sizes via a pure-CSS `height: 100%; max-height: inherit` chain that
- * works for `height`, `max-height`, and flex/grid-bounded ancestors —
- * including across the embed's shadow boundary (CSS inherits through
- * the composed tree). When the parent is truly unbounded the chat grows
- * with content; bound it by setting `height` or `max-height` on the
- * parent. Internally a flex column: header and input pinned, messages
- * scrolling between them.
+ * Sizes off its parent via two complementary mechanisms applied by the
+ * embed host: a `height: 100%; max-height: inherit` chain for
+ * definite-height parents, and `flex: 1 1 auto; min-height: 0` so the
+ * chat also fills a flex-column parent bounded only by `max-height`.
+ * Both work across the shadow boundary. When the parent is truly
+ * unbounded the chat grows with content; bound it by setting `height`,
+ * `max-height`, or a flex/grid track on the parent. Internally a flex
+ * column: header and input pinned, messages scrolling between them.
  */
 export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 	function ChatEmbed(props, ref) {

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -138,6 +138,25 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 			scrollToBottom("auto");
 		}, [scrollToBottom]);
 
+		// Keep the view pinned to the bottom when the scroll container resizes.
+		// The embed's host can settle asynchronously (ResizeObserver mirroring
+		// the parent's max-height runs after the first paint), which shrinks
+		// the scroll container and would otherwise leave scrollTop at 0 even
+		// though the initial mount effect already ran.
+		useEffect(() => {
+			const scroller = scrollRef.current;
+			if (!scroller || typeof ResizeObserver === "undefined") {
+				return;
+			}
+			const observer = new ResizeObserver(() => {
+				if (atBottomRef.current) {
+					scrollToBottom("auto");
+				}
+			});
+			observer.observe(scroller);
+			return () => observer.disconnect();
+		}, [scrollToBottom]);
+
 		const suggestionsState = useSuggestions({
 			messages: engine.messages,
 			status: engine.status,


### PR DESCRIPTION
## Summary

Three complementary fixes so the embed sizes correctly inside any reasonable customer container, including the unmodified demo:

```html
<div class="card" style="max-height:800px" data-waniwani-embed></div>
<!-- .card has padding: 1.5rem -->
```

1. **`flex: 1 1 auto; min-height: 0`** added to the host. Lets it fill a flex-column parent bounded by `max-height`, in addition to the existing `height: 100%; max-height: inherit` chain that works for parents with definite height.
2. **`display: flex` on the host + `display: contents` on the mount** (via the existing `ww:contents` utility). The chat root becomes the host's direct flex child, sidestepping a shadow-DOM quirk where `height: 100%` does not resolve against a flex-sized host.
3. **`ResizeObserver` mirrors the parent's `max-height` minus padding/border** onto the host's inline `max-height`. `max-height: inherit` ignores padding, so a `max-height: 800px; padding: 24px` container let the chat overflow by the padding amount.

## Why each fix is needed

- Without (1): `max-height` parents with no `height` give percentage children `auto`, so the chat grew to its content size and overflowed.
- Without (2): even with (1) fixing the host, percentage heights on the mount inside the shadow root do not resolve against a flex-sized host. `display: contents` collapses the mount out of layout so the chat sizes directly off the host.
- Without (3): `max-height: inherit` copies the parent's value verbatim. Padding on the parent left the host overflowing by the padding amount. Mirroring `max-height` rather than current content-box avoids a feedback loop: locking to current content-box would freeze the host below its true bound when the chat is shorter than the parent.

## Test plan

Verified in `mcps/tuio-pet-care/embed-demo.html` against:

- [x] `<div style="max-height:800px" data-waniwani-embed>` with `.card` padding (unchanged demo) — card stays 800px, host 750px, internal scroll active, no overflow.
- [x] `<div style="height:600px" data-waniwani-embed>` — card 600px, host 550px.
- [x] No bound at all — chat grows with content (card 991px, host 941px).
- [x] `<div style="display:flex; flex-direction:column; max-height:800px; padding:24px" data-waniwani-embed>` — card 800px, host 750px via flex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk layout-focused change: adjusts embed host/mount sizing and adds `ResizeObserver` syncing/cleanup, with minimal impact beyond chat embed rendering and scroll behavior.
> 
> **Overview**
> Fixes chat embed sizing when mounted inside flex-column containers bounded by `max-height`.
> 
> The embed host now participates correctly in flex layouts (`display:flex`, `flex:1`, `min-height:0`), uses a layout-neutral mount container (`ww:contents`), and mirrors the parent’s pixel `max-height` (minus padding/border) onto the host via `ResizeObserver` with proper disconnect on `destroy()`.
> 
> `ChatEmbed` adds a `ResizeObserver` on the scroll container to keep the view pinned to bottom when the embed’s height settles after initial paint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4eb98656b2af340b4f24479732bf1b2faa974cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->