### PR TITLE
feat(flows): record per-node visit timestamps in nodesVisited

### DIFF
--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -626,9 +626,15 @@ export type FlowContent =
 	| FlowCompleteContent
 	| FlowErrorContent;
 
+/** A single node visit during flow execution. `at` is the ISO timestamp of when the node was entered. */
+export type NodeVisit = {
+	id: string;
+	at: string;
+};
+
 export type ExecutionResult = {
 	content: FlowContent;
 	flowTokenContent?: FlowTokenContent;
 	/** Nodes visited during this execution (excludes nodes with hideFromFunnel). */
-	nodesVisited?: string[];
+	nodesVisited?: NodeVisit[];
 };

--- a/src/mcp/server/flows/__tests__/compile.test.ts
+++ b/src/mcp/server/flows/__tests__/compile.test.ts
@@ -65,6 +65,23 @@ function parsePayload(result: Record<string, unknown>) {
 	return JSON.parse(content[0]?.text ?? "") as Record<string, unknown>;
 }
 
+/** Assert the flow meta carries the expected visit ids, each stamped with a valid timestamp. */
+function expectNodesVisited(
+	meta: Record<string, unknown>,
+	flowId: string,
+	nodeIds: string[],
+) {
+	const flowMeta = meta[FLOW_META_KEY] as {
+		flowId: string;
+		nodesVisited: Array<{ id: string; at: string }>;
+	};
+	expect(flowMeta.flowId).toBe(flowId);
+	expect(flowMeta.nodesVisited.map((v) => v.id)).toEqual(nodeIds);
+	for (const visit of flowMeta.nodesVisited) {
+		expect(Number.isNaN(Date.parse(visit.at))).toBe(false);
+	}
+}
+
 describe("compileFlow response contract", () => {
 	test("returns an error when start is missing intent", async () => {
 		const store = new TestFlowStateStore();
@@ -2230,10 +2247,7 @@ describe("nodesVisited flow path tracking", () => {
 		>;
 		const meta = result._meta as Record<string, unknown>;
 
-		expect(meta[FLOW_META_KEY]).toEqual({
-			flowId: "nodes_visited_flow",
-			nodesVisited: ["ask_name"],
-		});
+		expectNodesVisited(meta, "nodes_visited_flow", ["ask_name"]);
 	});
 
 	test("action nodes traversed before interrupt are included in nodesVisited", async () => {
@@ -2266,10 +2280,55 @@ describe("nodesVisited flow path tracking", () => {
 		>;
 		const meta = result._meta as Record<string, unknown>;
 
-		expect(meta[FLOW_META_KEY]).toEqual({
-			flowId: "action_then_interrupt",
-			nodesVisited: ["compute", "ask_name"],
-		});
+		expectNodesVisited(meta, "action_then_interrupt", ["compute", "ask_name"]);
+	});
+
+	test("visit timestamps are non-decreasing in traversal order", async () => {
+		const store = new TestFlowStateStore();
+		const flow = createFlow({
+			id: "visit_timestamps_flow",
+			title: "Visit Timestamps",
+			description: "Test per-node visit timestamps.",
+			state: {
+				a: z.string().describe("A"),
+				b: z.string().describe("B"),
+				name: z.string().describe("Name"),
+			},
+		})
+			.addNode("first", async () => {
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return { a: "done" };
+			})
+			.addNode("second", () => ({ b: "done" }))
+			.addNode("ask_name", ({ interrupt }) =>
+				interrupt({ name: { question: "Name?" } }),
+			)
+			.addEdge(START, "first")
+			.addEdge("first", "second")
+			.addEdge("second", "ask_name")
+			.addEdge("ask_name", END)
+			.compile({ store });
+
+		const { server, registered } = mockServer();
+		await flow.register(server);
+		const handler = registered[0]?.[2];
+
+		const result = (await handler?.(startInput(), TEST_EXTRA)) as Record<
+			string,
+			unknown
+		>;
+		const meta = result._meta as Record<string, unknown>;
+		const flowMeta = meta[FLOW_META_KEY] as {
+			nodesVisited: Array<{ id: string; at: string }>;
+		};
+
+		const times = flowMeta.nodesVisited.map((v) => Date.parse(v.at));
+		expect(times).toHaveLength(3);
+		for (let i = 1; i < times.length; i++) {
+			expect(times[i]).toBeGreaterThanOrEqual(times[i - 1] ?? 0);
+		}
+		// The first node's handler sleeps, so the second visit is strictly later.
+		expect(times[1]).toBeGreaterThan(times[0] ?? 0);
 	});
 
 	test("completed flow includes all traversed nodes in nodesVisited", async () => {
@@ -2308,10 +2367,7 @@ describe("nodesVisited flow path tracking", () => {
 		const meta2 = r2._meta as Record<string, unknown>;
 
 		// Continue traverses ask_name (re-executes) then advances to ask_email
-		expect(meta2[FLOW_META_KEY]).toEqual({
-			flowId: "full_path_flow",
-			nodesVisited: ["ask_name", "ask_email"],
-		});
+		expectNodesVisited(meta2, "full_path_flow", ["ask_name", "ask_email"]);
 
 		// Answer email → complete
 		const r3 = (await handler?.(
@@ -2320,10 +2376,7 @@ describe("nodesVisited flow path tracking", () => {
 		)) as Record<string, unknown>;
 		const meta3 = r3._meta as Record<string, unknown>;
 
-		expect(meta3[FLOW_META_KEY]).toEqual({
-			flowId: "full_path_flow",
-			nodesVisited: ["ask_email"],
-		});
+		expectNodesVisited(meta3, "full_path_flow", ["ask_email"]);
 	});
 
 	test("hideFromFunnel nodes are excluded from nodesVisited", async () => {
@@ -2359,10 +2412,7 @@ describe("nodesVisited flow path tracking", () => {
 		>;
 		const meta = result._meta as Record<string, unknown>;
 
-		expect(meta[FLOW_META_KEY]).toEqual({
-			flowId: "hidden_node_flow",
-			nodesVisited: ["ask_name"],
-		});
+		expectNodesVisited(meta, "hidden_node_flow", ["ask_name"]);
 	});
 });
 
@@ -2403,10 +2453,7 @@ describe("addNode object form", () => {
 		>;
 		const meta = result._meta as Record<string, unknown>;
 
-		expect(meta[FLOW_META_KEY]).toEqual({
-			flowId: "object_form_flow",
-			nodesVisited: ["ask_name"],
-		});
+		expectNodesVisited(meta, "object_form_flow", ["ask_name"]);
 	});
 
 	test("object form without label defaults label to id", () => {

--- a/src/mcp/server/flows/execute.ts
+++ b/src/mcp/server/flows/execute.ts
@@ -7,6 +7,7 @@ import type {
 	MaybePromise,
 	NodeHandler,
 	NodeOptions,
+	NodeVisit,
 } from "./@types";
 import { END, interrupt, isInterrupt, isWidget, showWidget } from "./@types";
 import { resolveFieldSchema } from "./field-schema";
@@ -128,7 +129,7 @@ export async function executeFrom<TState extends Record<string, unknown>>(
 ): Promise<ExecutionResult> {
 	let currentNode = startNodeName;
 	let state = { ...startState };
-	const nodesVisited: string[] = [];
+	const nodesVisited: NodeVisit[] = [];
 
 	// Safety limit to prevent infinite loops
 	const MAX_ITERATIONS = 50;
@@ -156,7 +157,7 @@ export async function executeFrom<TState extends Record<string, unknown>>(
 		}
 
 		if (!nodeOptions?.get(currentNode)?.hideFromFunnel) {
-			nodesVisited.push(currentNode);
+			nodesVisited.push({ id: currentNode, at: new Date().toISOString() });
 		}
 
 		try {


### PR DESCRIPTION
Part of WAN-390 (write path); pairs with WaniWani-AI/app#642 (read path).

## Changes

- The flow execution engine stamps each node visit with an ISO timestamp at the moment traversal enters the node: `_meta["waniwani/flow"].nodesVisited` is now `[{ id, at }]` instead of `string[]`.
- New internal `NodeVisit` type; `ExecutionResult.nodesVisited` is `NodeVisit[]` (not publicly exported — no public API change).
- `compile.ts` and the `with-waniwani` meta passthrough are shape-agnostic and unchanged; `hideFromFunnel` exclusion unchanged.

## Why

Until now node visits had no timestamps of their own — the platform could only infer order from call-completion `occurredAt`, which is ambiguous for same-timestamp and overlapping calls (the WAN-390 journey-ordering bug). With per-node timestamps the platform orders visits by actual visit time.

## Release ordering

⚠️ **Do not release before WaniWani-AI/app#642 is deployed.** The platform's previous reader validated `nodesVisited` as `string[]` and silently dropped the new shape from sankey/use-case analytics. The app PR makes the reader dual-shape, after which old and new SDK clients coexist.

## Test plan

- Updated the six `nodesVisited` assertions to check ids in order + a valid timestamp per visit.
- New test: visit timestamps are non-decreasing in traversal order (strictly increasing across a sleeping node handler).
- `bun run typecheck`, `bun biome check .`, all 98 flow tests pass; the only suite failures (2 chat-widget `act()` tests) fail identically on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape of analytics metadata consumers read from flow tool `_meta`; platform must deploy the dual-shape reader (app#642) before this SDK ships or funnel/journey data can be dropped.
> 
> **Overview**
> Flow execution now records **per-node visit timestamps** in tool response metadata: `_meta["waniwani/flow"].nodesVisited` changes from `string[]` to `{ id, at }[]`, with `at` set as an ISO string when the engine enters each node (still skipping `hideFromFunnel` nodes).
> 
> Adds internal `NodeVisit` typing and updates compile tests via `expectNodesVisited` plus a new case that visit times are non-decreasing (and strictly increase after a delayed action node).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e8dbc623e81df2362dadbcfe1ff5181497aa7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->