### PR TITLE
fix(embed): derive resource endpoint from api when mcp config absent

### DIFF
--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -25,6 +25,7 @@ import { useCallTool } from "../hooks/use-call-tool";
 import { useChatEngine } from "../hooks/use-chat-engine";
 import { useSuggestions } from "../hooks/use-suggestions";
 import { useTypingPlaceholder } from "../hooks/use-typing-placeholder";
+import { buildResourceEndpoint } from "../lib/resource-endpoint";
 import { cn } from "../lib/utils";
 import { isDarkTheme, mergeTheme, themeToCSSProperties } from "../theme";
 import { Button } from "../ui/button";
@@ -70,6 +71,12 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 			sessionId: engine.sessionId,
 			onCallTool: mcp?.onCallTool,
 		});
+
+		// Fall back to deriving the resource endpoint from `api` + the bearer
+		// token so callers (including the IIFE embed) get widget rendering
+		// without having to pass an `mcp` config. Mirrors ChatBar/ChatCard.
+		const resourceEndpoint =
+			mcp?.resourceEndpoint ?? buildResourceEndpoint(api, props.headers);
 
 		const animatedPlaceholder = useTypingPlaceholder(placeholder, !engine.text);
 
@@ -276,7 +283,7 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 							welcomeMessage={welcomeMessage}
 							welcome={welcome}
 							onSuggestionSelect={handleSuggestionSelect}
-							resourceEndpoint={mcp?.resourceEndpoint}
+							resourceEndpoint={resourceEndpoint}
 							chatSessionId={engine.sessionId}
 							isDark={isDark}
 							onFollowUp={handleWidgetMessage}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `ChatEmbed` constructs the widget `resourceEndpoint`, potentially propagating bearer tokens into the resource URL; mistakes here could cause widget 401s or unintended token exposure in URLs/logs.
> 
> **Overview**
> `ChatEmbed` now **falls back to deriving** the widget `resourceEndpoint` from `api` and `props.headers` via `buildResourceEndpoint` when `mcp.resourceEndpoint` isn’t provided, so embed consumers still get widget rendering without supplying an `mcp` config. `MessageList` is updated to use this computed endpoint instead of passing through `mcp?.resourceEndpoint` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e33c8374e5fa8f418e184e6deb4ccb99e8bf1a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->