### PR TITLE
feat(embed): add data-show-tool-calls and data-channel-id

### DIFF
--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -129,6 +129,14 @@ export interface ChatBaseProps {
 	 */
 	debug?: boolean;
 	/**
+	 * Show tool call details (request/response panels). When `false`, each
+	 * tool call renders as a compact indicator so the user can still tell
+	 * the agent is doing something, but the JSON panels are hidden.
+	 * MCP App widgets attached to a tool call are always rendered.
+	 * Defaults to `true`.
+	 */
+	showToolCalls?: boolean;
+	/**
 	 * Skip fetching `/config` and `/tools` from the API on mount.
 	 * Use when the chat endpoint doesn't serve these routes (e.g. embed widgets
 	 * talking directly to the WaniWani app).

--- a/src/chat/web/ai-elements/tool.tsx
+++ b/src/chat/web/ai-elements/tool.tsx
@@ -273,6 +273,41 @@ export function ToolHeader({
 	);
 }
 
+export type ToolIndicatorProps = HTMLAttributes<HTMLDivElement> & {
+	title?: string;
+	state: ToolUIPart["state"];
+};
+
+/**
+ * Compact, non-interactive replacement for {@link ToolHeader} +
+ * {@link ToolContent}. Shows just the tool title in muted text, with a
+ * pulsing dot while the tool is still running — enough for the user to
+ * know the agent is doing something without implying there are
+ * request/response details to expand.
+ */
+export function ToolIndicator({
+	className,
+	title,
+	state,
+	...props
+}: ToolIndicatorProps) {
+	const isRunning = state === "input-available" || state === "input-streaming";
+	return (
+		<div
+			className={cn(
+				"ww:mb-4 ww:flex ww:items-center ww:gap-2 ww:py-1.5 ww:text-sm ww:text-muted-foreground ww:italic",
+				className,
+			)}
+			{...props}
+		>
+			<span className="ww:truncate">{title}</span>
+			{isRunning && (
+				<span className="ww:size-2 ww:shrink-0 ww:rounded-full ww:bg-primary ww:animate-pulse" />
+			)}
+		</div>
+	);
+}
+
 export type ToolServerInfoProps = HTMLAttributes<HTMLDivElement> & {
 	serverName?: string;
 	serverIcon?: string;

--- a/src/chat/web/components/message-list.tsx
+++ b/src/chat/web/components/message-list.tsx
@@ -19,6 +19,7 @@ import {
 	ToolContent,
 	type ToolDefinitionsMap,
 	ToolHeader,
+	ToolIndicator,
 	ToolInput,
 	ToolOutput,
 } from "../ai-elements/tool";
@@ -81,6 +82,13 @@ interface MessageListProps {
 	/** When true, show _meta in tool call inputs and outputs. */
 	debug?: boolean;
 	/**
+	 * Show tool call details (request/response panels). When `false`, render a
+	 * compact tool indicator instead so the user can still tell the agent is
+	 * doing something. MCP App widgets attached to a tool call are always
+	 * rendered regardless of this flag. Defaults to `true`.
+	 */
+	showToolCalls?: boolean;
+	/**
 	 * Cached tool catalog keyed by tool name. Drives spec-canonical widget
 	 * resolution: if a tool's definition `_meta` carries a widget resource
 	 * URI, the widget renders regardless of whether the server echoed it
@@ -104,6 +112,7 @@ export function MessageList({
 	onWidgetDisplayModeChange,
 	fullscreenToolCallId,
 	debug,
+	showToolCalls = true,
 	toolDefinitions,
 }: MessageListProps) {
 	const isLoading = status === "submitted" || status === "streaming";
@@ -198,24 +207,31 @@ export function MessageList({
 									}
 								>
 									<div style={isFullscreen ? { display: "none" } : undefined}>
-										<Tool>
-											<ToolHeader
+										{showToolCalls ? (
+											<Tool>
+												<ToolHeader
+													title={part.title ?? formatToolName(part.toolName)}
+													state={part.state}
+												/>
+												<ToolContent>
+													<ToolInput input={part.input} debug={debug} />
+													{output !== undefined && (
+														<ToolOutput
+															output={output}
+															errorText={
+																"errorText" in part ? part.errorText : undefined
+															}
+															debug={debug}
+														/>
+													)}
+												</ToolContent>
+											</Tool>
+										) : (
+											<ToolIndicator
 												title={part.title ?? formatToolName(part.toolName)}
 												state={part.state}
 											/>
-											<ToolContent>
-												<ToolInput input={part.input} debug={debug} />
-												{output !== undefined && (
-													<ToolOutput
-														output={output}
-														errorText={
-															"errorText" in part ? part.errorText : undefined
-														}
-														debug={debug}
-													/>
-												)}
-											</ToolContent>
-										</Tool>
+										)}
 									</div>
 									{resourceUri && resourceEndpoint && output !== undefined && (
 										<WidgetErrorBoundary>

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -21,6 +21,22 @@ export interface EmbedConfig {
 	token: string;
 	/** Override MCP server URL (optional — resolved from environment by default). */
 	mcpServerUrl?: string;
+	/**
+	 * Agent channel ID. Sent to the chat API so the WaniWani app routes the
+	 * conversation to the right agent. Surfaced as `data-channel-id` on the
+	 * embed script tag.
+	 */
+	channelId?: string;
+	/**
+	 * Show tool call details (request/response panels) in the chat.
+	 *
+	 * When `false`, each tool call still renders a compact indicator so the
+	 * user can tell the agent is doing something, but the JSON request and
+	 * response panels are hidden. Defaults to `true`.
+	 *
+	 * Surfaced as `data-show-tool-calls` on the embed script tag.
+	 */
+	showToolCalls?: boolean;
 	/** Title shown in the chat header. Defaults to `"Assistant"`. */
 	title?: string;
 	/** Welcome message shown before the first user message. */
@@ -134,6 +150,16 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 	const mcpServerUrl = str("data-mcp-server-url");
 	if (mcpServerUrl) {
 		config.mcpServerUrl = mcpServerUrl;
+	}
+
+	const channelId = str("data-channel-id");
+	if (channelId) {
+		config.channelId = channelId;
+	}
+
+	const showToolCalls = bool("data-show-tool-calls");
+	if (showToolCalls !== undefined) {
+		config.showToolCalls = showToolCalls;
 	}
 
 	const css = str("data-css");

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -55,17 +55,21 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 
 		const theme = buildChatTheme(config);
 
+		const body: Record<string, unknown> = {};
+		if (config.mcpServerUrl) {
+			body.mcpServerUrl = config.mcpServerUrl;
+		}
+		if (config.channelId) {
+			body.channelId = config.channelId;
+		}
+
 		return (
 			<ChatEmbed
 				ref={chatRef}
 				api={config.api ?? ""}
 				headers={{ Authorization: `Bearer ${config.token}` }}
 				skipRemoteConfig
-				body={
-					config.mcpServerUrl
-						? { mcpServerUrl: config.mcpServerUrl }
-						: undefined
-				}
+				body={Object.keys(body).length > 0 ? body : undefined}
 				theme={theme}
 				title={config.title}
 				welcomeMessage={config.welcomeMessage}
@@ -74,6 +78,7 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 					config.suggestions ? { initial: config.suggestions } : undefined
 				}
 				enableThreadHistory={config.enableThreadHistory}
+				showToolCalls={config.showToolCalls}
 			/>
 		);
 	},

--- a/src/chat/web/layouts/chat-bar.tsx
+++ b/src/chat/web/layouts/chat-bar.tsx
@@ -48,6 +48,7 @@ export const ChatBar = forwardRef<ChatHandle, ChatBarProps>(
 			placeholder = "Ask me anything...",
 			triggerEvent = "triggerDemoRequest",
 			api,
+			showToolCalls = true,
 		} = props;
 
 		const expandedWidth =
@@ -269,6 +270,7 @@ export const ChatBar = forwardRef<ChatHandle, ChatBarProps>(
 								onFollowUp={handleWidgetMessage}
 								onCallTool={handleCallTool}
 								fullscreenToolCallId={fullscreenToolCallId}
+								showToolCalls={showToolCalls}
 								toolDefinitions={engine.toolDefinitions}
 								onWidgetDisplayModeChange={(mode, widget) => {
 									setFullscreenToolCallId(

--- a/src/chat/web/layouts/chat-card.tsx
+++ b/src/chat/web/layouts/chat-card.tsx
@@ -52,6 +52,7 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 			api,
 			debug,
 			enableThreadHistory = false,
+			showToolCalls = true,
 		} = props;
 
 		const effectiveApi = api ?? "/api/waniwani";
@@ -248,6 +249,7 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 							onCallTool={handleCallTool}
 							fullscreenToolCallId={fullscreenToolCallId}
 							debug={effectiveDebug}
+							showToolCalls={showToolCalls}
 							toolDefinitions={engine.toolDefinitions}
 							onWidgetDisplayModeChange={(mode, widget) => {
 								setFullscreenToolCallId(

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -59,6 +59,7 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 			title,
 			headerActions,
 			enableThreadHistory = false,
+			showToolCalls = true,
 		} = props;
 
 		const resolvedTheme = mergeTheme(userTheme);
@@ -355,6 +356,7 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 							onCallTool={handleCallTool}
 							fullscreenToolCallId={fullscreenToolCallId}
 							debug={debug}
+							showToolCalls={showToolCalls}
 							toolDefinitions={engine.toolDefinitions}
 							onWidgetDisplayModeChange={(mode, widget) => {
 								setFullscreenToolCallId(


### PR DESCRIPTION
## Summary

Two embed-script attributes requested by customers.

### \`data-show-tool-calls\` (default \`true\`)

When set to \`false\`, tool calls in the chat render as a compact italic line (e.g. *Pet Health Search*) instead of the expandable Request/Response card. The user can still tell the agent is doing something, but the JSON payloads are gone. MCP App widgets attached to a tool call are still rendered either way — they're the actual user-facing artifact.

Before / after on the Tuio demo:

| Before | After |
| --- | --- |
| { } Pet Health Search ▾ (Request {…}, Response {…}) | *Pet Health Search* |

### \`data-channel-id\`

Forwarded to the chat API as a \`channelId\` body field so the WaniWani app can route the conversation to the right agent. It was already showing up on customer scripts (incl. our own demo) but was silently dropped on the wire — this PR plumbs it through.

## Test plan

- [x] Tuio demo with \`data-show-tool-calls=\"false\"\`: tool calls render as compact italic indicators with no chevron, no JSON panels, and no faux-clickable affordance. MCP App widget iframes still render.
- [x] Default (attribute omitted or \`true\`): existing Request/Response collapsible card unchanged.
- [x] \`data-channel-id=\"...\"\` is sent in the request body and observable on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/config plumbing change; main risk is minor regressions in embed request bodies or tool-call rendering toggles across chat layouts.
> 
> **Overview**
> Adds a `showToolCalls` toggle to the chat UI so embeds (and other layouts) can hide tool call request/response JSON, rendering a compact non-interactive `ToolIndicator` while still showing any attached MCP widget iframes.
> 
> Extends embed configuration parsing to accept `data-show-tool-calls` and `data-channel-id`, forwarding `channelId` (and existing `mcpServerUrl`) in the chat request body and passing `showToolCalls` through `InlineChat` → `ChatEmbed`/`ChatCard`/`ChatBar` → `MessageList`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93213833f69b9c7d62412e0e7f5cae0c5da319dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->