### PR TITLE
feat(embed): "powered by WaniWani" attribution under input

### DIFF
--- a/src/chat/web/components/powered-by.tsx
+++ b/src/chat/web/components/powered-by.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+const LOGO_URL = "https://app.waniwani.ai/assets/waniwani-logo.svg";
+const HREF = "https://waniwani.ai";
+
+/**
+ * Small "powered by WaniWani" link rendered under the chat input. Mirrors
+ * the attribution pattern of other embedded chat widgets and links back to
+ * the WaniWani site.
+ */
+export function PoweredBy() {
+	return (
+		<div className="ww:pt-2 ww:pb-1 ww:flex ww:justify-center">
+			<a
+				href={HREF}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="ww:flex ww:items-center ww:gap-1.5 ww:text-[11px] ww:text-muted-foreground ww:opacity-70 hover:ww:opacity-100 ww:transition-opacity"
+			>
+				<span>powered by</span>
+				<img
+					src={LOGO_URL}
+					alt="WaniWani"
+					width={72}
+					height={10}
+					className="ww:h-2.5 ww:w-auto"
+				/>
+			</a>
+		</div>
+	);
+}

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -19,6 +19,7 @@ import {
 } from "../ai-elements/prompt-input";
 import { ChatQueue } from "../components/chat-queue";
 import { MessageList } from "../components/message-list";
+import { PoweredBy } from "../components/powered-by";
 import { Suggestions } from "../components/suggestions";
 import { ThreadMenu } from "../components/thread-menu";
 import { useCallTool } from "../hooks/use-call-tool";
@@ -394,7 +395,7 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 							queuedMessages={engine.queuedMessages}
 							onRemove={engine.removeQueuedMessage}
 						/>
-						<div className="ww:px-4 ww:pb-4 ww:pt-2">
+						<div className="ww:px-4 ww:pb-2 ww:pt-2">
 							<div className="ww:mx-auto ww:w-full ww:max-w-3xl">
 								<PromptInput
 									onSubmit={engine.handleSubmit}
@@ -416,6 +417,7 @@ export const ChatEmbed = forwardRef<ChatHandle, ChatEmbedProps>(
 										/>
 									</div>
 								</PromptInput>
+								<PoweredBy />
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary

Small "powered by [WaniWani wordmark]" link rendered below the chat input — mirrors the "AI agent powered by X" pattern used by other embedded widgets and links back to https://waniwani.ai.

The logo loads from \`https://app.waniwani.ai/assets/waniwani-logo.svg\` (the WaniWani wordmark) — no bundle bloat, no extra dist asset to maintain.

Only the embed (\`ChatEmbed\`) layout renders it. The compact \`ChatBar\` and the hosted \`ChatCard\` are unchanged.

## Test plan

- [x] Tuio Pet Care demo: attribution renders below the input, muted opacity, hover reveals full opacity. Logo loads correctly from the WaniWani CDN.
- [x] Click opens https://waniwani.ai in a new tab with \`rel="noopener noreferrer"\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change; main consideration is reliance on an externally hosted logo asset and minor spacing tweaks in the embed footer.
> 
> **Overview**
> Adds a new `PoweredBy` component that renders a muted "powered by" link with the WaniWani wordmark (loaded from `https://app.waniwani.ai/...`) and opens `https://waniwani.ai` in a new tab with `rel="noopener noreferrer"`.
> 
> Updates `ChatEmbed` to render this attribution directly under the `PromptInput` and adjusts bottom padding to accommodate the new footer element.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2a5e3413015c0879e2488600e2dea403ba8d0d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->