### PR TITLE
fix(chat-embed): scroll to bottom on user submit and widget growth

### DIFF
--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -86,6 +86,7 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 		>(null);
 		const rootRef = useRef<HTMLDivElement>(null);
 		const scrollRef = useRef<HTMLDivElement>(null);
+		const scrollContentRef = useRef<HTMLDivElement>(null);
 		const bottomRef = useRef<HTMLDivElement>(null);
 		const [atBottom, setAtBottom] = useState(true);
 		const atBottomRef = useRef(atBottom);
@@ -133,10 +134,18 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 			return () => observer.disconnect();
 		}, []);
 
-		// Auto-scroll on new messages / streaming tokens when user is at bottom.
+		// Auto-scroll on new messages / streaming tokens. When the user
+		// just sent a message we always jump to the bottom — they expect
+		// to see what they typed and the response forming below it. For
+		// streaming assistant tokens we only stick if the user is already
+		// at the bottom, so reading older messages mid-stream isn't yanked
+		// away. Forcing the scroll on user submit also flips `atBottom`
+		// back to true, so widget iframes growing afterward (via the
+		// content ResizeObserver below) re-stick the view too.
 		// biome-ignore lint/correctness/useExhaustiveDependencies: scroll on length + last-message identity changes
 		useEffect(() => {
-			if (atBottomRef.current) {
+			const last = engine.messages[engine.messages.length - 1];
+			if (last?.role === "user" || atBottomRef.current) {
 				scrollToBottom("smooth");
 			}
 		}, [engine.messages.length, engine.messages[engine.messages.length - 1]]);
@@ -145,22 +154,50 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 			scrollToBottom("auto");
 		}, [scrollToBottom]);
 
-		// Keep the view pinned to the bottom when the scroll container resizes.
-		// The embed's host can settle asynchronously (ResizeObserver mirroring
-		// the parent's max-height runs after the first paint), which shrinks
-		// the scroll container and would otherwise leave scrollTop at 0 even
-		// though the initial mount effect already ran.
+		// Keep the view pinned to the bottom whenever either the scroll
+		// container or its inner content resizes. Two reasons:
+		//   - The embed host can settle asynchronously (`ResizeObserver`
+		//     mirroring the parent's max-height runs after the first paint)
+		//     which shrinks the scroll container.
+		//   - MCP App widgets render in iframes that grow once their
+		//     handshake completes and the host reports its content height;
+		//     the React `messages` array doesn't change, so the
+		//     length/identity effect above can't catch it.
+		//
+		// Track the previous scrollHeight so we can decide whether the user
+		// was at the bottom *before* this resize. `atBottom` from the
+		// IntersectionObserver is racy here: when an iframe suddenly grows,
+		// the bottom sentinel flicks out of view and the IO fires before
+		// the RO callback, leaving `atBottomRef.current = false` even
+		// though the user was clearly stuck to the bottom moments earlier.
 		useEffect(() => {
-			const scroller = scrollRef.current;
-			if (!scroller || typeof ResizeObserver === "undefined") {
+			if (typeof ResizeObserver === "undefined") {
 				return;
 			}
+			const scroller = scrollRef.current;
+			const content = scrollContentRef.current;
+			if (!scroller && !content) {
+				return;
+			}
+			let prevScrollHeight = scroller?.scrollHeight ?? 0;
 			const observer = new ResizeObserver(() => {
-				if (atBottomRef.current) {
+				const s = scrollRef.current;
+				if (!s) {
+					return;
+				}
+				const wasAtBottom =
+					s.scrollTop + s.clientHeight >= prevScrollHeight - 5;
+				prevScrollHeight = s.scrollHeight;
+				if (wasAtBottom) {
 					scrollToBottom("auto");
 				}
 			});
-			observer.observe(scroller);
+			if (scroller) {
+				observer.observe(scroller);
+			}
+			if (content) {
+				observer.observe(content);
+			}
 			return () => observer.disconnect();
 		}, [scrollToBottom]);
 
@@ -292,6 +329,7 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 					)}
 				>
 					<div
