### PR TITLE
fix(mcp/react): require resolved source before emitting events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.12.3",
+  "version": "0.12.2",
   "description": "MCP distribution SDK. Build sales funnels, lead generation, booking, and quote apps on top of your MCP server. Event tracking, flows, widgets, knowledge base.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "MCP distribution SDK. Build sales funnels, lead generation, booking, and quote apps on top of your MCP server. Event tracking, flows, widgets, knowledge base.",
   "type": "module",
   "exports": {

--- a/src/mcp/react/hooks/__tests__/auto-capture.test.ts
+++ b/src/mcp/react/hooks/__tests__/auto-capture.test.ts
@@ -35,7 +35,7 @@ describe("data-ww-conversion", () => {
 		document.body.appendChild(btn);
 
 		cleanup = initAutoCapture(
-			{ sessionId: "sess-1", traceId: "trace-1" },
+			{ sessionId: "sess-1", traceId: "trace-1", source: "chatgpt" },
 			(events) => enqueued.push(events),
 		);
 		btn.click();
@@ -60,7 +60,7 @@ describe("data-ww-conversion", () => {
 		document.body.appendChild(btn);
 
 		cleanup = initAutoCapture(
-			{ sessionId: "sess-1", traceId: "trace-1" },
+			{ sessionId: "sess-1", traceId: "trace-1", source: "chatgpt" },
 			(events) => enqueued.push(events),
 		);
 		btn.click();
@@ -84,7 +84,7 @@ describe("data-ww-conversion", () => {
 		document.body.appendChild(btn);
 
 		cleanup = initAutoCapture(
-			{ sessionId: "sess-1", traceId: "trace-1" },
+			{ sessionId: "sess-1", traceId: "trace-1", source: "chatgpt" },
 			(events) => enqueued.push(events),
 		);
 		span.click();
@@ -105,7 +105,7 @@ describe("data-ww-conversion", () => {
 		document.body.appendChild(btn);
 
 		cleanup = initAutoCapture(
-			{ sessionId: "sess-1", traceId: "trace-1" },
+			{ sessionId: "sess-1", traceId: "trace-1", source: "chatgpt" },
 			(events) => enqueued.push(events),
 		);
 		btn.click();
@@ -133,7 +133,7 @@ describe("data-ww-step", () => {
 		document.body.appendChild(btn2);
 
 		cleanup = initAutoCapture(
-			{ sessionId: "sess-1", traceId: "trace-1" },
+			{ sessionId: "sess-1", traceId: "trace-1", source: "chatgpt" },
 			(events) => enqueued.push(events),
 		);
 		btn1.click();
@@ -157,7 +157,7 @@ describe("data-ww-step", () => {
 		document.body.appendChild(btn);
 
 		cleanup = initAutoCapture(
-			{ sessionId: "sess-1", traceId: "trace-1" },
+			{ sessionId: "sess-1", traceId: "trace-1", source: "chatgpt" },
 			(events) => enqueued.push(events),
 		);
 		btn.click();
@@ -183,7 +183,7 @@ describe("data-ww-step", () => {
 		document.body.appendChild(btn);
 
 		cleanup = initAutoCapture(
-			{ sessionId: "sess-1", traceId: "trace-1" },
+			{ sessionId: "sess-1", traceId: "trace-1", source: "chatgpt" },
 			(events) => enqueued.push(events),
 		);
 		span.click();
@@ -201,7 +201,7 @@ describe("data-ww-step", () => {
 		document.body.appendChild(btn);
 
 		cleanup = initAutoCapture(
-			{ sessionId: "sess-1", traceId: "trace-1" },
+			{ sessionId: "sess-1", traceId: "trace-1", source: "chatgpt" },
 			(events) => enqueued.push(events),
 		);
 		btn.click();

--- a/src/mcp/react/hooks/__tests__/use-waniwani.test.ts
+++ b/src/mcp/react/hooks/__tests__/use-waniwani.test.ts
@@ -173,17 +173,6 @@ describe("auto-capture (baseFields)", () => {
 	});
 });
 
-// ── Source attribution regression ─────────────────────────────────────
-//
-// Regression: prior versions stamped events with the literal string
-// "widget" when no source had been resolved from the request `_meta`.
-// That synthetic value corrupted per-session attribution on the backend
-// (sessions that should have shown "chatgpt" / "chatbar" / etc. ended up
-// bucketed under "widget"). Two layers now guarantee the placeholder
-// cannot leak: `useWaniwani` refuses to start the tracker without a
-// known source, and `toV2Envelope` passes `ev.source` through verbatim
-// instead of papering it over.
-
 describe("source attribution", () => {
 	const mockFetch = mock(() =>
 		Promise.resolve(new Response("{}", { status: 200 })),

--- a/src/mcp/react/hooks/__tests__/use-waniwani.test.ts
+++ b/src/mcp/react/hooks/__tests__/use-waniwani.test.ts
@@ -172,3 +172,48 @@ describe("auto-capture (baseFields)", () => {
 		expect((event.metadata as Record<string, unknown>)?.click_x).toBe(100);
 	});
 });
+
+// ── Source attribution regression ─────────────────────────────────────
+//
+// Regression: prior versions stamped events with the literal string
+// "widget" when no source had been resolved from the request `_meta`.
+// That synthetic value corrupted per-session attribution on the backend
+// (sessions that should have shown "chatgpt" / "chatbar" / etc. ended up
+// bucketed under "widget"). Two layers now guarantee the placeholder
+// cannot leak: `useWaniwani` refuses to start the tracker without a
+// known source, and `toV2Envelope` passes `ev.source` through verbatim
+// instead of papering it over.
+
+describe("source attribution", () => {
+	const mockFetch = mock(() =>
+		Promise.resolve(new Response("{}", { status: 200 })),
+	);
+
+	beforeEach(() => {
+		mockFetch.mockClear();
+		globalThis.fetch = mockFetch as unknown as typeof fetch;
+	});
+
+	test("toV2Envelope preserves the explicit source verbatim", async () => {
+		const { WidgetTransport } = await import("../widget-transport");
+		const transport = new WidgetTransport({
+			endpoint: "https://app.waniwani.ai/api/mcp/events/v2/batch",
+		});
+
+		transport.send([
+			{
+				event_id: "e1",
+				event_type: "widget_click",
+				timestamp: new Date().toISOString(),
+				source: "chatgpt",
+			},
+		]);
+
+		await transport.flush();
+		transport.stop();
+
+		const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+		const body = JSON.parse(opts.body as string);
+		expect(body.events[0].source).toBe("chatgpt");
+	});
+});

--- a/src/mcp/react/hooks/auto-capture.ts
+++ b/src/mcp/react/hooks/auto-capture.ts
@@ -22,7 +22,12 @@ interface AutoCaptureConfig {
 	sessionId?: string;
 	traceId?: string;
 	metadata?: Record<string, unknown>;
-	source?: string;
+	/**
+	 * Required. The caller (`useWaniwani`) refuses to start auto-capture without
+	 * a resolved source so events never get stamped with a misleading
+	 * placeholder.
+	 */
+	source: string;
 	capture?: AutoCaptureToggles;
 }
 
@@ -39,7 +44,7 @@ function baseFields(
 		event_id: eventId(),
 		event_type: eventType,
 		timestamp: new Date().toISOString(),
-		source: config.source ?? "widget",
+		source: config.source,
 		session_id: config.sessionId,
 		trace_id: config.traceId,
 		...extra,

--- a/src/mcp/react/hooks/auto-capture.ts
+++ b/src/mcp/react/hooks/auto-capture.ts
@@ -22,11 +22,6 @@ interface AutoCaptureConfig {
 	sessionId?: string;
 	traceId?: string;
 	metadata?: Record<string, unknown>;
-	/**
-	 * Required. The caller (`useWaniwani`) refuses to start auto-capture without
-	 * a resolved source so events never get stamped with a misleading
-	 * placeholder.
-	 */
 	source: string;
 	capture?: AutoCaptureToggles;
 }

--- a/src/mcp/react/hooks/use-waniwani.ts
+++ b/src/mcp/react/hooks/use-waniwani.ts
@@ -24,10 +24,7 @@ interface WaniwaniConfig {
 	source?: string;
 }
 
-/**
- * Options for the useWaniwani hook.
- */
-export interface UseWaniwaniOptions {
+interface BaseUseWaniwaniOptions {
 	/**
 	 * JWT widget token for authenticating directly with the WaniWani backend.
 	 * If omitted, the hook resolves from tool response metadata
@@ -35,23 +32,11 @@ export interface UseWaniwaniOptions {
 	 */
 	token?: string;
 	/**
-	 * The V2 batch endpoint URL to POST tracking events to.
-	 * If omitted, the hook resolves from tool response metadata
-	 * (`toolResponseMetadata.waniwani` or `toolResponseMetadata._meta.waniwani`).
-	 */
-	endpoint?: string;
-	/**
 	 * Session ID to use for event correlation.
 	 * If omitted, the hook resolves from tool response metadata
 	 * (`toolResponseMetadata.waniwani.sessionId`), then falls back to a random UUID.
 	 */
 	sessionId?: string;
-	/**
-	 * Originating session source (e.g. `"chatgpt"`, `"chatbar"`, `"playground"`).
-	 * If omitted, the hook resolves from tool response metadata
-	 * (`toolResponseMetadata.waniwani.source`).
-	 */
-	source?: string;
 	/**
 	 * Additional metadata to include with every tracked event.
 	 */
@@ -66,6 +51,34 @@ export interface UseWaniwaniOptions {
 	 */
 	capture?: AutoCaptureToggles;
 }
+
+/**
+ * Context-driven options: `endpoint` and `source` are resolved from
+ * `WidgetProvider`'s `toolResponseMetadata.waniwani`. `source` may be
+ * overridden explicitly.
+ */
+interface ContextDrivenOptions extends BaseUseWaniwaniOptions {
+	endpoint?: undefined;
+	/** Optional override; otherwise resolved from context. */
+	source?: string;
+}
+
+/**
+ * Explicit-endpoint options: when `endpoint` is passed directly, `source`
+ * is required so events never get stamped with a placeholder.
+ */
+interface ExplicitEndpointOptions extends BaseUseWaniwaniOptions {
+	/** V2 batch endpoint URL to POST tracking events to. */
+	endpoint: string;
+	/** Required when `endpoint` is explicit (e.g. `"chatgpt"`, `"chatbar"`). */
+	source: string;
+}
+
+/**
+ * Options for the useWaniwani hook. Either rely on `WidgetProvider`
+ * context (omit `endpoint`) or pass `endpoint` + `source` explicitly.
+ */
+export type UseWaniwaniOptions = ContextDrivenOptions | ExplicitEndpointOptions;
 
 /**
  * The tracking API returned by `useWaniwani()`.

--- a/src/mcp/react/hooks/use-waniwani.ts
+++ b/src/mcp/react/hooks/use-waniwani.ts
@@ -361,29 +361,20 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 	captureRef.current = options.capture;
 	const captureKey = captureKeyOf(options.capture);
 
-	// Track consumer mount/unmount for singleton lifecycle
-	useEffect(() => {
-		consumerCount++;
-		return () => {
-			consumerCount = Math.max(consumerCount - 1, 0);
-			if (consumerCount === 0) {
-				state?.cleanup();
-				state = null;
-			}
-		};
-	}, []);
-
 	// Create/swap singleton state when config changes.
 	// All side effects (timers, DOM listeners) happen here in useEffect,
 	// making this safe in Strict Mode and concurrent rendering.
+	//
+	// Only consumers with a resolved config hold a stake in the singleton.
+	// A consumer with `config === null` becomes a local no-op without
+	// touching the singleton (other consumers may still be driving it),
+	// and the singleton is torn down only when the last stake is released.
 	useEffect(() => {
 		if (typeof window === "undefined") {
 			return;
 		}
 
 		if (!config) {
-			// Local no-op: another consumer may still be driving the singleton,
-			// so don't tear it down here.
 			setWidget(NOOP_WIDGET);
 			return;
 		}
@@ -395,7 +386,16 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 			state?.cleanup();
 			state = createState(config, metadataRef.current, captureRef.current);
 		}
-		setWidget(state?.widget ?? NOOP_WIDGET);
+		setWidget(state.widget);
+		consumerCount++;
+
+		return () => {
+			consumerCount = Math.max(consumerCount - 1, 0);
+			if (consumerCount === 0) {
+				state?.cleanup();
+				state = null;
+			}
+		};
 	}, [config, captureKey]);
 
 	return widget;

--- a/src/mcp/react/hooks/use-waniwani.ts
+++ b/src/mcp/react/hooks/use-waniwani.ts
@@ -47,6 +47,16 @@ export interface UseWaniwaniOptions {
 	 */
 	sessionId?: string;
 	/**
+	 * Originating session source (e.g. `"chatgpt"`, `"chatbar"`, `"playground"`).
+	 * If omitted, the hook resolves from tool response metadata
+	 * (`toolResponseMetadata.waniwani.source`). When neither an explicit option
+	 * nor context provides a source the tracker stays a no-op — events are
+	 * dropped rather than emitted with a misleading default — so that callers
+	 * that pass `endpoint` without a known source don't pollute session
+	 * attribution.
+	 */
+	source?: string;
+	/**
 	 * Additional metadata to include with every tracked event.
 	 */
 	metadata?: Record<string, unknown>;
@@ -83,10 +93,14 @@ const NOOP_WIDGET: WaniwaniWidget = {
 	conversion() {},
 };
 
+interface ResolvedConfig extends WaniwaniConfig {
+	source: string;
+}
+
 interface WidgetState {
 	widget: WaniwaniWidget;
 	cleanup: () => void;
-	config: WaniwaniConfig | null;
+	config: ResolvedConfig | null;
 	captureKey: string;
 }
 
@@ -204,7 +218,7 @@ function useContextConfig(
 }
 
 function createState(
-	config: WaniwaniConfig,
+	config: ResolvedConfig,
 	metadata?: Record<string, unknown>,
 	capture?: AutoCaptureToggles,
 ): WidgetState {
@@ -223,7 +237,7 @@ function createState(
 		transport.send(events);
 	};
 
-	const source = config.source ?? "widget";
+	const source = config.source;
 
 	const cleanupCapture = initAutoCapture(
 		{ sessionId, traceId, metadata, source, capture },
@@ -304,9 +318,9 @@ function createState(
  * instance shared across all consumers.
  *
  * Config resolution order:
- * 1. Explicit `endpoint` (+ optional `token` / `sessionId`) options
+ * 1. Explicit `endpoint` / `token` / `sessionId` / `source` options
  * 2. `toolResponseMetadata.waniwani` from WidgetProvider context
- * 3. No-op if neither is available
+ * 3. No-op if `endpoint` cannot be resolved or `source` is unknown
  *
  * @example
  * ```tsx
@@ -325,19 +339,37 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 	const explicitEndpoint = normalizeString(options.endpoint);
 	const explicitToken = normalizeString(options.token);
 	const explicitSessionId = normalizeString(options.sessionId);
+	const explicitSource = normalizeString(options.source);
 
-	// Stabilize config identity — only changes when the primitives change
-	const config = useMemo<WaniwaniConfig | null>(() => {
+	// Stabilize config identity — only changes when the primitives change.
+	// When `source` cannot be resolved (neither explicitly passed nor injected
+	// by `withWaniwani` via context), return `null` so the tracker stays a
+	// no-op. Emitting events with a synthetic fallback source would corrupt
+	// per-session attribution on the backend (the original "widget" sink).
+	const config = useMemo<ResolvedConfig | null>(() => {
+		const source = explicitSource ?? contextConfig?.source;
+		if (!source) {
+			return null;
+		}
 		if (explicitEndpoint) {
 			return {
 				endpoint: explicitEndpoint,
 				token: explicitToken ?? contextConfig?.token,
 				sessionId: explicitSessionId ?? contextConfig?.sessionId,
-				source: contextConfig?.source,
+				source,
 			};
 		}
-		return contextConfig;
-	}, [explicitEndpoint, explicitToken, explicitSessionId, contextConfig]);
+		if (!contextConfig) {
+			return null;
+		}
+		return { ...contextConfig, source };
+	}, [
+		explicitEndpoint,
+		explicitToken,
+		explicitSessionId,
+		explicitSource,
+		contextConfig,
+	]);
 
 	const [widget, setWidget] = useState<WaniwaniWidget>(NOOP_WIDGET);
 	const metadataRef = useRef(options.metadata);

--- a/src/mcp/react/hooks/use-waniwani.ts
+++ b/src/mcp/react/hooks/use-waniwani.ts
@@ -49,11 +49,7 @@ export interface UseWaniwaniOptions {
 	/**
 	 * Originating session source (e.g. `"chatgpt"`, `"chatbar"`, `"playground"`).
 	 * If omitted, the hook resolves from tool response metadata
-	 * (`toolResponseMetadata.waniwani.source`). When neither an explicit option
-	 * nor context provides a source the tracker stays a no-op — events are
-	 * dropped rather than emitted with a misleading default — so that callers
-	 * that pass `endpoint` without a known source don't pollute session
-	 * attribution.
+	 * (`toolResponseMetadata.waniwani.source`).
 	 */
 	source?: string;
 	/**
@@ -118,15 +114,6 @@ function normalizeString(value: unknown): string | undefined {
 	}
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function createNoopState(): WidgetState {
-	return {
-		widget: NOOP_WIDGET,
-		cleanup: () => {},
-		config: null,
-		captureKey: "",
-	};
 }
 
 function captureKeyOf(capture?: AutoCaptureToggles): string {
@@ -341,11 +328,7 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 	const explicitSessionId = normalizeString(options.sessionId);
 	const explicitSource = normalizeString(options.source);
 
-	// Stabilize config identity — only changes when the primitives change.
-	// When `source` cannot be resolved (neither explicitly passed nor injected
-	// by `withWaniwani` via context), return `null` so the tracker stays a
-	// no-op. Emitting events with a synthetic fallback source would corrupt
-	// per-session attribution on the backend (the original "widget" sink).
+	// Stabilize config identity — only changes when the primitives change
 	const config = useMemo<ResolvedConfig | null>(() => {
 		const source = explicitSource ?? contextConfig?.source;
 		if (!source) {
@@ -399,11 +382,9 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 		}
 
 		if (!config) {
-			if (state?.config) {
-				state.cleanup();
-				state = createNoopState();
-				setWidget(NOOP_WIDGET);
-			}
+			// Local no-op: another consumer may still be driving the singleton,
+			// so don't tear it down here.
+			setWidget(NOOP_WIDGET);
 			return;
 		}
 
@@ -413,8 +394,8 @@ export function useWaniwani(options: UseWaniwaniOptions = {}): WaniwaniWidget {
 		) {
 			state?.cleanup();
 			state = createState(config, metadataRef.current, captureRef.current);
-			setWidget(state.widget);
 		}
+		setWidget(state?.widget ?? NOOP_WIDGET);
 	}, [config, captureKey]);
 
 	return widget;

--- a/src/mcp/react/hooks/widget-transport.ts
+++ b/src/mcp/react/hooks/widget-transport.ts
@@ -67,7 +67,7 @@ function toV2Envelope(ev: WidgetEvent): Record<string, unknown> {
 		id: ev.event_id,
 		type: "mcp.event",
 		name: eventName,
-		source: ev.source || "widget",
+		source: ev.source,
 		timestamp: ev.timestamp,
 		correlation,
 		properties,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes analytics attribution and may no-op tracking for integrations that omit source; no auth or payment impact, but product metrics could shift until callers pass source or metadata includes it.
> 
> **Overview**
> Widget tracking no longer defaults event **`source`** to `"widget"`. **`useWaniwani`** only wires up transport and auto-capture when **`source`** is known (from **`WidgetProvider`** metadata or an explicit option), and passing **`endpoint`** directly now **requires** **`source`** in the type system.
> 
> **`initAutoCapture`** and **`toV2Envelope`** propagate **`source`** as-is with no fallback, so misconfigured hooks stay on the no-op widget instead of sending mislabeled events. Singleton teardown is scoped to consumers with a resolved config so a no-op mount does not reset tracking for others.
> 
> Tests were updated to pass explicit sources (e.g. `"chatgpt"`) and to assert the V2 batch payload preserves **`source`** verbatim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a261ec5c8bdc4ff4e8424e820bfbd4ea20fa58a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->