### PR TITLE
feat(chat): expose sessionId via embed API

### DIFF
--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -316,4 +316,6 @@ export interface ChatHandle {
 	focus: () => void;
 	/** Current chat messages */
 	messages: import("ai").UIMessage[];
+	/** Session ID used for event correlation. Available after the first message. */
+	sessionId: string | undefined;
 }

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -46,6 +46,8 @@ declare global {
 				focus: () => void;
 				/** Snapshot of the current chat messages. Empty until mounted. */
 				getMessages: () => UIMessage[];
+				/** Session ID for event correlation. Undefined until the first message. */
+				getSessionId: () => string | undefined;
 			};
 		};
 	}
@@ -62,6 +64,7 @@ interface EmbedInstance {
 	reset: () => void;
 	focus: () => void;
 	getMessages: () => UIMessage[];
+	getSessionId: () => string | undefined;
 }
 
 let currentInstance: EmbedInstance | null = null;
@@ -330,6 +333,7 @@ function mountInline(
 		reset: () => inlineRef.current?.chat?.reset(),
 		focus: () => inlineRef.current?.chat?.focus(),
 		getMessages: () => inlineRef.current?.chat?.messages ?? [],
+		getSessionId: () => inlineRef.current?.chat?.sessionId,
 	};
 }
 
@@ -381,6 +385,7 @@ window.WaniWani.chat = {
 	reset: () => currentInstance?.reset(),
 	focus: () => currentInstance?.focus(),
 	getMessages: () => currentInstance?.getMessages() ?? [],
+	getSessionId: () => currentInstance?.getSessionId(),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -312,12 +312,16 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 				get messages() {
 					return engine.messages;
 				},
+				get sessionId() {
+					return engine.sessionId;
+				},
 			}),
 			[
 				engine.handleSubmit,
 				engine.sendMessageAndWait,
 				engine.reset,
 				engine.messages,
+				engine.sessionId,
 				focusInput,
 			],
 		);

--- a/src/legacy/chat/web/chat-card.tsx
+++ b/src/legacy/chat/web/chat-card.tsx
@@ -190,12 +190,16 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 				get messages() {
 					return engine.messages;
 				},
+				get sessionId() {
+					return engine.sessionId;
+				},
 			}),
 			[
 				engine.handleSubmit,
 				engine.sendMessageAndWait,
 				engine.reset,
 				engine.messages,
+				engine.sessionId,
 				focusInput,
 			],
 		);


### PR DESCRIPTION
## Summary

Exposes the chat session ID through the embed API so clients embedding the playground can retrieve it programmatically.

Adds `getSessionId()` to `window.WaniWani.chat` and `sessionId` to the `ChatHandle` ref interface.

## Usage

```js
// After the chat widget has loaded and the user has sent at least one message:
const sessionId = window.WaniWani.chat.getSessionId();
// → "a1b2c3d4-..." (UUID) or undefined if no message has been sent yet
```

For React consumers using a ref on `ChatEmbed` or `WaniwaniChat`:

```tsx
const chatRef = useRef<ChatHandle>(null);

// After first message:
const sessionId = chatRef.current?.sessionId;
```

**Note:** The session ID is resolved after the first message exchange. Before that, `getSessionId()` returns `undefined`.

## Breaking changes

None. This is a purely additive change:

- New `getSessionId()` method on the global `window.WaniWani.chat` object
- New `sessionId` property on the `ChatHandle` interface

Existing integrations are unaffected — no existing methods or types were modified or removed.