### PR TITLE
feat(chat): support hiding tool calls or showing titles only (WAN-422)

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -80,7 +80,7 @@ The dashboard owns the agent's display and behavior config. Use `overrides` only
 | `placeholder` | `string` | Input placeholder |
 | `suggestions` | `string[]` | Initial suggestion chips |
 | `enableThreadHistory` | `boolean` | Persist conversations across reloads in IndexedDB |
-| `showToolCalls` | `boolean` | Show tool call request/response panels |
+| `showToolCalls` | `boolean \| "titles-only"` | `true` (default) shows full request/response panels, `"titles-only"` shows just the tool title, `false` hides tool calls entirely |
 | `allowAttachments` | `boolean` | Enable file attachments in the input |
 | `appearance` | `ChatAppearance` | Theme preset + per-property overrides — see [Theming the chat widget](#theming-the-chat-widget) |
 | `api` | `string` | Chat API URL. Defaults to `https://app.waniwani.ai/api/mcp/chat` |
@@ -223,7 +223,7 @@ The chat fits within whatever bound you set and scrolls internally — no need t
 | `data-placeholder` | No | Input field placeholder text |
 | `data-suggestions` | No | Comma-separated suggestion chips |
 | `data-enable-thread-history` | No | `"true"`/`"false"` — persist threads in IndexedDB, show thread menu in header |
-| `data-show-tool-calls` | No | `"true"`/`"false"` — toggle tool call panels |
+| `data-show-tool-calls` | No | `"true"` (default) shows full tool call panels, `"titles-only"` shows just the tool title, `"false"` hides tool calls entirely |
 | `data-css` | No | URL to custom stylesheet (injected into Shadow DOM) |
 | `data-theme` | No | `"light"` (default), `"dark"`, or `"auto"` (follow `prefers-color-scheme`) |
 | `data-locale` | No | `"en"`, `"fr"`, or `"es"`. Auto-detects from `<html lang>` / `navigator.language` when omitted |

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -2,10 +2,14 @@
 // Chat Theme
 // ============================================================================
 
-import type { ChatAppearance } from "./embed/config";
+import type { ChatAppearance, ShowToolCalls } from "./embed/config";
 import type { MessageOverrides } from "./i18n";
 
-export type { ChatAppearance, ThemePreset } from "./embed/config";
+export type {
+	ChatAppearance,
+	ShowToolCalls,
+	ThemePreset,
+} from "./embed/config";
 export type { Locale } from "./i18n";
 export type { MessageOverrides };
 
@@ -143,13 +147,17 @@ export interface ChatBaseProps {
 	 */
 	debug?: boolean;
 	/**
-	 * Show tool call details (request/response panels). When `false`, each
-	 * tool call renders as a compact indicator so the user can still tell
-	 * the agent is doing something, but the JSON panels are hidden.
+	 * How tool calls are rendered in the chat.
+	 *
+	 * - `true` (default) — full request/response panels.
+	 * - `"titles-only"` — a compact text indicator with the tool title, no
+	 *   JSON panels.
+	 * - `false` — tool calls are hidden entirely; a generic working
+	 *   indicator shows while tools run.
+	 *
 	 * MCP App widgets attached to a tool call are always rendered.
-	 * Defaults to `true`.
 	 */
-	showToolCalls?: boolean;
+	showToolCalls?: ShowToolCalls;
 	/**
 	 * Skip fetching `/config` and `/tools` from the API on mount.
 	 * Use when the chat endpoint doesn't serve these routes (e.g. embed widgets

--- a/src/chat/web/ai-elements/tool.tsx
+++ b/src/chat/web/ai-elements/tool.tsx
@@ -282,8 +282,9 @@ export type ToolIndicatorProps = HTMLAttributes<HTMLDivElement> & {
 
 /**
  * Compact, non-interactive replacement for {@link ToolHeader} +
- * {@link ToolContent}. Matches the Reasoning trigger style: muted text
- * with a shimmering label while the tool is running.
+ * {@link ToolContent}: just the tool title, no icon and no JSON panels
+ * (the `showToolCalls: "titles-only"` mode). Matches the Reasoning trigger
+ * style: muted text with a shimmering label while the tool is running.
  */
 export function ToolIndicator({
 	className,
@@ -302,7 +303,6 @@ export function ToolIndicator({
 			style={{ animation: "ww-fade-in 0.2s ease-out" }}
 			{...props}
 		>
-			<BracesIcon className="ww:size-4 ww:shrink-0" />
 			<span className="ww:truncate">
 				{isRunning ? <Shimmer duration={1.6}>{label}</Shimmer> : label}
 			</span>

--- a/src/chat/web/ai-elements/working-indicator.tsx
+++ b/src/chat/web/ai-elements/working-indicator.tsx
@@ -30,10 +30,15 @@ export function hasVisibleParts(message: UIMessage): boolean {
 /**
  * Returns true when the chat is loading but the assistant has not yet
  * produced any visible content.
+ *
+ * Pass `ignoreToolParts` when tool calls render nothing (`showToolCalls:
+ * false`) — tool parts then don't count as visible content, so the
+ * indicator keeps showing while tools run instead of leaving a blank chat.
  */
 export function shouldShowWorkingIndicator(
 	messages: UIMessage[],
 	status: ChatStatus,
+	options?: { ignoreToolParts?: boolean },
 ): boolean {
 	if (status !== "submitted" && status !== "streaming") {
 		return false;
@@ -42,7 +47,10 @@ export function shouldShowWorkingIndicator(
 	if (!last || last.role !== "assistant") {
 		return true;
 	}
-	return !hasVisibleParts(last);
+	const visible = options?.ignoreToolParts
+		? last.parts.some((p) => isVisiblePart(p) && !("toolCallId" in p))
+		: hasVisibleParts(last);
+	return !visible;
 }
 
 export type WorkingIndicatorProps = HTMLAttributes<HTMLDivElement>;

--- a/src/chat/web/components/message-list.tsx
+++ b/src/chat/web/components/message-list.tsx
@@ -2,7 +2,7 @@
 
 import type { ChatStatus, ReasoningUIPart, ToolUIPart, UIMessage } from "ai";
 import type { ModelContextUpdate } from "../../../shared/model-context";
-import type { WelcomeConfig } from "../@types";
+import type { ShowToolCalls, WelcomeConfig } from "../@types";
 import { Attachments } from "../ai-elements/attachments";
 import {
 	Message,
@@ -89,12 +89,13 @@ interface MessageListProps {
 	/** When true, show _meta in tool call inputs and outputs. */
 	debug?: boolean;
 	/**
-	 * Show tool call details (request/response panels). When `false`, render a
-	 * compact tool indicator instead so the user can still tell the agent is
-	 * doing something. MCP App widgets attached to a tool call are always
-	 * rendered regardless of this flag. Defaults to `true`.
+	 * How tool calls render: `true` (default) shows full request/response
+	 * panels, `"titles-only"` shows a compact indicator with just the tool
+	 * title, `false` hides tool calls entirely (the working indicator covers
+	 * the running state instead). MCP App widgets attached to a tool call are
+	 * always rendered regardless of this flag.
 	 */
-	showToolCalls?: boolean;
+	showToolCalls?: ShowToolCalls;
 	/**
 	 * Cached tool catalog keyed by tool name. Drives spec-canonical widget
 	 * resolution: if a tool's definition `_meta` carries a widget resource
@@ -127,7 +128,10 @@ export function MessageList({
 
 	const isFullscreenActive = fullscreenToolCallId != null;
 	const showWorking =
-		!isFullscreenActive && shouldShowWorkingIndicator(messages, status);
+		!isFullscreenActive &&
+		shouldShowWorkingIndicator(messages, status, {
+			ignoreToolParts: showToolCalls === false,
+		});
 
 	return (
 		<>
@@ -181,6 +185,28 @@ export function MessageList({
 					return <div key={message.id} style={{ display: "none" }} />;
 				}
 
+				// With tool calls fully hidden, an assistant message whose only
+				// visible parts are widget-less tool calls renders nothing —
+				// collapse it so it doesn't occupy a gap slot in the message
+				// column (and so the WorkingIndicator stays flush while running).
+				if (
+					showToolCalls === false &&
+					message.role === "assistant" &&
+					!hasTextContent &&
+					reasoningParts.length === 0 &&
+					fileParts.length === 0 &&
+					toolParts.every((p) => {
+						const output = "output" in p ? p.output : undefined;
+						return (
+							output === undefined ||
+							!resourceEndpoint ||
+							!resolveWidgetResourceUri(p.toolName, output, toolDefinitions)
+						);
+					})
+				) {
+					return <div key={message.id} style={{ display: "none" }} />;
+				}
+
 				return (
 					<Message from={message.role} key={message.id}>
 						{!containsFullscreenTool &&
@@ -207,6 +233,16 @@ export function MessageList({
 							);
 							const isFullscreen = part.toolCallId === fullscreenToolCallId;
 
+							// A fully hidden tool call with no widget renders nothing.
+							// Returning an empty wrapper instead would still occupy a
+							// gap slot in the message's flex column.
+							if (
+								showToolCalls === false &&
+								!(resourceUri && resourceEndpoint && output !== undefined)
+							) {
+								return null;
+							}
+
 							return (
 								<div
 									key={part.toolCallId}
@@ -224,33 +260,37 @@ export function MessageList({
 											: undefined
 									}
 								>
-									<div style={isFullscreen ? { display: "none" } : undefined}>
-										{showToolCalls ? (
-											<Tool>
-												<ToolHeader
+									{showToolCalls !== false && (
+										<div style={isFullscreen ? { display: "none" } : undefined}>
+											{showToolCalls === "titles-only" ? (
+												<ToolIndicator
 													title={part.title ?? formatToolName(part.toolName)}
 													state={part.state}
 												/>
-												<ToolContent>
-													<ToolInput input={part.input} debug={debug} />
-													{output !== undefined && (
-														<ToolOutput
-															output={output}
-															errorText={
-																"errorText" in part ? part.errorText : undefined
-															}
-															debug={debug}
-														/>
-													)}
-												</ToolContent>
-											</Tool>
-										) : (
-											<ToolIndicator
-												title={part.title ?? formatToolName(part.toolName)}
-												state={part.state}
-											/>
-										)}
-									</div>
+											) : (
+												<Tool>
+													<ToolHeader
+														title={part.title ?? formatToolName(part.toolName)}
+														state={part.state}
+													/>
+													<ToolContent>
+														<ToolInput input={part.input} debug={debug} />
+														{output !== undefined && (
+															<ToolOutput
+																output={output}
+																errorText={
+																	"errorText" in part
+																		? part.errorText
+																		: undefined
+																}
+																debug={debug}
+															/>
+														)}
+													</ToolContent>
+												</Tool>
+											)}
+										</div>
+									)}
 									{resourceUri && resourceEndpoint && output !== undefined && (
 										<WidgetErrorBoundary>
 											<McpAppFrame

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -158,31 +158,31 @@ describe("resolveConfig — render mode", () => {
 	});
 });
 
-describe("parseConfigFromScript — render mode attrs", () => {
-	async function parseWithAttrs(
-		attrs: Record<string, string>,
-	): Promise<Record<string, unknown>> {
-		const { parseConfigFromScript } = await import(
-			`../config?t=${Date.now()}-${Math.random()}`
-		);
-		const fakeScript = {
-			getAttribute(name: string) {
-				return name in attrs ? attrs[name] : null;
-			},
-		};
-		const prevDocument = g.document;
-		const prevHtmlScriptElement = g.HTMLScriptElement;
-		g.HTMLScriptElement = class {};
-		Object.setPrototypeOf(fakeScript, g.HTMLScriptElement.prototype);
-		g.document = { currentScript: fakeScript, querySelectorAll: () => [] };
-		try {
-			return parseConfigFromScript();
-		} finally {
-			g.document = prevDocument;
-			g.HTMLScriptElement = prevHtmlScriptElement;
-		}
+async function parseWithAttrs(
+	attrs: Record<string, string>,
+): Promise<Record<string, unknown>> {
+	const { parseConfigFromScript } = await import(
+		`../config?t=${Date.now()}-${Math.random()}`
+	);
+	const fakeScript = {
+		getAttribute(name: string) {
+			return name in attrs ? attrs[name] : null;
+		},
+	};
+	const prevDocument = g.document;
+	const prevHtmlScriptElement = g.HTMLScriptElement;
+	g.HTMLScriptElement = class {};
+	Object.setPrototypeOf(fakeScript, g.HTMLScriptElement.prototype);
+	g.document = { currentScript: fakeScript, querySelectorAll: () => [] };
+	try {
+		return parseConfigFromScript();
+	} finally {
+		g.document = prevDocument;
+		g.HTMLScriptElement = prevHtmlScriptElement;
 	}
+}
 
+describe("parseConfigFromScript — render mode attrs", () => {
 	test("data-mode=floating parses", async () => {
 		const cfg = await parseWithAttrs({
 			"data-token": "tok",
@@ -209,6 +209,53 @@ describe("parseConfigFromScript — render mode attrs", () => {
 		expect(cfg.position).toBe("bottom-left");
 		expect(cfg.height).toBe("500px");
 		expect(cfg.launcherText).toBe("Need help?");
+	});
+});
+
+describe("parseConfigFromScript — data-show-tool-calls", () => {
+	test("undefined when unspecified — consumers default to full panels", async () => {
+		const cfg = await parseWithAttrs({ "data-token": "tok" });
+		expect(cfg.showToolCalls).toBeUndefined();
+	});
+
+	test("'true' parses as true", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-show-tool-calls": "true",
+		});
+		expect(cfg.showToolCalls).toBe(true);
+	});
+
+	test("'false' parses as false", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-show-tool-calls": "false",
+		});
+		expect(cfg.showToolCalls).toBe(false);
+	});
+
+	test("'titles-only' parses as titles-only", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-show-tool-calls": "titles-only",
+		});
+		expect(cfg.showToolCalls).toBe("titles-only");
+	});
+
+	test("'titles-only' is case- and whitespace-insensitive", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-show-tool-calls": " Titles-Only ",
+		});
+		expect(cfg.showToolCalls).toBe("titles-only");
+	});
+
+	test("unrecognized value is ignored", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-show-tool-calls": "maybe",
+		});
+		expect(cfg.showToolCalls).toBeUndefined();
 	});
 });
 

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -30,6 +30,17 @@ export interface ChatAppearance {
 }
 
 /**
+ * Tool call rendering mode.
+ *
+ * - `true` (default) — full request/response panels.
+ * - `"titles-only"` — a compact text indicator with the tool title, no
+ *   JSON panels.
+ * - `false` — tool calls are hidden entirely; a generic working indicator
+ *   shows while tools run.
+ */
+export type ShowToolCalls = boolean | "titles-only";
+
+/**
  * Configuration for the embeddable chat widget.
  *
  * Resolution priority (later wins):
@@ -53,15 +64,13 @@ export interface EmbedConfig {
 	 */
 	channelId?: string;
 	/**
-	 * Show tool call details (request/response panels) in the chat.
-	 *
-	 * When `false`, each tool call still renders a compact indicator so the
-	 * user can tell the agent is doing something, but the JSON request and
-	 * response panels are hidden. Defaults to `true`.
+	 * How tool calls render in the chat: `true` (default) shows full
+	 * request/response panels, `"titles-only"` shows a compact indicator
+	 * with just the tool title, `false` hides tool calls entirely.
 	 *
 	 * Surfaced as `data-show-tool-calls` on the embed script tag.
 	 */
-	showToolCalls?: boolean;
+	showToolCalls?: ShowToolCalls;
 	/** Title shown in the chat header. Defaults to `"Assistant"`. */
 	title?: string;
 	/**
@@ -243,9 +252,14 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 		config.channelId = channelId;
 	}
 
-	const showToolCalls = bool("data-show-tool-calls");
-	if (showToolCalls !== undefined) {
-		config.showToolCalls = showToolCalls;
+	const showToolCallsRaw = str("data-show-tool-calls")?.trim().toLowerCase();
+	if (showToolCallsRaw === "titles-only") {
+		config.showToolCalls = "titles-only";
+	} else {
+		const showToolCalls = bool("data-show-tool-calls");
+		if (showToolCalls !== undefined) {
+			config.showToolCalls = showToolCalls;
+		}
 	}
 
 	const css = str("data-css");

--- a/src/chat/web/index.ts
+++ b/src/chat/web/index.ts
@@ -15,6 +15,7 @@ export type {
 	ChatEmbedProps,
 	ChatHandle,
 	ChatTheme,
+	ShowToolCalls,
 	SuggestionsConfig,
 	ThemePreset,
 	WelcomeConfig,

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { forwardRef, useEffect, useMemo, useState } from "react";
-import type { ChatAppearance, ChatHandle, WelcomeConfig } from "../@types";
+import type {
+	ChatAppearance,
+	ChatHandle,
+	ShowToolCalls,
+	WelcomeConfig,
+} from "../@types";
 import type { EmbedConfig } from "../embed/config";
 import { resolveConfig } from "../embed/config";
 import {
@@ -45,8 +50,12 @@ export interface WaniwaniChatOverrides {
 	suggestions?: string[];
 	/** Persist conversations across reloads in IndexedDB. */
 	enableThreadHistory?: boolean;
-	/** Show tool call request/response panels. */
-	showToolCalls?: boolean;
+	/**
+	 * How tool calls render: `true` (default) shows full request/response
+	 * panels, `"titles-only"` shows a compact indicator with just the tool
+	 * title, `false` hides tool calls entirely.
+	 */
+	showToolCalls?: ShowToolCalls;
 	/** Enable file attachments in the input. */
 	allowAttachments?: boolean;
 	/**


### PR DESCRIPTION
## What

Extends `showToolCalls` from `boolean` to `boolean | "titles-only"` across the chat widget, per [WAN-422](https://linear.app/waniwani/issue/WAN-422/allow-hiding-ai-chat-tools-via-sdk-config):

- `true` (default) — full request/response panels, unchanged
- `"titles-only"` — new value: compact shimmer indicator with just the tool title (the braces icon was removed from `ToolIndicator`)
- `false` — tool calls are now hidden entirely (previously showed the compact indicator)

Accepted everywhere the option already existed: the `data-show-tool-calls` script-tag attribute, `ChatEmbed`/`WaniwaniChat` props (`ChatBaseProps`, `WaniwaniChatOverrides`), and `embed.js init()`. The new `ShowToolCalls` type is exported from `@waniwani/sdk/chat`.

## Why

Customers want to hide the agent's tool activity from end users (or show only a friendly title) without forking the widget.

## Reviewer notes

- **Behavior change for existing `showToolCalls={false}` users** (including legacy `ChatCard`): previously a compact indicator, now fully hidden. This is the intent of the ticket; worth a release-note line.
- Two UX guards for the fully-hidden mode:
  - `shouldShowWorkingIndicator` gains an `ignoreToolParts` option so the "Working…" shimmer stays visible while hidden tools run instead of the chat looking frozen.
  - Widget-less tool parts return `null` and tool-only messages collapse to `display:none`, so hidden tool calls don't leave phantom flex-gap slots in the message column.
- MCP App widgets attached to a tool call still always render, regardless of the flag.
- Unrecognized `data-show-tool-calls` values are ignored (existing behavior for invalid attrs); `titles-only` parsing is case/whitespace-insensitive.
- Docs updated in `skills/waniwani-sdk/references/chat-widget.md` (overrides + script-tag tables); six new parse tests in `config.test.ts`.

Typecheck, lint, build, and tests pass (the 2 failures in `use-chat-engine.test.tsx` are pre-existing `act()` warnings, present on a clean checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `showToolCalls={false}` is a deliberate behavior change (fully hidden vs compact indicator) for existing embeds and legacy ChatCard; otherwise limited to chat presentation and config parsing.
> 
> **Overview**
> Extends **`showToolCalls`** from a boolean to **`boolean | "titles-only"`** (`ShowToolCalls`, exported from `@waniwani/sdk/chat`). **`true`** still shows full request/response panels; **`"titles-only"`** uses a title-only shimmer line (no braces icon, no JSON); **`false`** now hides tool UI entirely instead of the old compact indicator.
> 
> The option is wired through embed **`data-show-tool-calls`** (including case-insensitive `titles-only`), **`WaniwaniChat` overrides**, and **`ChatEmbed`**. MCP App widgets on a tool call still render in every mode.
> 
> For **`showToolCalls: false`**, **`shouldShowWorkingIndicator`** ignores tool parts so “Working…” stays visible during tool runs, and **`MessageList`** collapses widget-less tool-only messages so hidden tools don’t leave empty gaps.
> 
> Docs in **`chat-widget.md`** and six **`config.test.ts`** cases cover the new attribute values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0845b3a048b981d15638a18aa9eb527c716e55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->