### PR TITLE
fix(chat): thread menu unswitchable inside shadow DOM

### DIFF
--- a/src/chat/web/components/thread-menu.tsx
+++ b/src/chat/web/components/thread-menu.tsx
@@ -117,12 +117,20 @@ export function ThreadMenu({
 			return;
 		}
 		const handler = (event: MouseEvent) => {
-			if (
-				containerRef.current &&
-				!containerRef.current.contains(event.target as Node)
-			) {
-				setOpen(false);
+			const container = containerRef.current;
+			if (!container) {
+				return;
 			}
+			// In the embed we render inside a shadow root, so events that
+			// bubble to `document` are retargeted to the shadow host and
+			// `event.target` no longer points at the actual click target.
+			// `composedPath()` reports the true path through the shadow
+			// tree, which is what we need to distinguish clicks inside
+			// the menu from genuine outside-clicks.
+			if (event.composedPath().includes(container)) {
+				return;
+			}
+			setOpen(false);
 		};
 		document.addEventListener("mousedown", handler);
 		return () => document.removeEventListener("mousedown", handler);


### PR DESCRIPTION
## Summary

The thread history dropdown couldn't be used in the embed: clicking a thread row or its delete button closed the menu without doing anything.

## Cause

The outside-click handler tested `containerRef.current.contains(event.target)`. When an event bubbles out of an open shadow root and reaches a `document` listener, the browser **retargets** `event.target` to the shadow host — so from the document's perspective `event.target` is `#waniwani-chat-embed`, never an element inside the shadow tree. The check in the handler always reported \"outside\", so every click inside the embed closed the menu on `mousedown` before the button's `onClick` could fire.

## Fix

Use `event.composedPath()`, which preserves the true path through the shadow tree, and bail when the menu container is along it.

## Test plan

Verified in the Tuio Pet Care embed-demo with two persisted threads:

- [x] Clicking a non-active thread row switches the active thread.
- [x] Clicking the trash icon deletes that thread.
- [x] Clicking outside the menu (anywhere else on the page or inside the chat) still closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI event-handling change limited to the thread history dropdown; main risk is inadvertently altering outside-click detection in non-embed contexts.
> 
> **Overview**
> Fixes the thread history dropdown’s outside-click handling when rendered inside a shadow root (embed) by switching from `container.contains(event.target)` to `event.composedPath()`.
> 
> This prevents legitimate clicks within the menu (select thread / delete thread) from being misclassified as outside-clicks and closing the menu before the click handlers run, while still closing on genuine outside clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c5a817307d4b4b6f22ff37358af5ae68d347afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->