### PR TITLE
fix(mcp): stop emitting ui.domain on MCP Apps widget resources

### DIFF
--- a/src/legacy/mcp/resources/__tests__/meta.test.ts
+++ b/src/legacy/mcp/resources/__tests__/meta.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { buildMcpAppsResourceMeta, buildOpenAIResourceMeta } from "../meta";
+
+describe("buildMcpAppsResourceMeta", () => {
+	// Regression: Claude's MCP Apps host validates `ui.domain` against the format
+	// "{hash}.claudemcpcontent.com" and rejects self-hosted widget origins. We must
+	// never emit `ui.domain` for the MCP Apps resource.
+	it("never emits ui.domain (Claude rejects non-claudemcpcontent.com domains)", () => {
+		const meta = buildMcpAppsResourceMeta({
+			description: "A widget",
+			prefersBorder: true,
+			widgetCSP: {
+				connect_domains: ["https://v1.isalud.mcp.waniwani.run"],
+				resource_domains: ["https://v1.isalud.mcp.waniwani.run"],
+			},
+		});
+
+		expect(meta.ui).toBeDefined();
+		expect(meta.ui).not.toHaveProperty("domain");
+	});
+
+	it("still conveys the widget origin via CSP domains", () => {
+		const meta = buildMcpAppsResourceMeta({
+			widgetCSP: {
+				connect_domains: ["https://example.com"],
+				resource_domains: ["https://example.com"],
+				frame_domains: ["https://frames.example.com"],
+				redirect_domains: ["https://redirect.example.com"],
+			},
+		});
+
+		expect(meta.ui?.csp).toEqual({
+			connectDomains: ["https://example.com"],
+			resourceDomains: ["https://example.com"],
+			frameDomains: ["https://frames.example.com"],
+			redirectDomains: ["https://redirect.example.com"],
+		});
+	});
+
+	it("includes prefersBorder when set", () => {
+		expect(buildMcpAppsResourceMeta({ prefersBorder: true }).ui).toEqual({
+			prefersBorder: true,
+		});
+		expect(buildMcpAppsResourceMeta({ prefersBorder: false }).ui).toEqual({
+			prefersBorder: false,
+		});
+	});
+});
+
+describe("buildOpenAIResourceMeta", () => {
+	// OpenAI's Apps SDK accepts arbitrary widget domains via `openai/widgetDomain`,
+	// so the OpenAI path is unaffected by the Claude restriction above.
+	it("still emits openai/widgetDomain", () => {
+		const meta = buildOpenAIResourceMeta({
+			description: "A widget",
+			prefersBorder: true,
+			widgetDomain: "my-app.com",
+		});
+
+		expect(meta["openai/widgetDomain"]).toBe("my-app.com");
+	});
+});

--- a/src/legacy/mcp/resources/create-resource.ts
+++ b/src/legacy/mcp/resources/create-resource.ts
@@ -141,7 +141,6 @@ export function createResource(config: ResourceConfig): RegisteredResource {
 						_meta: buildMcpAppsResourceMeta({
 							description: uiDescription,
 							prefersBorder,
-							widgetDomain,
 							widgetCSP,
 						}),
 					},

--- a/src/legacy/mcp/resources/meta.ts
+++ b/src/legacy/mcp/resources/meta.ts
@@ -54,7 +54,6 @@ interface McpAppsResourceMeta {
 			frameDomains?: string[];
 			redirectDomains?: string[];
 		};
-		domain?: string;
 		prefersBorder?: boolean;
 	};
 }
@@ -62,7 +61,6 @@ interface McpAppsResourceMeta {
 export function buildMcpAppsResourceMeta(config: {
 	description?: string;
 	prefersBorder?: boolean;
-	widgetDomain?: string;
 	widgetCSP?: WidgetCSP;
 }): McpAppsResourceMeta {
 	const csp = config.widgetCSP
@@ -74,10 +72,16 @@ export function buildMcpAppsResourceMeta(config: {
 			}
 		: undefined;
 
+	// NOTE: we intentionally do NOT emit `ui.domain` here. Claude's MCP Apps
+	// host validates `ui.domain` against the format "{hash}.claudemcpcontent.com"
+	// and rejects any other value (e.g. a self-hosted widget origin) with:
+	//   Invalid ui.domain format: expected "{hash}.claudemcpcontent.com", got "<our domain>".
+	// The widget origin is already conveyed via the CSP domains above, so the
+	// field is redundant for MCP Apps. The OpenAI Apps SDK path keeps its own
+	// `openai/widgetDomain` (see buildOpenAIResourceMeta), which OpenAI accepts.
 	return {
 		ui: {
 			...(csp && { csp }),
-			...(config.widgetDomain && { domain: config.widgetDomain }),
 			...(config.prefersBorder !== undefined && {
 				prefersBorder: config.prefersBorder,
 			}),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow metadata change for MCP Apps resources with tests; OpenAI widget metadata is untouched.
> 
> **Overview**
> Fixes Claude MCP Apps widget registration failures caused by **`ui.domain`** being set to self-hosted origins, which Claude’s host rejects unless the value matches `{hash}.claudemcpcontent.com`.
> 
> **`buildMcpAppsResourceMeta`** no longer accepts or emits **`ui.domain`**; widget origins stay on **`ui.csp`** (`connectDomains`, `resourceDomains`, etc.). **`createResource`** stops passing **`widgetDomain`** into that builder for MCP Apps resources. **`openai/widgetDomain`** on the OpenAI Apps SDK path is unchanged.
> 
> Adds **`meta.test.ts`** regression tests: MCP Apps meta must not include **`domain`**, CSP and **`prefersBorder`** behavior preserved, and OpenAI meta still sets **`openai/widgetDomain`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323821ccdbee02ae12e85161a4350b9ee59d7767. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->