### PR TITLE
feat(mcp/server): add optional ttlSeconds to KV store set

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -28,7 +28,7 @@ export {
 	StateGraph,
 } from "./server/flows";
 // Generic key-value store — OSS interface, free-tier hosted impl
-export type { KvStore } from "./server/kv";
+export type { KvStore, KvStoreSetOptions } from "./server/kv";
 export { MemoryKvStore, WaniwaniKvStore } from "./server/kv";
 // Scoped client — free tier (used inside withWaniwani-wrapped tools)
 export type { ScopedWaniWaniClient } from "./server/scoped-client";

--- a/src/mcp/server/flows/flow-store.ts
+++ b/src/mcp/server/flows/flow-store.ts
@@ -5,7 +5,7 @@
  * Config comes from env vars (WANIWANI_API_KEY, WANIWANI_API_URL).
  */
 
-import { WaniwaniKvStore } from "../kv";
+import { type KvStoreSetOptions, WaniwaniKvStore } from "../kv";
 import type { FlowTokenContent } from "./@types";
 
 // ============================================================================
@@ -14,7 +14,11 @@ import type { FlowTokenContent } from "./@types";
 
 export interface FlowStore {
 	get(key: string): Promise<FlowTokenContent | null>;
-	set(key: string, value: FlowTokenContent): Promise<void>;
+	set(
+		key: string,
+		value: FlowTokenContent,
+		options?: KvStoreSetOptions,
+	): Promise<void>;
 	delete(key: string): Promise<void>;
 }
 
@@ -29,8 +33,12 @@ export class WaniwaniFlowStore implements FlowStore {
 		return this.store.get(key);
 	}
 
