### PR TITLE
fix(mcp/server): stop deriving "chatbar" from waniwani/sessionId

### DIFF
--- a/src/mcp/server/__tests__/utils.test.ts
+++ b/src/mcp/server/__tests__/utils.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { extractSource } from "../utils";
+
+describe("extractSource", () => {
+	it("returns undefined for missing meta", () => {
+		expect(extractSource(undefined)).toBeUndefined();
+		expect(extractSource({})).toBeUndefined();
+	});
+
+	it("returns the explicit waniwani/source when set", () => {
+		expect(extractSource({ "waniwani/source": "playground" })).toBe(
+			"playground",
+		);
+	});
+
+	it("explicit waniwani/source wins over any session-derived source", () => {
+		expect(
+			extractSource({
+				"waniwani/source": "playground",
+				"openai/sessionId": "v1/abc",
+			}),
+		).toBe("playground");
+	});
+
+	it("derives chatgpt from openai/sessionId", () => {
+		expect(extractSource({ "openai/sessionId": "v1/abc" })).toBe("chatgpt");
+	});
+
+	it("derives chatgpt from openai/session", () => {
+		expect(extractSource({ "openai/session": "v1/abc" })).toBe("chatgpt");
+	});
+
+	// Regression: WAN-374 — when both `waniwani/sessionId` and `openai/*` are
+	// present (ChatGPT session whose meta was enriched with the same id under
+	// both keys, or whose transport propagated `mcp-session-id` separately),
+	// the source must be "chatgpt", not "chatbar".
+	it("prefers openai keys over waniwani/sessionId when both are present", () => {
+		expect(
+			extractSource({
+				"waniwani/sessionId": "v1/abc",
+				"openai/sessionId": "v1/abc",
+			}),
+		).toBe("chatgpt");
+
+		expect(
+			extractSource({
+				"waniwani/sessionId": "v1/abc",
+				"openai/session": "v1/abc",
+			}),
+		).toBe("chatgpt");
+	});
+
+	// Regression: WAN-374 — `waniwani/sessionId` alone is a correlation ID,
+	// not an implicit "chatbar" signal. Callers that genuinely come from the
+	// chatbar opt in via `waniwani/source`.
+	it("does not derive a source from waniwani/sessionId alone", () => {
+		expect(extractSource({ "waniwani/sessionId": "ses-1" })).toBeUndefined();
+	});
+
+	it("derives chatbar only when waniwani/source is explicitly set", () => {
+		expect(
+			extractSource({
+				"waniwani/source": "chatbar",
+				"waniwani/sessionId": "ses-1",
+			}),
+		).toBe("chatbar");
+	});
+
+	it("ignores non-string source values", () => {
+		expect(
+			extractSource({
+				"waniwani/source": 42,
+				"openai/sessionId": "v1/abc",
+			} as Record<string, unknown>),
+		).toBe("chatgpt");
+	});
+
+	it("ignores empty-string source and session values", () => {
+		expect(
+			extractSource({
+				"waniwani/source": "",
+				"openai/sessionId": "",
+			}),
+		).toBeUndefined();
+	});
+});

--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -113,19 +113,6 @@ export function extractTurnCount(
 	return undefined;
 }
 
