### PR TITLE
fix: merge flow metadata from response _meta into tracked events

### DIFF
--- a/src/mcp/server/with-waniwani/helpers.ts
+++ b/src/mcp/server/with-waniwani/helpers.ts
@@ -3,7 +3,7 @@ import type {
 	TrackInput,
 } from "../../../tracking/index.js";
 import type { WaniWaniClient } from "../../../types.js";
-import { extractSessionId, extractSource } from "../utils.js";
+import { extractSessionId, extractSource, FLOW_META_KEY } from "../utils.js";
 import type { WidgetTokenCache } from "../widget-token.js";
 import type { FunnelSyncPayload } from "./funnel-sync.js";
 
@@ -140,6 +140,18 @@ export function buildTrackInput(
 				}
 			: io?.output;
 
+	const responseMeta =
+		isRecord(io?.output) && isRecord((io.output as UnknownRecord)._meta)
+			? ((io.output as UnknownRecord)._meta as UnknownRecord)
+			: undefined;
+	const flowMeta = responseMeta?.[FLOW_META_KEY];
+	const mergedMeta =
+		flowMeta && meta
+			? { ...meta, [FLOW_META_KEY]: flowMeta }
+			: flowMeta
+				? { [FLOW_META_KEY]: flowMeta }
+				: meta;
+
 	return {
 		event: "tool.called",
 		properties: {
@@ -149,7 +161,7 @@ export function buildTrackInput(
 			...(input !== undefined && { input }),
 			...(output !== undefined && { output }),
 		},
-		meta,
+		meta: mergedMeta,
 		source: extractSource(meta),
 		metadata: {
 			...(options.metadata ?? {}),


### PR DESCRIPTION
## Summary

- Flow execution sets `waniwani/flow` metadata (flowId + nodesVisited) on the tool **response** `_meta` in `compile.ts`, but `buildTrackInput` only read meta from the **request** `_meta` — the response flow data was never merged into the tracked event
- This caused all `tool.called` events to be missing `waniwani/flow` in their `meta`, making use case analytics (funnel tracking) return zero results
- Fix: extract `waniwani/flow` from the response `_meta` and merge it into the event's `meta` field