-	set(key: string, value: FlowTokenContent): Promise<void> {
-		return this.store.set(key, value);
+	set(
+		key: string,
+		value: FlowTokenContent,
+		options?: KvStoreSetOptions,
+	): Promise<void> {
+		return this.store.set(key, value, options);
 	}
 
 	delete(key: string): Promise<void> {

--- a/src/mcp/server/kv/__tests__/kv-store.test.ts
+++ b/src/mcp/server/kv/__tests__/kv-store.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { WaniwaniKvStore } from "../kv-store";
+
+// Captures the request the store sends so we can assert how `ttlSeconds`
+// (Redis-style TTL) is forwarded to /api/mcp/redis/set.
+
+const realFetch = globalThis.fetch;
+
+let captured: { url: string; body: Record<string, unknown> } | null = null;
+
+beforeEach(() => {
+	process.env.WANIWANI_API_KEY = "wwk_test";
+	delete process.env.WANIWANI_API_URL;
+	delete process.env.WANIWANI_ENCRYPTION_KEY;
+	captured = null;
+	globalThis.fetch = (async (input: string, init: RequestInit) => {
+		captured = { url: String(input), body: JSON.parse(String(init.body)) };
+		return new Response(JSON.stringify({ data: { ok: true } }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}) as typeof fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = realFetch;
+});
+
+describe("WaniwaniKvStore TTL", () => {
+	test("forwards ttlSeconds to /api/mcp/redis/set when provided", async () => {
+		const store = new WaniwaniKvStore();
+		const sevenDays = 7 * 24 * 60 * 60;
+
+		await store.set("k", { a: 1 }, { ttlSeconds: sevenDays });
+
+		expect(captured?.url).toBe("https://app.waniwani.ai/api/mcp/redis/set");
+		expect(captured?.body).toEqual({
+			key: "k",
+			value: { a: 1 },
+			ttlSeconds: sevenDays,
+		});
+	});
+
+	test("omits ttlSeconds when not provided (server applies its default)", async () => {
+		const store = new WaniwaniKvStore();
+
+		await store.set("k", { a: 1 });
+
+		expect(captured?.body).toEqual({ key: "k", value: { a: 1 } });
+		expect(captured?.body && "ttlSeconds" in captured.body).toBe(false);
+	});
+});

--- a/src/mcp/server/kv/index.ts
+++ b/src/mcp/server/kv/index.ts
@@ -2,6 +2,6 @@
 
 export type { EncryptedEnvelope } from "./crypto";
 export { isEncryptedEnvelope } from "./crypto";
-export type { KvStore } from "./kv-store";
+export type { KvStore, KvStoreSetOptions } from "./kv-store";
 export { WaniwaniKvStore } from "./kv-store";
 export { MemoryKvStore } from "./memory-kv-store";

--- a/src/mcp/server/kv/kv-store.ts
+++ b/src/mcp/server/kv/kv-store.ts
@@ -17,9 +17,18 @@ import { decryptValue, encryptValue, isEncryptedEnvelope } from "./crypto";
 // Interface
 // ============================================================================
 
+export interface KvStoreSetOptions {
+	/**
+	 * Time-to-live in seconds, mirroring Redis `SET ... EX`. When omitted the
+	 * server applies its default retention window. The value is kept until it
+	 * expires, however far in the future.
+	 */
+	ttlSeconds?: number;
+}
+
 export interface KvStore<T = Record<string, unknown>> {
 	get(key: string): Promise<T | null>;
-	set(key: string, value: T): Promise<void>;
+	set(key: string, value: T, options?: KvStoreSetOptions): Promise<void>;
 	delete(key: string): Promise<void>;
 }
 
@@ -74,7 +83,7 @@ export class WaniwaniKvStore<T = Record<string, unknown>>
 		return data as T;
 	}
 
-	async set(key: string, value: T): Promise<void> {
+	async set(key: string, value: T, options?: KvStoreSetOptions): Promise<void> {
 		if (!this.apiKey) {
 			throw new Error(
 				"[WaniWani KV] No API key configured. Set WANIWANI_API_KEY env var.",
@@ -87,7 +96,13 @@ export class WaniwaniKvStore<T = Record<string, unknown>>
 		const payload = encKey
 			? await encryptValue(value as Record<string, unknown>, encKey)
 			: value;
-		await this.request("/api/mcp/redis/set", { key, value: payload });
+		// `ttlSeconds: undefined` is dropped by JSON.stringify, so the server
+		// falls back to its default retention window when no TTL is given.
+		await this.request("/api/mcp/redis/set", {
+			key,
+			value: payload,
+			ttlSeconds: options?.ttlSeconds,
+		});
 	}
 
 	async delete(key: string): Promise<void> {

--- a/src/mcp/server/kv/kv-store.ts
+++ b/src/mcp/server/kv/kv-store.ts
@@ -96,8 +96,6 @@ export class WaniwaniKvStore<T = Record<string, unknown>>
 		const payload = encKey
 			? await encryptValue(value as Record<string, unknown>, encKey)
 			: value;
-		// `ttlSeconds: undefined` is dropped by JSON.stringify, so the server
-		// falls back to its default retention window when no TTL is given.
 		await this.request("/api/mcp/redis/set", {
 			key,
 			value: payload,

--- a/src/mcp/server/kv/memory-kv-store.ts
+++ b/src/mcp/server/kv/memory-kv-store.ts
@@ -7,7 +7,7 @@
  * `WANIWANI_API_KEY` to use the hosted store.
  */
 
-import type { KvStore } from "./kv-store";
+import type { KvStore, KvStoreSetOptions } from "./kv-store";
 
 export class MemoryKvStore<T = Record<string, unknown>> implements KvStore<T> {
 	private readonly map = new Map<string, T>();
@@ -16,7 +16,13 @@ export class MemoryKvStore<T = Record<string, unknown>> implements KvStore<T> {
 		return this.map.get(key) ?? null;
 	}
 
-	async set(key: string, value: T): Promise<void> {
+	// In-memory storage has no expiry; `options` (e.g. `ttlSeconds`) is accepted
+	// for parity with WaniwaniKvStore but ignored.
+	async set(
+		key: string,
+		value: T,
+		_options?: KvStoreSetOptions,
+	): Promise<void> {
 		this.map.set(key, value);
 	}
 


### PR DESCRIPTION
## Summary

Exposes a Redis-style TTL on the hosted KV store so SDK callers can keep a value beyond the server's 24h default. Pairs with the app-side change that made `/api/mcp/redis/set` honor a per-item `ttlSeconds` (kept until it actually expires, like Redis).

The SDK talks to the app via hand-written `fetch` (it does **not** consume `@waniwani-ai/api-client`), so TTL support had to be wired explicitly here rather than arriving via a generated-client bump.

## Changes

- **`KvStoreSetOptions { ttlSeconds? }`** added; `KvStore.set` / `WaniwaniKvStore.set` take an optional `options` and forward `ttlSeconds` in the `POST /api/mcp/redis/set` body.
- **`FlowStore.set` / `WaniwaniFlowStore.set`** thread the same option through (flow tokens rely on the KV TTL to expire completed flows).
- **`MemoryKvStore.set`** accepts the option for parity but ignores it (in-memory has no expiry).
- `KvStoreSetOptions` re-exported from `@waniwani/sdk/mcp`.

`ttlSeconds: undefined` is dropped by `JSON.stringify`, so when omitted the server applies its default retention window.

## Backward compatibility

Fully compatible — the new param is optional and trailing. Existing 2-arg `set(key, value)` callers (including the default flow-state persist) are unchanged and keep the 24h default.

## Tests

New `src/mcp/server/kv/__tests__/kv-store.test.ts` mocks `fetch` and asserts `ttlSeconds` is present in the request body when provided and absent when omitted. `bun test` passes (117); `tsc --noEmit` and Biome are clean.

> Note: versioning is handled by `npm run release:patch`, so `package.json` is left at `0.12.12` here — a release will bump/publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional trailing parameter with unchanged two-arg callers; behavior only changes when callers pass an explicit TTL.
> 
> **Overview**
> Adds optional **`KvStoreSetOptions`** with **`ttlSeconds`** on **`KvStore.set`**, so hosted **`WaniwaniKvStore`** can request retention longer than the app’s default when calling **`POST /api/mcp/redis/set`**. Omitted TTL still serializes without the field so server defaults apply.
> 
> **`FlowStore.set`** forwards the same options for flow-token persistence; **`MemoryKvStore`** accepts but ignores TTL for API parity. **`KvStoreSetOptions`** is re-exported from **`@waniwani/sdk/mcp`**. New unit tests mock **`fetch`** and assert the set body includes or omits **`ttlSeconds`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3aad05d0408eb613a954bd5ad4ab27b1709eff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->