### PR TITLE
feat(mcp/react): add unstable_useSendFollowUpWithGhostGuard

### DIFF
--- a/src/legacy/mcp/react/hooks/index.ts
+++ b/src/legacy/mcp/react/hooks/index.ts
@@ -7,6 +7,8 @@ export type {
 } from "../../../../shared/model-context";
 // Types
 export type * from "./@types";
+export type { UnstableSendFollowUpWithGhostGuardResult } from "./unstable-use-send-follow-up";
+export { unstable_useSendFollowUpWithGhostGuard } from "./unstable-use-send-follow-up";
 export { useCallTool } from "./use-call-tool";
 export { useDisplayMode } from "./use-display-mode";
 export type { FlowActionResult } from "./use-flow-action";

--- a/src/legacy/mcp/react/hooks/unstable-use-send-follow-up.tsx
+++ b/src/legacy/mcp/react/hooks/unstable-use-send-follow-up.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import {
+	type JSX,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+} from "react";
+import { WidgetClientContext } from "../../../../mcp/react/context";
+import type { SendFollowUpOptions } from "./use-send-follow-up";
+
+const ADVANCED_KEY_PREFIX = "waniwani:send-follow-up:advanced:";
+const ADVANCED_WINDOW_MS = 10_000;
+
+type AdvancedRecord = { at: number; byMountId: string };
+
+function advancedKeyFor(viewUUID: string | undefined): string {
+	return `${ADVANCED_KEY_PREFIX}${viewUUID ?? "default"}`;
+}
+
+function readAdvanced(viewUUID: string | undefined): AdvancedRecord | null {
+	try {
+		const raw = globalThis.localStorage?.getItem(advancedKeyFor(viewUUID));
+		if (!raw) {
+			return null;
+		}
+		const parsed = JSON.parse(raw) as AdvancedRecord;
+		if (
+			typeof parsed?.at !== "number" ||
+			typeof parsed?.byMountId !== "string"
+		) {
+			return null;
+		}
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+function markAdvanced(viewUUID: string | undefined, byMountId: string): void {
+	try {
+		globalThis.localStorage?.setItem(
+			advancedKeyFor(viewUUID),
+			JSON.stringify({ at: Date.now(), byMountId } satisfies AdvancedRecord),
+		);
+	} catch {
+		// quota / security errors — best effort
+	}
+}
+
+/**
+ * Same heuristic the legacy `InitializeNextJsInIframe` helper uses
+ * (`typeof window.openai !== "undefined"`), but evaluated at call time so
+ * it works in any iframe ChatGPT loads — we can't depend on
+ * `useIsChatGptApp` because that reads `window.__isChatGptApp`, which is
+ * only set by the Next.js helper. Widgets built directly on skybridge
+ * never get that flag.
+ */
+function isChatGptHost(): boolean {
+	if (typeof window === "undefined") {
+		return false;
+	}
+	// biome-ignore lint/suspicious/noExplicitAny: ChatGPT injects `window.openai`
+	return typeof (window as any).openai === "object";
+}
+
+interface ChatGPTHostBridge {
+	toolResponseMetadata?: { viewUUID?: unknown } | null;
+}
+
+function getChatGptHostBridge(): ChatGPTHostBridge | null {
+	if (!isChatGptHost()) {
+		return null;
+	}
+	// biome-ignore lint/suspicious/noExplicitAny: ChatGPT injects `window.openai`
+	return (window as any).openai as ChatGPTHostBridge;
+}
+
+/**
+ * Collapses the iframe document to 0×0 with a transparent background by
+ * overriding `<html>` and `<body>` inline styles. The host's auto-resize
+ * (ResizeObserver on documentElement/body) then notifies ChatGPT that the
+ * iframe should shrink — without this, ChatGPT keeps the iframe at its
+ * default size with whatever background the widget's CSS paints.
+ */
+function GhostSuppressor(): null {
+	useLayoutEffect(() => {
+		const html = document.documentElement;
+		const body = document.body;
+		const prevHtmlStyle = html.getAttribute("style");
+		const prevBodyStyle = body.getAttribute("style");
+		const zero =
+			"margin:0!important;padding:0!important;border:0!important;background:transparent!important;background-color:transparent!important;height:0!important;min-height:0!important;max-height:0!important;overflow:hidden!important;";
+		html.setAttribute("style", zero);
+		body.setAttribute("style", zero);
+		return () => {
+			if (prevHtmlStyle === null) {
+				html.removeAttribute("style");
+			} else {
+				html.setAttribute("style", prevHtmlStyle);
+			}
+			if (prevBodyStyle === null) {
+				body.removeAttribute("style");
+			} else {
+				body.setAttribute("style", prevBodyStyle);
+			}
+		};
+	}, []);
+	return null;
+}
+
+export interface UnstableSendFollowUpWithGhostGuardResult {
+	/** Wrapped `sendFollowUp`. Same signature as the one you passed in. */
+	sendFollowUp: (prompt: string, options?: SendFollowUpOptions) => void;
+	/**
+	 * Wrap your widget's root render with this so the suppression can take
+	 * effect. On non-ChatGPT hosts it is a transparent pass-through.
+	 */
+	Guard: (props: { children: ReactNode }) => JSX.Element | null;
+}
+
+/**
+ * ⚠️ EXPERIMENTAL — DO NOT USE UNLESS YOU UNDERSTAND THE TRADE-OFFS ⚠️
+ *
+ * Wraps an existing `sendFollowUp` with ghost-guard suppression specific
+ * to ChatGPT. ChatGPT renders the source widget a SECOND time alongside
+ * the new user message a widget emits via `sendFollowUpMessage`. The
+ * second iframe is a brand-new React tree with no link to the original;
+ * skybridge's `useViewState` persistence does not survive across them.
+ * The result is a visible duplicate widget for ~1s before ChatGPT
+ * collapses one of them.
+ *
+ * On ChatGPT the hook adds a per-`viewUUID` `localStorage` write before
+ * each `sendFollowUp` call, and the returned `Guard` checks that record
+ * on mount — if it sees a record set by a different `mountId` within
+ * `ADVANCED_WINDOW_MS`, it collapses the iframe to 0×0.
+ *
+ * On every other host (WaniWani embed, MCP Apps, etc.) the hook is a
+ * pure pass-through: `sendFollowUp` is your function unchanged and
+ * `Guard` is a transparent fragment.
+ *
+ * The hook does NOT require `WidgetProvider`. It reads the widget's
+ * `viewUUID` from `WidgetClientContext` when one is available and falls
+ * back to `window.openai.toolResponseMetadata.viewUUID` otherwise.
+ *
+ * Caveats:
+ *  - Relies on ChatGPT's widget iframes sharing a single `localStorage`
+ *    scope — verified at the time of writing but not guaranteed.
+ *  - 10s suppression window per `viewUUID`. Two unrelated `sendFollowUp`
+ *    calls inside 10s with the same viewUUID could mistakenly suppress one.
+ *  - The `Guard` MUST wrap the widget's root render. If you forget it,
+ *    the localStorage write happens but nothing is suppressed.
+ *
+ * @param sendFollowUp - The underlying `sendFollowUp` to wrap. On ChatGPT the
+ *   hook adds the per-`viewUUID` localStorage write before delegating; on any
+ *   other host the hook is a pure pass-through. Typically the value of
+ *   `useSendFollowUpMessage()` from `skybridge/web` or `useSendFollowUp()`
+ *   from this module.
+ *
+ * @example
+ *   function MyWidget() {
+ *     const sendFollowUpMessage = useSendFollowUpMessage(); // skybridge/web
+ *     const { sendFollowUp, Guard } =
+ *       unstable_useSendFollowUpWithGhostGuard(sendFollowUpMessage);
+ *
+ *     // The Guard MUST wrap the widget's root render, otherwise the ghost
+ *     // iframe will not be suppressed.
+ *     return (
+ *       <Guard>
+ *         <div className="my-widget">
+ *           <button onClick={() => sendFollowUp("I uploaded my bill")}>
+ *             Continue
+ *           </button>
+ *         </div>
+ *       </Guard>
+ *     );
+ *   }
+ *
+ * @experimental Subject to change or removal without notice.
+ */
+export function unstable_useSendFollowUpWithGhostGuard(
+	sendFollowUp: (prompt: string) => void | Promise<void>,
+): UnstableSendFollowUpWithGhostGuardResult {
+	const client = useContext(WidgetClientContext);
+	const innerRef = useRef(sendFollowUp);
+	innerRef.current = sendFollowUp;
+
+	// Read viewUUID from whichever source is available: the widget client
+	// (when wrapped in WidgetProvider) or the raw ChatGPT host global.
+	const clientMetadata = client?.getToolResponseMetadata?.() ?? null;
+	const hostMetadata = getChatGptHostBridge()?.toolResponseMetadata ?? null;
+	const metadata = clientMetadata ?? hostMetadata;
+	const viewUUID =
+		metadata &&
+		typeof (metadata as { viewUUID?: unknown }).viewUUID === "string"
+			? (metadata as { viewUUID: string }).viewUUID
+			: undefined;
+
+	const mountIdRef = useRef<string>("");
+	if (mountIdRef.current === "") {
+		mountIdRef.current = crypto.randomUUID();
+	}
+
+	const wrappedSendFollowUp = useCallback(
+		(prompt: string, _options?: SendFollowUpOptions) => {
+			if (isChatGptHost()) {
+				markAdvanced(viewUUID, mountIdRef.current);
+			}
+			try {
+				void Promise.resolve(innerRef.current(prompt)).catch((err) => {
+					console.error("[unstable_useSendFollowUpWithGhostGuard]", err);
+				});
+			} catch (err) {
+				console.error("[unstable_useSendFollowUpWithGhostGuard]", err);
+			}
+		},
+		[viewUUID],
+	);
+
+	const Guard = useMemo(() => {
+		const mountId = mountIdRef.current;
+		return function Guard({
+			children,
+		}: {
+			children: ReactNode;
+		}): JSX.Element | null {
+			if (!isChatGptHost()) {
+				return <>{children}</>;
+			}
+			const advanced = readAdvanced(viewUUID);
+			if (
+				advanced &&
+				advanced.byMountId !== mountId &&
+				Date.now() - advanced.at < ADVANCED_WINDOW_MS
+			) {
+				return <GhostSuppressor />;
+			}
+			return <>{children}</>;
+		};
+	}, [viewUUID]);
+
+	return { sendFollowUp: wrappedSendFollowUp, Guard };
+}

--- a/src/legacy/mcp/react/index.ts
+++ b/src/legacy/mcp/react/index.ts
@@ -34,8 +34,10 @@ export type {
 	ModelContextContentBlock,
 	ModelContextUpdate,
 	SendFollowUpOptions,
+	UnstableSendFollowUpWithGhostGuardResult,
 } from "./hooks/index";
 export {
+	unstable_useSendFollowUpWithGhostGuard,
 	useCallTool,
 	useDisplayMode,
 	useFlowAction,

--- a/src/mcp/react/index.ts
+++ b/src/mcp/react/index.ts
@@ -21,6 +21,7 @@ export type {
 	ToolResult,
 	UnifiedWidgetClient,
 	UnknownObject,
+	UnstableSendFollowUpWithGhostGuardResult,
 	UserAgent,
 	WidgetPlatform,
 } from "../../legacy/mcp/react";
@@ -33,6 +34,7 @@ export {
 	isMCPApps,
 	isOpenAI,
 	LoadingWidget,
+	unstable_useSendFollowUpWithGhostGuard,
 	updateMockDisplayMode,
 	updateMockGlobal,
 	updateMockTheme,


### PR DESCRIPTION
## Summary

Adds an experimental `unstable_useSendFollowUpWithGhostGuard` hook that wraps a consumer-provided `sendFollowUp` with ChatGPT-specific suppression logic for the duplicate-widget UX glitch.

When a widget calls `sendFollowUpMessage` on ChatGPT, the host renders the source widget a second time alongside the new user message. That second iframe is a brand-new React tree with no link to the original, so skybridge's `useViewState` persistence doesn't carry over and the ghost renders the widget from scratch — visible as a duplicate widget for ~1s before ChatGPT collapses one of them.

On ChatGPT the hook adds a per-`viewUUID` `localStorage` write before each `sendFollowUp` call, and the returned `<Guard>` checks that record on mount — if it sees a record set by a different `mountId` within `ADVANCED_WINDOW_MS` (10s), it collapses the iframe to 0×0 by overriding `<html>`/`<body>` inline styles. The host's auto-resize then notifies ChatGPT to shrink the iframe chrome.

On every other host the hook is a pure pass-through: `sendFollowUp` is your function unchanged and `Guard` is a transparent fragment.

## API

The hook takes the `sendFollowUp` you'd otherwise call directly as its single argument. The returned `Guard` MUST wrap the widget's root render — without it, the localStorage write happens but the ghost iframe is not suppressed.

```tsx
function MyWidget() {
  const sendFollowUpMessage = useSendFollowUpMessage(); // skybridge/web
  const { sendFollowUp, Guard } =
    unstable_useSendFollowUpWithGhostGuard(sendFollowUpMessage);

  return (
    <Guard>
      <div className="my-widget">
        <button onClick={() => sendFollowUp("I did a thing!")}>
          Continue
        </button>
        <button onClick={() => sendFollowUp("I skipped a thing!")}>
          Skip
        </button>
      </div>
    </Guard>
  );
}
```

## Design notes

- **Wraps a consumer-provided `sendFollowUp`** rather than reimplementing transport. On ChatGPT the hook adds the localStorage write and Guard logic; on every other host it's a pure pass-through. Consumers keep using whatever `sendFollowUp` they already have (skybridge's `useSendFollowUpMessage`, this module's `useSendFollowUp`, etc.).
- **No `WidgetProvider` requirement.** Reads `viewUUID` from `WidgetClientContext` when available and falls back to `window.openai.toolResponseMetadata` directly. Usable from widgets built on skybridge primitives that don't adopt the full waniwani widget runtime.
- **ChatGPT detection via `typeof window.openai === "object"`** rather than `useIsChatGptApp`. `useIsChatGptApp` reads `window.__isChatGptApp`, which is only set by the legacy Next.js `InitializeNextJsInIframe` helper — widgets built directly on skybridge never get that flag.

## Caveats (documented inline + `@experimental`)

- Relies on ChatGPT's widget iframes sharing a single `localStorage` scope.
- 10s suppression window per `viewUUID`; two unrelated `sendFollowUp` calls inside 10s with the same viewUUID could mistakenly suppress one.
- Suppression is no-op on non-ChatGPT hosts.
- The `Guard` MUST wrap the widget's root render — without it, the localStorage write happens but the ghost iframe is not suppressed.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun x biome check` passes
- [x] Verified end-to-end on an app in ChatGPT: localStorage record written on click, second iframe collapses to 0×0
- [x] Verified on WaniWani playground: pass-through, no warning, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client-side behavior that uses `localStorage` coordination and forcibly overrides `<html>/<body>` styles to collapse ChatGPT iframes, which could affect rendering/sizing in host environments if the detection heuristic is wrong.
> 
> **Overview**
> Adds **experimental** `unstable_useSendFollowUpWithGhostGuard`, which wraps a consumer-provided `sendFollowUp` and returns a `Guard` component that suppresses ChatGPT’s duplicate follow-up iframe by writing a per-`viewUUID` marker to `localStorage` and, on a subsequent mount within 10s from a different mount, collapsing the document to 0×0 via inline style overrides.
> 
> The hook is exported through both `src/legacy/mcp/react` and `src/mcp/react`, including the new `UnstableSendFollowUpWithGhostGuardResult` type, while remaining a no-op pass-through on non-ChatGPT hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aef5ef88a30447fddbab5af9ea6d3da501a83c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->