### PR TITLE
Add security policy and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
+<div align="center">
+
 # @waniwani/sdk
 
-[![npm](https://img.shields.io/npm/v/@waniwani/sdk.svg)](https://www.npmjs.com/package/@waniwani/sdk)
-[![license](https://img.shields.io/npm/l/@waniwani/sdk.svg)](./LICENSE)
+**The open-source TypeScript SDK for MCP funnels** — multi-step conversational flows (sales, lead generation, booking, quotes) that run as a single MCP tool inside ChatGPT, Claude, Cursor, and any MCP-capable client.
 
-The open-source TypeScript SDK for **MCP funnels**: multi-step conversational flows (sales, lead generation, booking, quotes) that run as a single MCP tool inside ChatGPT, Claude, Cursor, and any MCP-capable client. One typed state graph compiles to one MCP tool. MIT, bring your own store, optional hosted Platform via one env var.
+[![npm version](https://img.shields.io/npm/v/@waniwani/sdk?labelColor=333333&color=666666)](https://www.npmjs.com/package/@waniwani/sdk)
+[![npm downloads](https://img.shields.io/npm/dm/@waniwani/sdk?labelColor=333333&color=666666)](https://www.npmjs.com/package/@waniwani/sdk)
+[![last commit](https://img.shields.io/github/last-commit/WaniWani-AI/sdk?labelColor=333333&color=666666)](https://github.com/WaniWani-AI/sdk/commits)
+[![commit activity](https://img.shields.io/github/commit-activity/m/WaniWani-AI/sdk?labelColor=333333&color=666666)](https://github.com/WaniWani-AI/sdk/pulse)
+[![stars](https://img.shields.io/github/stars/WaniWani-AI/sdk?labelColor=333333&color=666666)](https://github.com/WaniWani-AI/sdk/stargazers)
+[![license](https://img.shields.io/npm/l/@waniwani/sdk?labelColor=333333&color=666666)](./LICENSE)
+[![follow @waniwani_ai](https://img.shields.io/badge/follow-%40waniwani__ai-333333?logo=x&logoColor=white&labelColor=333333&color=666666)](https://x.com/waniwani_ai)
+
+[**Docs**](https://docs.waniwani.ai) · [**Website**](https://waniwani.ai) · [**Dashboard**](https://app.waniwani.ai) · [**CLI**](https://www.npmjs.com/package/@waniwani/cli) · [**Issues**](https://github.com/WaniWani-AI/sdk/issues)
+
+</div>
+
+One typed state graph compiles to one MCP tool. MIT, bring your own store, optional hosted Platform via one env var.
 
 Forked from production MCPs we shipped for paying customers (insurance quoting, pet care, lead capture, booking), and open-sourced once the shape stabilized.
 
@@ -131,6 +144,10 @@ Full docs at **[docs.waniwani.ai](https://docs.waniwani.ai)**. Same source as [`
 - **Website:** [waniwani.ai](https://waniwani.ai)
 - **Dashboard:** [app.waniwani.ai](https://app.waniwani.ai)
 - **Issues:** [github.com/WaniWani-AI/sdk/issues](https://github.com/WaniWani-AI/sdk/issues)
+
+## Security
+
+Found a vulnerability? Please report it privately — see [SECURITY.md](./SECURITY.md). Do not open a public issue for security reports.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+We take the security of `@waniwani/sdk` and the WaniWani Platform seriously. Thank you for helping keep our users safe.
+
+## Supported versions
+
+We ship from the latest `0.x` minor release. Security fixes are published to the most recent minor; older minors are not patched. Always upgrade to the latest version before reporting.
+
+| Version | Supported |
+| ------- | --------- |
+| latest `0.x` | ✅ |
+| older `0.x` | ❌ |
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report privately through either channel:
+
+- **GitHub Security Advisories (preferred):** open a private report at
+  [github.com/WaniWani-AI/sdk/security/advisories/new](https://github.com/WaniWani-AI/sdk/security/advisories/new).
+  This keeps the disclosure private and lets us collaborate on a fix.
+- **Email:** [security@waniwani.ai](mailto:security@waniwani.ai).
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- Affected version(s) and environment.
+- Any suggested remediation, if you have one.
+
+## What to expect
+
+- **Acknowledgement** within 3 business days.
+- **Initial assessment** (severity and triage) within 7 business days.
+- **Progress updates** as we work toward a fix, and credit in the release notes once a patch ships — unless you'd prefer to stay anonymous.
+
+## Scope
+
+In scope:
+
+- The `@waniwani/sdk` npm package (the open-source flow engine and the hosted-tier client code in this repository).
+
+Out of scope:
+
+- Vulnerabilities in third-party dependencies — please report those upstream (we'll still want to know so we can pin or patch).
+- Issues that require a compromised host, physical access, or a non-default, explicitly insecure configuration.
+- Findings in the hosted Platform infrastructure (`app.waniwani.ai`) unrelated to this SDK — email [security@waniwani.ai](mailto:security@waniwani.ai) for those.
+
+## Disclosure
+
+We follow coordinated disclosure. We ask that you give us a reasonable window to ship a fix before any public disclosure, and we'll keep you in the loop on the timeline.


### PR DESCRIPTION
## Summary

Establishes a formal security policy for the SDK and enhances the README with better branding, badges, and security guidance.

## Changes

- **Added `SECURITY.md`**: Defines vulnerability reporting procedures, supported versions, disclosure timeline, and scope. Directs security reports to GitHub Security Advisories or `security@waniwani.ai` rather than public issues.

- **Enhanced `README.md`**:
  - Centered header with improved tagline positioning
  - Added descriptive subtitle: "The open-source TypeScript SDK for MCP funnels"
  - Expanded badge set: npm version, downloads, last commit, commit activity, stars, and Twitter follow link
  - Added quick links section: Docs, Website, Dashboard, CLI, Issues
  - Added "Security" section with link to `SECURITY.md` and guidance against public security issue reports

## Implementation details

The security policy follows coordinated disclosure best practices:
- 3-day acknowledgement SLA
- 7-day initial assessment SLA
- Clear scope boundaries (SDK in-scope, third-party deps and Platform infrastructure out-of-scope)
- Support for both GitHub Security Advisories and email reporting channels

README improvements maintain the existing content while making the project more discoverable and professional, with consistent badge styling and clear navigation to key resources.

https://claude.ai/code/session_01T95GuVnQHEKveAefkmGtAx