### PR TITLE
chore: route @waniwani-ai scope to GitHub Packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+; @waniwani-ai scope lives on GitHub Packages (private).
+; NODE_AUTH_TOKEN must be set to a PAT with read:packages scope locally,
+; or to ${{ secrets.GITHUB_TOKEN }} in same-org GitHub Actions workflows.
+@waniwani-ai:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
## Summary

Adds `.npmrc` so `bun install` (and `npm install`) routes the `@waniwani-ai/*` scope to **GitHub Packages** instead of the public npm registry. Auth via the `NODE_AUTH_TOKEN` env var.

Forward-looking infrastructure for [WaniWani-AI/app#585](https://github.com/WaniWani-AI/app/pull/585) (WAN-372), which now publishes `@waniwani-ai/api-client` to GitHub Packages. Nothing in this repo depends on `@waniwani-ai/*` yet — the `.npmrc` stays dormant until the first import lands. This unblocks Batch 1 of the typesafe-API migration (sdk's `kb/client.ts` rewrite around the typed client).

## What's not in this PR (deliberate)

- **No CI workflow changes.** Current installs don't touch `@waniwani-ai/*`, so adding `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to CI workflows is unnecessary today. Will land alongside the first `@waniwani-ai/api-client` import.
- **No CONTRIBUTING/README updates.** Same reason — local devs don't need a PAT until pulling a branch that adds an `@waniwani-ai/*` dep.

## Test plan

- [ ] CI passes (no behavior change for current installs)
- [ ] `bun install` still works locally on the existing `package.json`