+						ref={scrollContentRef}
 						className={cn(
 							"ww:mx-auto ww:w-full ww:max-w-3xl ww:px-4 ww:py-6 ww:flex ww:flex-col ww:gap-6",
 							fullscreenToolCallId && "ww:!py-0",

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -164,12 +164,17 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 		//     the React `messages` array doesn't change, so the
 		//     length/identity effect above can't catch it.
 		//
-		// Track the previous scrollHeight so we can decide whether the user
-		// was at the bottom *before* this resize. `atBottom` from the
-		// IntersectionObserver is racy here: when an iframe suddenly grows,
-		// the bottom sentinel flicks out of view and the IO fires before
-		// the RO callback, leaving `atBottomRef.current = false` even
-		// though the user was clearly stuck to the bottom moments earlier.
+		// Track the previous scrollHeight *and* clientHeight so we can
+		// decide whether the user was at the bottom *before* this resize.
+		// `atBottom` from the IntersectionObserver is racy here: when an
+		// iframe suddenly grows, the bottom sentinel flicks out of view
+		// and the IO fires before the RO callback, leaving
+		// `atBottomRef.current = false` even though the user was clearly
+		// stuck to the bottom moments earlier. Both dimensions need the
+		// pre-resize value: e.g. when the host shrinks (its mirrored
+		// max-height settling), clientHeight drops while scrollHeight is
+		// unchanged, and using the post-resize clientHeight against the
+		// pre-resize scrollHeight would miss the at-bottom case.
 		useEffect(() => {
 			if (typeof ResizeObserver === "undefined") {
 				return;
@@ -180,14 +185,16 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 				return;
 			}
 			let prevScrollHeight = scroller?.scrollHeight ?? 0;
+			let prevClientHeight = scroller?.clientHeight ?? 0;
 			const observer = new ResizeObserver(() => {
 				const s = scrollRef.current;
 				if (!s) {
 					return;
 				}
 				const wasAtBottom =
-					s.scrollTop + s.clientHeight >= prevScrollHeight - 5;
+					s.scrollTop + prevClientHeight >= prevScrollHeight - 5;
 				prevScrollHeight = s.scrollHeight;
+				prevClientHeight = s.clientHeight;
 				if (wasAtBottom) {
 					scrollToBottom("auto");
 				}


### PR DESCRIPTION
## Summary

Two cases where the chat embed wasn't auto-scrolling to the latest content:

1. **User submit while not at bottom** — when the welcome message + suggestions made the chat scrollable from the start, sending a message did nothing visible. The user typed something and the view stayed put because the message-change effect only scrolled when \`atBottomRef.current\` was true.
2. **MCP App widget growth** — widgets render in iframes that grow asynchronously after a postMessage handshake. The React \`messages\` array doesn't change, so the existing length/identity effect couldn't catch it, and the view stayed scrolled to the previous bottom (now the middle).

## Fix

- On user-role messages, always scroll. They chose to send something; they expect to follow the conversation. Forcing the scroll also flips \`atBottom\` back to true, so widget iframes growing afterward re-stick the view.
- Observe the scroll container's inner content with \`ResizeObserver\`. On resize, re-scroll when the user was at the bottom *just before* this layout change. The pre-resize check uses the previous \`scrollHeight\` rather than the IntersectionObserver \`atBottom\` signal — when the iframe suddenly grows, the bottom sentinel flicks out of view and the IO fires before the RO callback, so the IO-based flag reads false even though the user was clearly stuck to the bottom moments earlier.

## Test plan

Verified in the Camby demo (\`http://localhost:3003/camby-demo-prod.html\`) with the widget-rendering message \`compare electricity tariffs\`:

- [x] Fresh thread, send the message → user bubble and rendered widget land at the bottom of the visible area, input still visible below.
- [x] Send a follow-up text message → assistant response streams while view stays pinned to bottom.
- [x] Mid-conversation user scrolls up to read older messages → streaming tokens do *not* yank them back (only stick when at bottom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to chat-embed scrolling, but it adjusts auto-scroll heuristics and resize handling which could affect edge-case scroll positioning.
> 
> **Overview**
> Fixes `ChatEmbed` auto-scroll behavior so sending a user message always scrolls to the latest content, while assistant streaming only auto-sticks when the user is already at the bottom.
> 
> Adds a `ResizeObserver` that watches both the scroll container and its inner content (tracked via a new `scrollContentRef`) and re-scrolls when the user was at-bottom *before* a resize, covering asynchronous host sizing changes and MCP widget/iframe height growth without new messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 320369ad7a123d5a4cfdac598da0986ecd5784ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->