### PR TITLE
docs(mcp-server): document the WaniWani MCP server in a new MCP Server tab

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -137,6 +137,19 @@
         ]
       },
       {
+        "tab": "MCP Server",
+        "groups": [
+          {
+            "group": "Get started",
+            "pages": [
+              "mcp-server/overview",
+              "mcp-server/connect",
+              "mcp-server/how-it-works"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Changelog",
         "groups": [
           {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -83,6 +83,14 @@ Optional. Adds tracking, knowledge base, chat widget, and hosted flow state to a
 - [Environment variables](https://docs.waniwani.ai/configuration/environment-variables): All env vars the SDK recognizes.
 - [Security](https://docs.waniwani.ai/configuration/security): Encryption at rest, key management, rotation.
 
+## WaniWani MCP server (drive the platform from your AI client)
+
+Connect Claude, Cursor, or ChatGPT to `https://mcp.waniwani.ai/mcp` (OAuth 2.1, no API keys) and operate the WaniWani platform conversationally: environments, API keys, analytics digests, session breakdowns. This is WaniWani's own hosted MCP server — distinct from the MCP funnel servers you build with the SDK.
+
+- [Overview](https://docs.waniwani.ai/mcp-server/overview): What the server is, example prompts, capability categories.
+- [Connect your AI client](https://docs.waniwani.ai/mcp-server/connect): Setup for claude.ai, Claude Code, Cursor, and ChatGPT; the OAuth sign-in flow; troubleshooting.
+- [How it works](https://docs.waniwani.ai/mcp-server/how-it-works): The four tools (`whoami`, `set_active_org`, `search`, `execute`), scopes & consent, sandboxed execution, the security model.
+
 ## Tracking & analytics (free tier)
 
 - [Tracking overview](https://docs.waniwani.ai/tracking/overview): Send events from your MCP server to the WaniWani dashboard.

--- a/docs/mcp-server/connect.mdx
+++ b/docs/mcp-server/connect.mdx
@@ -1,0 +1,101 @@
+---
+title: Connect your AI client
+description: "Add the WaniWani MCP server to claude.ai, Claude Code, Cursor, or ChatGPT and sign in with your WaniWani account — no API keys."
+keywords: ["connect WaniWani MCP", "claude.ai connector", "Claude Code MCP", "Cursor MCP", "ChatGPT connector", "mcp.waniwani.ai", "MCP OAuth"]
+---
+
+One URL works in every client:
+
+```text
+https://mcp.waniwani.ai/mcp
+```
+
+It's a remote MCP server (Streamable HTTP) that authenticates with OAuth 2.1. There is no API key to paste: you add the URL, your client opens a browser window, you sign in to WaniWani and approve the requested permissions. From then on the connection acts as *you* — same organizations, same role.
+
+## Claude (claude.ai and desktop)
+
+1. Open **Settings → Connectors**.
+2. Click **Add custom connector**.
+3. Enter `https://mcp.waniwani.ai/mcp` and confirm.
+4. A WaniWani sign-in window opens — sign in and approve the permissions.
+
+On Team and Enterprise plans, an admin may need to enable custom connectors for your workspace first.
+
+## Claude Code
+
+```bash
+claude mcp add --transport http waniwani https://mcp.waniwani.ai/mcp
+```
+
+Then run `/mcp` inside Claude Code and select **waniwani** to complete the browser sign-in.
+
+## Cursor
+
+Add the server to `~/.cursor/mcp.json` (or **Settings → MCP → Add new MCP server**):
+
+```json ~/.cursor/mcp.json
+{
+  "mcpServers": {
+    "waniwani": {
+      "url": "https://mcp.waniwani.ai/mcp"
+    }
+  }
+}
+```
+
+Cursor prompts you to authenticate in the browser the first time it connects.
+
+## ChatGPT
+
+Custom MCP connectors require developer mode:
+
+1. Open **Settings → Apps & Connectors → Advanced settings** and enable **Developer mode**.
+2. Back in **Connectors**, click **Create** and enter `https://mcp.waniwani.ai/mcp`.
+3. Complete the sign-in when prompted.
+
+<Note>
+Client UIs change quickly. If a menu has moved, follow your client's own guide for adding a **remote MCP server** and use the URL above — the server implements the standard discovery flow, so any MCP-capable client that supports OAuth can connect.
+</Note>
+
+## What happens when you sign in
+
+<Steps>
+  <Step title="Your client discovers WaniWani">
+    The client reads the server's metadata and learns that `app.waniwani.ai` handles sign-in. It registers itself automatically — no manual client IDs.
+  </Step>
+  <Step title="You sign in to WaniWani">
+    The browser opens your usual WaniWani login. If you're already signed in, you go straight to consent.
+  </Step>
+  <Step title="You approve the permissions">
+    The consent screen itemizes exactly what the connection may do (read environments and analytics, create environments and keys, and so on). You only see permissions your account is entitled to.
+  </Step>
+  <Step title="Connected">
+    The client receives a token bound to this server and your approved permissions. Every call it makes runs under your identity.
+  </Step>
+</Steps>
+
+## First thing to try
+
+> Who am I signed in to WaniWani as, and what can you do for me here?
+
+Your client will call the server's `whoami` and `search` tools and report your account, your organizations, and the available operations. From there, ask for what you want in plain language — see [the overview](/mcp-server/overview) for example prompts.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="The consent screen shows fewer permissions than I expected">
+    That's by design. The permission list is narrowed to what your account is entitled to — for example, internal WaniWani staff permissions never appear for customer accounts. Approve what's shown; it's everything available to you.
+  </Accordion>
+  <Accordion title="Calls suddenly fail with an authentication error">
+    Your token expired or was invalidated. Most clients refresh automatically; if yours doesn't, disconnect and reconnect the server (re-running the sign-in) to mint a fresh token.
+  </Accordion>
+  <Accordion title='"You must be a member of the target org"'>
+    `set_active_org` only switches to organizations you belong to. Ask *"who am I?"* — the `whoami` tool lists the organizations you can act on and their ids.
+  </Accordion>
+  <Accordion title="My active organization changed in the dashboard too">
+    Expected. The active organization is a property of your account, shared between the dashboard and connected AI clients. Switching it in one place switches it everywhere.
+  </Accordion>
+  <Accordion title="The model says an operation doesn't exist">
+    The available surface is curated and grows over time. Ask the model to run `search` again — it returns the live catalog with exact signatures. If what you need isn't there yet, tell us.
+  </Accordion>
+</AccordionGroup>

--- a/docs/mcp-server/connect.mdx
+++ b/docs/mcp-server/connect.mdx
@@ -89,11 +89,11 @@ Your client will call the server's `whoami` and `search` tools and report your a
   <Accordion title="Calls suddenly fail with an authentication error">
     Your token expired or was invalidated. Most clients refresh automatically; if yours doesn't, disconnect and reconnect the server (re-running the sign-in) to mint a fresh token.
   </Accordion>
-  <Accordion title='"You must be a member of the target org"'>
-    `set_active_org` only switches to organizations you belong to. Ask *"who am I?"* — the `whoami` tool lists the organizations you can act on and their ids.
+  <Accordion title="I can't switch to another organization (NOT_ORG_MEMBER)">
+    `set_active_org` only switches to organizations you belong to — the API rejects anything else with a `NOT_ORG_MEMBER` error. Ask *"who am I?"* — the `whoami` tool lists the organizations you can act on and their ids.
   </Accordion>
-  <Accordion title="My active organization changed in the dashboard too">
-    Expected. The active organization is a property of your account, shared between the dashboard and connected AI clients. Switching it in one place switches it everywhere.
+  <Accordion title="I switched organizations in the dashboard, but this connection still uses the old one">
+    Expected. Each connection carries its own active organization, independent of the dashboard — switching in one place doesn't switch the other. Ask the model to switch here too (it calls `set_active_org`), or check where you stand with *"who am I?"*.
   </Accordion>
   <Accordion title="The model says an operation doesn't exist">
     The available surface is curated and grows over time. Ask the model to run `search` again — it returns the live catalog with exact signatures. If what you need isn't there yet, tell us.

--- a/docs/mcp-server/how-it-works.mdx
+++ b/docs/mcp-server/how-it-works.mdx
@@ -1,0 +1,74 @@
+---
+title: How it works
+description: "Four tools, OAuth scopes, org context, and sandboxed execution: what happens between your prompt and the WaniWani API."
+keywords: ["WaniWani MCP tools", "whoami", "set_active_org", "search", "execute", "MCP OAuth scopes", "MCP security", "code mode"]
+---
+
+The server is deliberately small: four tools that compose, rather than one tool per API endpoint.
+
+## The four tools
+
+| Tool | What it does |
+|---|---|
+| `whoami` | Returns your identity: user id, granted permissions, the organizations you can act on, and which one is active. |
+| `set_active_org` | Switches your active organization for subsequent calls. Membership is enforced server-side. |
+| `search` | Lists the WaniWani API operations available to `execute`, with full TypeScript signatures — inputs *and* response shapes. Takes an optional keyword filter. |
+| `execute` | Runs a short piece of JavaScript in an isolated sandbox. The code calls operations as `api.<name>(input)` and returns a value. |
+
+## The loop
+
+A request like *"give me a digest of activity for the last 7 days"* plays out as:
+
+1. The model calls `search("analytics")` and reads the typed signatures.
+2. It writes a snippet and calls `execute`:
+
+   ```js
+   const envs = await api.listEnvironments();
+   // arguments elided — `search` returns the exact signatures
+   const summaries = await Promise.all(
+     envs.map((env) => api.getEnvironmentAnalytics(/* ... */)),
+   );
+   return summaries;
+   ```
+
+3. The returned data lands back in the conversation, and the model writes your digest.
+
+Because `execute` runs real code, the model can chain, filter, and aggregate in a single round trip instead of stitching together a dozen separate tool calls. Top-level `await` is supported, and whatever the snippet `return`s comes back as the tool result.
+
+## Org context
+
+Operations run against your **active organization**:
+
+- It defaults to the same active organization you last used — the setting is shared with the dashboard.
+- `set_active_org` switches it, and the switch is enforced server-side: you can only activate organizations you belong to.
+- Because it's an account-level setting, switching here also switches it in the dashboard (and for any other connected client). Last writer wins.
+
+`whoami` always tells you where you currently stand.
+
+## Permissions: scopes and consent
+
+When you connect, the consent screen itemizes the connection's permissions as OAuth scopes:
+
+| Scope | Grants |
+|---|---|
+| `orgs:read` / `orgs:write` | See your organizations and membership / invite members |
+| `mcp:read` / `mcp:write` | Read environments and analytics / create environments, create and rotate API keys |
+| `kb:read` / `kb:write` | Read / write the knowledge base |
+
+Two properties worth knowing:
+
+- **You only see what you're entitled to.** The consent screen narrows the list to your account's role — permissions reserved for WaniWani staff never appear for customer accounts.
+- **Scopes are enforced on every API call, server-side.** The MCP server doesn't get to be generous: each `api.*` operation is re-checked against your token's scopes and your org membership by the WaniWani API itself.
+
+## Security model
+
+- **OAuth 2.1, no API keys.** You sign in through `app.waniwani.ai` — the same login as the dashboard. The token your client receives is bound to this server specifically and to the scopes you approved.
+- **The sandbox never sees your token.** Code submitted through `execute` runs in an isolated sandbox that can reach only the curated `api.*` operations. Your credentials are attached to outbound API calls *outside* the sandbox — code running inside it has no way to read or exfiltrate them.
+- **Every call is your call.** All operations execute under your identity with your permissions. The connection can do nothing your account can't do in the dashboard.
+- **Stateless by design.** The server keeps no session state and stores no conversation content; each request is authenticated independently by your token. Disconnecting the server from your client severs its access.
+
+## Limits worth knowing
+
+- The exposed operation surface is curated and grows over time — `search` is the source of truth, not this page.
+- The active organization is account-level, shared with the dashboard.
+- Long or heavy aggregations should be scoped (a date range, a single environment): `execute` snippets run within a bounded execution window.

--- a/docs/mcp-server/how-it-works.mdx
+++ b/docs/mcp-server/how-it-works.mdx
@@ -39,9 +39,10 @@ Because `execute` runs real code, the model can chain, filter, and aggregate in 
 
 Operations run against your **active organization**:
 
-- It defaults to the same active organization you last used — the setting is shared with the dashboard.
+- When you first connect, it starts as the organization you last used in the dashboard.
 - `set_active_org` switches it, and the switch is enforced server-side: you can only activate organizations you belong to.
-- Because it's an account-level setting, switching here also switches it in the dashboard (and for any other connected client). Last writer wins.
+- The switch applies to **this connection only**. The dashboard and any other connected clients each keep their own active organization, so driving WaniWani from your AI client never silently moves your browser session — or vice versa.
+- It takes effect on your next call: the server invalidates the connection's current token and your client silently refreshes into the new organization.
 
 `whoami` always tells you where you currently stand.
 
@@ -52,8 +53,8 @@ When you connect, the consent screen itemizes the connection's permissions as OA
 | Scope | Grants |
 |---|---|
 | `orgs:read` / `orgs:write` | See your organizations and membership / invite members |
-| `mcp:read` / `mcp:write` | Read environments and analytics / create environments, create and rotate API keys |
-| `kb:read` / `kb:write` | Read / write the knowledge base |
+| `mcp:read` / `mcp:write` | Read environments and analytics / create environments and API keys |
+| `kb:read` / `kb:write` | Read / write the knowledge base *(operations not yet exposed through `execute`)* |
 
 Two properties worth knowing:
 
@@ -70,5 +71,5 @@ Two properties worth knowing:
 ## Limits worth knowing
 
 - The exposed operation surface is curated and grows over time — `search` is the source of truth, not this page.
-- The active organization is account-level, shared with the dashboard.
+- The active organization is per-connection: switching it here doesn't affect the dashboard or other connected clients, and switching in the dashboard doesn't affect this connection.
 - Long or heavy aggregations should be scoped (a date range, a single environment): `execute` snippets run within a bounded execution window.

--- a/docs/mcp-server/overview.mdx
+++ b/docs/mcp-server/overview.mdx
@@ -1,0 +1,38 @@
+---
+title: WaniWani MCP server
+description: "Connect Claude, Cursor, or ChatGPT to the WaniWani platform and drive it from a conversation — environments, API keys, analytics digests, session breakdowns."
+keywords: ["WaniWani MCP server", "mcp.waniwani.ai", "remote MCP", "MCP connector", "WaniWani from Claude", "platform MCP"]
+---
+
+The WaniWani MCP server lets your AI client operate the WaniWani platform for you. Connect once to `https://mcp.waniwani.ai/mcp`, sign in with your WaniWani account, and ask for the things you would otherwise click through the dashboard for.
+
+<Note>
+This is **WaniWani's own MCP server** — the one that drives *the platform*. It is not the MCP funnel server you build with the SDK. Everywhere else in these docs, "your MCP server" means the one you ship to your users; this tab is about the one we host for you at `mcp.waniwani.ai`.
+</Note>
+
+## What you can ask it
+
+- "Give me a digest of activity across my environments for the last 7 days."
+- "Create a new environment called *staging* and hand me its API key."
+- "Which sessions hit production yesterday? Where did people drop off?"
+- "What sources are sending events to my production environment?"
+- "Rotate the production API key."
+- "Invite jane@acme.com to our organization."
+
+## What it can do
+
+| Category | Examples |
+|---|---|
+| **Environments & API keys** | List your environments, create one, create or rotate an environment's API key |
+| **Analytics & sessions** | Activity summaries over a date range, funnel flow breakdowns, per-session drill-downs, event sources |
+| **Organization** | Check who you're signed in as, switch your active org, invite a teammate |
+
+The surface grows over time, so this table stays deliberately coarse. The server's own `search` tool is the live catalog: once connected, ask *"what WaniWani operations are available?"* and your client will list every operation with its exact signature.
+
+## How you use it
+
+1. [Connect your client](/mcp-server/connect) — add the URL, sign in, approve the permissions. No API keys involved.
+2. Ask in plain language. The model discovers the right operations and calls them with your identity — every call is permission-checked server-side.
+3. Results come back into the conversation.
+
+Everything the connection can do is bounded by your own WaniWani account: your organizations, your role, the permissions you approved at sign-in. The mechanics are on [How it works](/mcp-server/how-it-works).

--- a/docs/mcp-server/overview.mdx
+++ b/docs/mcp-server/overview.mdx
@@ -16,14 +16,14 @@ This is **WaniWani's own MCP server** — the one that drives *the platform*. It
 - "Create a new environment called *staging* and hand me its API key."
 - "Which sessions hit production yesterday? Where did people drop off?"
 - "What sources are sending events to my production environment?"
-- "Rotate the production API key."
+- "Compare this week's activity to last week's across all my environments."
 - "Invite jane@acme.com to our organization."
 
 ## What it can do
 
 | Category | Examples |
 |---|---|
-| **Environments & API keys** | List your environments, create one, create or rotate an environment's API key |
+| **Environments & API keys** | List your environments, create one, issue an environment's API key |
 | **Analytics & sessions** | Activity summaries over a date range, funnel flow breakdowns, per-session drill-downs, event sources |
 | **Organization** | Check who you're signed in as, switch your active org, invite a teammate |
 


### PR DESCRIPTION
Adds a public **MCP Server** tab to docs.waniwani.ai documenting the centralized WaniWani MCP server (`mcp.waniwani.ai`).

Linear: WAN-427 (content decisions — audience, naming, depth — are settled on the ticket).

## Pages

- `docs/mcp-server/overview.mdx` — what the server is, a disambiguation callout (WaniWani's own platform MCP vs the funnel MCPs you build with the SDK), example prompts, and coarse capability categories with the server's `search` tool as the live catalog.
- `docs/mcp-server/connect.mdx` — one URL (`https://mcp.waniwani.ai/mcp`), per-client setup (claude.ai/desktop, Claude Code, Cursor, ChatGPT), a step-by-step OAuth sign-in walkthrough, and troubleshooting grounded in real behaviors (role-narrowed consent, token expiry, org membership, per-connection active org).
- `docs/mcp-server/how-it-works.mdx` — the four tools (`whoami`, `set_active_org`, `search`, `execute`), the search→execute loop, org-context semantics, the customer scope table, and the security model (token never enters the sandbox, per-call server-side scope checks, stateless server).

## Wiring

- `docs/docs.json` — new top-level tab between Guides and Changelog.
- `docs/llms.txt` — new section linking the three pages.

## Notes for review

- Capabilities are presented as example prompts + categories rather than an operation table, so the pages stay accurate when WAN-419 grows the exposed `api.*` surface.
- "How it works" stays conceptual on purpose: no deployment topology or internal hostnames on the public site.
- Per the ticket's stated non-goal, the client connect instructions follow each vendor's published docs and were **not** verified end-to-end against `mcp.waniwani.ai`; a callout tells readers to fall back to their client's own remote-MCP guide if a menu has moved.
- Technical claims (tool behavior, consent narrowing, sandbox/token handling, statelessness) are sourced from the current `WaniWani-AI/mcp` server code.