-/**
- * Session-ID keys that uniquely identify a specific host and therefore imply
- * a source. `openai/sessionId` and `openai/session` are only ever set by an
- * OpenAI host (ChatGPT, Apps SDK), so seeing one is a reliable signal.
- *
- * `waniwani/sessionId` is deliberately NOT in this list: it doubles as a
- * generic correlation ID — set by the WaniWani chatbar/playground/embed AND
- * auto-derived from `mcp-session-id` headers as a fallback by `withWaniwani`.
- * Treating it as an implicit "chatbar" signal mis-attributes any non-chatbar
- * caller that happens to carry that key (e.g. a ChatGPT session whose `_meta`
- * also carries `waniwani/sessionId`). Callers that genuinely come from the
- * chatbar set `waniwani/source` explicitly.
- */
 const SOURCE_SESSION_KEYS = [
 	{ key: "openai/sessionId", source: "chatgpt" },
 	{ key: "openai/session", source: "chatgpt" },
@@ -137,12 +124,10 @@ export function extractSource(
 	if (!meta) {
 		return undefined;
 	}
-	// Explicit source set by the caller (e.g. "chatbar", "playground", "embed")
 	const explicit = meta["waniwani/source"];
 	if (typeof explicit === "string" && explicit.length > 0) {
 		return explicit;
 	}
-	// Derive from session ID keys that uniquely identify a host
 	for (const { key, source } of SOURCE_SESSION_KEYS) {
 		const value = meta[key];
 		if (typeof value === "string" && value.length > 0) {

--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -113,8 +113,20 @@ export function extractTurnCount(
 	return undefined;
 }
 
+/**
+ * Session-ID keys that uniquely identify a specific host and therefore imply
+ * a source. `openai/sessionId` and `openai/session` are only ever set by an
+ * OpenAI host (ChatGPT, Apps SDK), so seeing one is a reliable signal.
+ *
+ * `waniwani/sessionId` is deliberately NOT in this list: it doubles as a
+ * generic correlation ID — set by the WaniWani chatbar/playground/embed AND
+ * auto-derived from `mcp-session-id` headers as a fallback by `withWaniwani`.
+ * Treating it as an implicit "chatbar" signal mis-attributes any non-chatbar
+ * caller that happens to carry that key (e.g. a ChatGPT session whose `_meta`
+ * also carries `waniwani/sessionId`). Callers that genuinely come from the
+ * chatbar set `waniwani/source` explicitly.
+ */
 const SOURCE_SESSION_KEYS = [
-	{ key: "waniwani/sessionId", source: "chatbar" },
 	{ key: "openai/sessionId", source: "chatgpt" },
 	{ key: "openai/session", source: "chatgpt" },
 ] as const;
@@ -125,12 +137,12 @@ export function extractSource(
 	if (!meta) {
 		return undefined;
 	}
-	// Explicit source set by the caller (e.g. chatbar name)
+	// Explicit source set by the caller (e.g. "chatbar", "playground", "embed")
 	const explicit = meta["waniwani/source"];
 	if (typeof explicit === "string" && explicit.length > 0) {
 		return explicit;
 	}
-	// Derive from session ID key
+	// Derive from session ID keys that uniquely identify a host
 	for (const { key, source } of SOURCE_SESSION_KEYS) {
 		const value = meta[key];
 		if (typeof value === "string" && value.length > 0) {


### PR DESCRIPTION
## Summary

Fixes [WAN-374](https://linear.app/waniwani/issue/WAN-374/sdk-extractsource-flips-between-chatgpt-and-chatbar-within-the-same) — `extractSource` flipped between `"chatgpt"` and `"chatbar"` across consecutive tool calls in a single ChatGPT session.

Implements **Option B** from the issue: remove the implicit `waniwani/sessionId → "chatbar"` mapping. `waniwani/sessionId` is now treated purely as a correlation ID with no implicit source. Callers that genuinely come from the WaniWani chatbar already opt in via `waniwani/source` explicitly.

### Why Option B over A

`waniwani/sessionId` doubles as a generic correlation ID — set by the WaniWani chatbar/playground/embed AND auto-derived from `mcp-session-id` headers by `withWaniwani`. Reordering priorities (Option A) still leaves a wrong implicit guess for any non-chatbar host that happens to carry that key (e.g. Claude with no openai/* keys, but with `mcp-session-id` enrichment). Option B removes the guess entirely.

Per Maxime's comment on the issue: "I think the best would be to remove `chatbar` entirely imho. it's again another default. Even on wani itself we never set that source."

### Transport-session enrichment

`withWaniwani` still writes `waniwani/sessionId` from `mcp-session-id` headers when no session ID is present (`src/mcp/server/with-waniwani/index.ts:185-196`). With this change that's now purely correlation — it doesn't carry a source signal anymore. No code change needed there.

### Open question (out of scope here)

For Claude (no session ID, no `openai/*` key, no explicit `waniwani/source`), `extractSource` now returns `undefined` and events fall back to the `@waniwani/sdk` default in the tracking mapper. Detecting Claude as a source needs a separate signal (User-Agent, clientInfo from MCP, etc.) — flagged in the issue thread and left for a follow-up.

## Test plan

- [x] `bun test src/mcp/server/__tests__/utils.test.ts` — 10 new tests covering the both-keys-present case, the chatbar opt-in case, and edge cases
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Pre-existing `use-chat-engine.test.tsx` failures confirmed unrelated (missing `fake-indexeddb` package — fails on `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics/source attribution for MCP tool calls; behavior is intentional but some sessions may report `undefined` source until clients set `waniwani/source` or OpenAI keys are present.
> 
> **Overview**
> Stops MCP `extractSource` from treating `waniwani/sessionId` as an implicit **chatbar** signal, fixing WAN-374 where the same ChatGPT session could be labeled **chatgpt** on one tool call and **chatbar** on the next.
> 
> **`extractSource`** in `utils.ts` no longer maps `waniwani/sessionId` → `"chatbar"`; that key is correlation-only. **ChatGPT** still comes from `openai/sessionId` or `openai/session`, and any client (including chatbar) must set **`waniwani/source`** explicitly. Meta with only `waniwani/sessionId` now yields `undefined` for source (SDK default in tracking).
> 
> Adds **`utils.test.ts`** with regression cases for openai vs waniwani keys, explicit chatbar, and invalid/empty values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c84038c563607fc85127c5084f36c0609109b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->