### PR TITLE
feat(mcp/server): add extractTurnCount helper for waniwani/turnCount _meta key

### DIFF
--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -53,6 +53,8 @@ const EXTERNAL_USER_ID_KEYS = [
 
 const CORRELATION_ID_KEYS = ["correlationId", "openai/requestId"] as const;
 
+const TURN_COUNT_KEYS = ["waniwani/turnCount"] as const;
+
 /** Meta key for flow execution path (nodesVisited, flowId). */
 export const FLOW_META_KEY = "waniwani/flow" as const;
 
@@ -86,6 +88,29 @@ export function extractCorrelationId(
 	meta: Record<string, unknown> | undefined,
 ): string | undefined {
 	return meta ? pickFirst(meta, CORRELATION_ID_KEYS) : undefined;
+}
+
+/**
+ * Number of user messages in the current chat session, as counted by the
+ * WaniWani app before dispatching the MCP request. Useful for MCPs that
+ * gate behavior on conversation length (e.g. compulsory email verification
+ * after N turns) without each MCP having to track turn state itself.
+ *
+ * Forwarded as `waniwani/turnCount` (non-negative integer).
+ */
+export function extractTurnCount(
+	meta: Record<string, unknown> | undefined,
+): number | undefined {
+	if (!meta) {
+		return undefined;
+	}
+	for (const key of TURN_COUNT_KEYS) {
+		const value = meta[key];
+		if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+			return value;
+		}
+	}
+	return undefined;
 }
 
 const SOURCE_SESSION_KEYS = [


### PR DESCRIPTION
## Summary

- Declares the canonical \`waniwani/turnCount\` _meta key alongside the existing key lists in \`src/mcp/server/utils.ts\`.
- Adds a typed \`extractTurnCount(meta)\` reader following the same pattern as \`extractSessionId\`, \`extractSource\`, etc.

## Why

The WaniWani app is starting to forward user-message count as \`waniwani/turnCount\` in MCP request \`_meta\` (companion PR: [WaniWani-AI/app#536](https://github.com/WaniWani-AI/app/pull/536)). This SDK addition is the canonical declaration of that key — useful for customer MCPs that want to gate behavior on conversation length without tracking turn state themselves.

First consumer: the Tuio pet-care MCP's new \`pet_chat\` flow ([tuio-pet-care#10](https://github.com/WaniWani-Managed/tuio-pet-care/pull/10)), which currently reads the \`_meta\` field directly via a small local helper. The SDK helper isn't strictly required — it's defensive infrastructure for future MCPs that prefer the typed extractor pattern.

## Status

**Strictly optional for the Tuio use case.** The MCP reads \`_meta[\"waniwani/turnCount\"]\` directly today. Merging this PR makes the key formally part of the SDK surface and gives future MCPs a typed accessor.

## Test plan

- [x] Existing tests pass (the function is additive, follows the established extractor pattern).
- [x] No callers in the SDK depend on the new function yet (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive helper only; low risk aside from potential downstream assumptions about `waniwani/turnCount` presence/type when adopted by callers.
> 
> **Overview**
> Adds canonical support for the `waniwani/turnCount` `_meta` field by introducing `TURN_COUNT_KEYS` and a new `extractTurnCount(meta)` helper in `src/mcp/server/utils.ts`.
> 
> The extractor returns a validated non-negative finite number (or `undefined`), enabling MCPs to gate behavior on conversation length without implementing their own turn-count parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2baad659b9dff2350a28b607d1d4f7c1db585737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->