### PR TITLE
feat(modules/email): email module for sending emails from flow nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Same SDK, hosted features added when the key is present.
 
 - `WaniwaniKvStore` (hosted flow state) — used by `createFlow` default when key is set
 - `waniwani()`, `tracking/*`, `withWaniwani`, `createTrackingRoute`, `widget-token`, `scoped-client` from `@waniwani/sdk` and `@waniwani/sdk/mcp`
+- Modules — `ctx.waniwani.modules.email.send()` inside `withWaniwani`-wrapped flow nodes (requires `projectId` in `waniwani.json`); types (`EmailModule`, `EmailSendInput`, `EmailSendResult`, `ModulesContext`) exported from `@waniwani/sdk/mcp`
 - `createKbClient` from `@waniwani/sdk/kb`
 - `useWaniwani` from `@waniwani/sdk/mcp/react` (also OSS — degrades to no-op without config; BYO endpoint also supported)
 - `WaniwaniChat` (hosted React chat — recommended), themes, `embed.js` (IIFE for non-React hosts), `styles.css` from `@waniwani/sdk/chat`
@@ -61,6 +62,7 @@ src/
 │   ├── server/
 │   │   ├── flows/        # OSS: createFlow, StateGraph
 │   │   ├── kv/           # OSS interface + MemoryKvStore + WaniwaniKvStore
+│   │   ├── modules/      # Free tier: ctx.waniwani.modules.* (email)
 │   │   ├── tools/        # LEGACY: createTool
 │   │   ├── resources/    # LEGACY: createResource
 │   │   ├── with-waniwani/# Free tier wrapper (no-key safe)
@@ -127,6 +129,7 @@ Target SDK **users**, not SDK developers.
 | `src/mcp/server/flows/` | `references/flows.md` + `flows-api-reference.md` |
 | `src/tracking/` + `src/mcp/server/scoped-client.ts` | `references/events.md` (NEW) |
 | `src/mcp/server/kv/` | `references/kv-store.md` (NEW) |
+| `src/mcp/server/modules/` | `references/modules.md` |
 | Self-hosting | `references/self-hosting.md` (NEW) |
 | `src/kb/` | `references/knowledge-base.md` |
 | `src/chat/web/` | `references/chat-widget.md` |

--- a/skills/waniwani-sdk/SKILL.md
+++ b/skills/waniwani-sdk/SKILL.md
@@ -82,7 +82,7 @@ Get a free key at [app.waniwani.ai](https://app.waniwani.ai). See [setup.md](ref
 | Export | Purpose | Tier | Reference |
 |---|---|---|---|
 | `@waniwani/sdk` | `waniwani()` client, `track.*` event helpers, `WaniWaniError` | Free tier | [setup.md](references/setup.md), [events.md](references/events.md) |
-| `@waniwani/sdk/mcp` | `createFlow`, `KvStore`, `MemoryKvStore`, `withWaniwani`, tracking helpers | OSS + Free tier | [flows.md](references/flows.md), [kv-store.md](references/kv-store.md), [events.md](references/events.md) |
+| `@waniwani/sdk/mcp` | `createFlow`, `KvStore`, `MemoryKvStore`, `withWaniwani`, tracking helpers, modules types | OSS + Free tier | [flows.md](references/flows.md), [kv-store.md](references/kv-store.md), [events.md](references/events.md), [modules.md](references/modules.md) |
 | `@waniwani/sdk/mcp/react` | `useWaniwani` standalone tracking hook | OSS + Free tier | (rest of this entry point is legacy) |
 | `@waniwani/sdk/chat` | `ChatEmbed`, themes | Free tier | [chat-widget.md](references/chat-widget.md) |
 | `@waniwani/sdk/chat/embed.js` | Self-contained `<script>` install for any website | Free tier | [chat-widget.md](references/chat-widget.md) |
@@ -112,6 +112,7 @@ Adds hosted features on top of the OSS flow engine.
 - **Knowledge base** — `createKbClient()` for ingest/search.
 - **Funnel analytics** — flow graphs auto-sync to the dashboard.
 - **Chat widget** — `ChatEmbed` talks directly to `app.waniwani.ai`.
+- **Modules** — `ctx.waniwani.modules.email.send()` inside flow nodes (requires `projectId` in `waniwani.json`). See [modules.md](references/modules.md).
 
 `withWaniwani(server)` is safe to call with or without an API key — its auto-captured `tool.called` events are internally guarded, and session-ID bridging and widget metadata forwarding still happen. Your own tracking calls are **not** guarded: `client.track.*`, `identify()`, and the scoped `context.waniwani` throw `WANIWANI_API_KEY is not set` when no key is configured, so guard them in code paths that must also run keyless. See [events.md](references/events.md).
 
@@ -133,6 +134,7 @@ The following are still exported for back-compat with existing customer MCPs but
 | Add a free-tier API key and unlock tracking + dashboard | [setup.md](references/setup.md) |
 | Track events and build a revenue funnel (lead → price → converted), incl. off-platform conversions | [events.md](references/events.md) |
 | Use the flow API in detail (nodes, edges, interrupts, widgets) | [flows-api-reference.md](references/flows-api-reference.md) |
+| Send emails from flow nodes | [modules.md](references/modules.md) |
 | Add knowledge-base search | [knowledge-base.md](references/knowledge-base.md) |
 | Embed the chat widget on a website | [chat-widget.md](references/chat-widget.md) |
 

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -151,6 +151,7 @@ function App() {
 | `reset()` | Clear all messages and start fresh |
 | `focus()` | Focus the chat input |
 | `messages` | Current chat messages (readonly `UIMessage[]`) |
+| `sessionId` | Session ID used for event correlation (`undefined` until the first message) |
 
 ## `<script>` embed (non-React)
 
@@ -303,6 +304,7 @@ The IIFE exposes the same imperative methods as the React ref, both globally and
 | `reset()` | Clear all messages |
 | `focus()` | Focus the chat input (opens the panel in floating mode) |
 | `getMessages()` | Snapshot of current `UIMessage[]` |
+| `getSessionId()` | Session ID used for event correlation (`undefined` until the first message) |
 
 Pre-mount, write methods no-op silently and read methods return `undefined` / `[]`. Pick whichever feels right — call them globally (`window.WaniWani.chat.sendMessage(...)`) when you don't have the instance handle, or on the instance when you do.
 

--- a/skills/waniwani-sdk/references/modules.md
+++ b/skills/waniwani-sdk/references/modules.md
@@ -42,6 +42,8 @@ await ctx.waniwani.modules.email.send({
 
 `replyTo` is optional on all variants. Template variables use `{{variableName}}` syntax in the template HTML and subject; values are HTML-escaped before substitution in the body.
 
+For template sends, the template's saved subject is used when set (with variable substitution applied), and the `subject` you pass is the fallback used when the template has no saved subject. The `subject` you pass is always used for `content` and `html` sends.
+
 ### Result
 
 ```ts

--- a/skills/waniwani-sdk/references/modules.md
+++ b/skills/waniwani-sdk/references/modules.md
@@ -1,0 +1,56 @@
+# Modules — pre-built integrations for MCP flows
+
+Modules are hosted integrations exposed as `ctx.waniwani.modules.*` inside flow node handlers when the server is wrapped with `withWaniwani()`. They are a **free tier** feature: they require `WANIWANI_API_KEY` plus a `projectId` in `waniwani.json`.
+
+## Email module
+
+Send emails from flow nodes via `ctx.waniwani.modules.email.send()`. Sending, domain verification, templates, and delivery logs are managed in the WaniWani dashboard under **Modules → Email**.
+
+### Requirements
+
+- `WANIWANI_API_KEY` set in the environment
+- `projectId` set in `waniwani.json` — without it, `send()` rejects with a configuration error
+
+### Sending
+
+Exactly one of `content`, `html`, or `templateId` must be provided.
+
+```ts
+// Inline content — wrapped in a basic WaniWani layout
+await ctx.waniwani.modules.email.send({
+  to: "user@example.com",
+  subject: "Welcome!",
+  content: "<h1>Welcome to our platform!</h1>",
+});
+
+// Raw HTML — sent as-is
+await ctx.waniwani.modules.email.send({
+  to: "user@example.com",
+  subject: "Custom Email",
+  html: "<!DOCTYPE html><html>...</html>",
+});
+
+// Saved template — templateId is the template's UUID
+// (dashboard → Modules → Email → Templates → "Copy template ID")
+await ctx.waniwani.modules.email.send({
+  to: "user@example.com",
+  subject: "Order Confirmation",
+  templateId: "550e8400-e29b-41d4-a716-446655440000",
+  variables: { orderId: "12345", customerName: "John" },
+});
+```
+
+`replyTo` is optional on all variants. Template variables use `{{variableName}}` syntax in the template HTML and subject; values are HTML-escaped before substitution in the body.
+
+### Result
+
+```ts
+type EmailSendResult = {
+  id: string;      // Resend email id (used for delivery/open/click tracking)
+  success: boolean;
+};
+```
+
+### Types
+
+`EmailModule`, `EmailSendInput`, `EmailSendResult`, and `ModulesContext` are exported from `@waniwani/sdk/mcp`.

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -30,6 +30,13 @@ export {
 // Generic key-value store — OSS interface, free-tier hosted impl
 export type { KvStore, KvStoreSetOptions } from "./server/kv";
 export { MemoryKvStore, WaniwaniKvStore } from "./server/kv";
+// Modules — pre-built integrations for MCP flows (email, etc.)
+export type {
+	EmailModule,
+	EmailSendInput,
+	EmailSendResult,
+	ModulesContext,
+} from "./server/modules";
 // Scoped client — free tier (used inside withWaniwani-wrapped tools)
 export type { ScopedWaniWaniClient } from "./server/scoped-client";
 // Tracking helpers — free tier

--- a/src/mcp/server/modules/email/index.ts
+++ b/src/mcp/server/modules/email/index.ts
@@ -70,11 +70,12 @@ export interface EmailModule {
 	 * });
 	 *
 	 * @example
-	 * // Send with a saved template
+	 * // Send with a saved template — templateId is the template's UUID,
+	 * // available via "Copy template ID" in the dashboard.
 	 * await ctx.waniwani.modules.email.send({
 	 *   to: "user@example.com",
 	 *   subject: "Order Confirmation",
-	 *   templateId: "order-confirmation",
+	 *   templateId: "550e8400-e29b-41d4-a716-446655440000",
 	 *   variables: { orderId: "12345", customerName: "John" },
 	 * });
 	 */
@@ -130,6 +131,7 @@ export function createEmailModule(config: {
 					headers: {
 						"Content-Type": "application/json",
 						Authorization: `Bearer ${apiKey}`,
+						"X-WaniWani-SDK": "@waniwani/sdk",
 					},
 					body: JSON.stringify(body),
 				},

--- a/src/mcp/server/modules/email/index.ts
+++ b/src/mcp/server/modules/email/index.ts
@@ -1,0 +1,152 @@
+/**
+ * Email module for sending emails from MCP flows.
+ *
+ * Available as `ctx.waniwani.modules.email` inside flow node handlers
+ * when the server is wrapped with `withWaniwani()`.
+ */
+
+export type EmailSendInput = {
+	to: string;
+	subject: string;
+	replyTo?: string;
+} & (
+	| { content: string; html?: never; templateId?: never; variables?: never }
+	| { html: string; content?: never; templateId?: never; variables?: never }
+	| {
+			templateId: string;
+			variables?: Record<string, string>;
+			content?: never;
+			html?: never;
+	  }
+);
+
+type EmailSendApiBody =
+	| {
+			type: "content";
+			to: string;
+			subject: string;
+			replyTo?: string;
+			content: string;
+	  }
+	| {
+			type: "html";
+			to: string;
+			subject: string;
+			replyTo?: string;
+			html: string;
+	  }
+	| {
+			type: "template";
+			to: string;
+			subject: string;
+			replyTo?: string;
+			templateId: string;
+			variables?: Record<string, string>;
+	  };
+
+export type EmailSendResult = {
+	id: string;
+	success: boolean;
+};
+
+export interface EmailModule {
+	/**
+	 * Send an email.
+	 *
+	 * @example
+	 * // Send with inline content (wrapped in a basic template)
+	 * await ctx.waniwani.modules.email.send({
+	 *   to: "user@example.com",
+	 *   subject: "Welcome!",
+	 *   content: "<h1>Welcome to our platform!</h1>",
+	 * });
+	 *
+	 * @example
+	 * // Send with raw HTML
+	 * await ctx.waniwani.modules.email.send({
+	 *   to: "user@example.com",
+	 *   subject: "Custom Email",
+	 *   html: "<!DOCTYPE html><html>...</html>",
+	 * });
+	 *
+	 * @example
+	 * // Send with a saved template
+	 * await ctx.waniwani.modules.email.send({
+	 *   to: "user@example.com",
+	 *   subject: "Order Confirmation",
+	 *   templateId: "order-confirmation",
+	 *   variables: { orderId: "12345", customerName: "John" },
+	 * });
+	 */
+	send(input: EmailSendInput): Promise<EmailSendResult>;
+}
+
+export function createEmailModule(config: {
+	apiUrl: string;
+	apiKey: string;
+	projectId: string;
+}): EmailModule {
+	const { apiUrl, apiKey, projectId } = config;
+
+	return {
+		async send(input: EmailSendInput): Promise<EmailSendResult> {
+			let body: EmailSendApiBody;
+
+			if ("content" in input && input.content) {
+				body = {
+					type: "content",
+					to: input.to,
+					subject: input.subject,
+					replyTo: input.replyTo,
+					content: input.content,
+				};
+			} else if ("html" in input && input.html) {
+				body = {
+					type: "html",
+					to: input.to,
+					subject: input.subject,
+					replyTo: input.replyTo,
+					html: input.html,
+				};
+			} else if ("templateId" in input && input.templateId) {
+				body = {
+					type: "template",
+					to: input.to,
+					subject: input.subject,
+					replyTo: input.replyTo,
+					templateId: input.templateId,
+					variables: input.variables,
+				};
+			} else {
+				throw new Error(
+					"EmailSendInput must have one of: content, html, or templateId",
+				);
+			}
+
+			const response = await fetch(
+				`${apiUrl}/api/mcp/projects/${projectId}/modules/email/send`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `Bearer ${apiKey}`,
+					},
+					body: JSON.stringify(body),
+				},
+			);
+
+			if (!response.ok) {
+				const errorBody = await response.text();
+				throw new Error(
+					`Failed to send email: ${response.status} ${errorBody}`,
+				);
+			}
+
+			const result = (await response.json()) as {
+				success: boolean;
+				data: EmailSendResult;
+			};
+			return result.data;
+		},
+	};
+}

--- a/src/mcp/server/modules/index.ts
+++ b/src/mcp/server/modules/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Modules context providing pre-built integrations for MCP flows.
+ *
+ * Available as `ctx.waniwani.modules` inside flow node handlers
+ * when the server is wrapped with `withWaniwani()`.
+ */
+
+export type { EmailModule, EmailSendInput, EmailSendResult } from "./email";
+export { createEmailModule } from "./email";
+
+import type { EmailModule } from "./email";
+
+export interface ModulesContext {
+	/**
+	 * Email module for sending emails.
+	 *
+	 * @example
+	 * await ctx.waniwani.modules.email.send({
+	 *   to: "user@example.com",
+	 *   subject: "Welcome!",
+	 *   content: "<h1>Hello!</h1>",
+	 * });
+	 */
+	readonly email: EmailModule;
+}

--- a/src/mcp/server/scoped-client.ts
+++ b/src/mcp/server/scoped-client.ts
@@ -6,6 +6,8 @@ import type {
 	TrackingClient,
 } from "../../tracking/@types.js";
 import { createRevenueApi } from "../../tracking/revenue.js";
+import { createEmailModule } from "./modules/email/index.js";
+import type { ModulesContext } from "./modules/index.js";
 
 /**
  * Well-known key used to attach the scoped client to the MCP `extra` object.
@@ -33,8 +35,13 @@ export interface ScopedWaniWaniClient {
 	): Promise<{ eventId: string }>;
 	/** Knowledge base client (no meta needed). */
 	readonly kb: KbClient;
+	/**
+	 * Pre-built integrations for MCP flows.
+	 * Requires `projectId` in `waniwani.json` to be set.
+	 */
+	readonly modules: ModulesContext;
 	/** @internal Resolved API config from withWaniwani(). */
-	readonly _config?: { apiUrl?: string; apiKey?: string };
+	readonly _config?: { apiUrl?: string; apiKey?: string; projectId?: string };
 }
 
 /**
@@ -57,10 +64,29 @@ export function createScopedClient(
 		readonly kb: KbClient;
 	},
 	meta: Record<string, unknown>,
-	config?: { apiUrl?: string; apiKey?: string },
+	config?: { apiUrl?: string; apiKey?: string; projectId?: string },
 ): ScopedWaniWaniClient {
 	const trackOnce = (event: TrackInput): Promise<{ eventId: string }> =>
 		base.track({ ...event, meta: { ...meta, ...event.meta } });
+
+	const modules: ModulesContext = {
+		email:
+			config?.apiUrl && config?.apiKey && config?.projectId
+				? createEmailModule({
+						apiUrl: config.apiUrl,
+						apiKey: config.apiKey,
+						projectId: config.projectId,
+					})
+				: {
+						send: () =>
+							Promise.reject(
+								new Error(
+									"Email module unavailable: missing apiUrl, apiKey, or projectId in config. " +
+										"Set projectId in waniwani.json to enable modules.",
+								),
+							),
+					},
+	};
 
 	return {
 		track: Object.assign(trackOnce, createRevenueApi(trackOnce)),
@@ -68,6 +94,7 @@ export function createScopedClient(
 			return base.identify(userId, properties, meta);
 		},
 		kb: base.kb,
+		modules,
 		_config: config,
 	};
 }

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -1,3 +1,4 @@
+import { loadProjectConfig } from "../../../project-config.js";
 import type { ToolCalledProperties } from "../../../tracking/index.js";
 import { createLogger } from "../../../utils/logger.js";
 import { waniwani } from "../../../waniwani.js";
@@ -228,6 +229,7 @@ function createWrappedHandler(
 		const scopedClient = createScopedClient(tracker, meta, {
 			apiUrl: tracker._config.apiUrl,
 			apiKey: tracker._config.apiKey,
+			projectId: loadProjectConfig()?.projectId,
 		});
 		if (isRecord(extra)) {
 			extra[SCOPED_CLIENT_KEY] = scopedClient;


### PR DESCRIPTION
## Summary

Adds the **Email module** to `@waniwani/sdk` — `ctx.waniwani.modules.email.send()`, callable from inside `withWaniwani`-wrapped flow nodes and tools. It posts to the app's email `send` endpoint (added in the paired app PR).

## What's included
- `src/mcp/server/modules/email/` — `createEmailModule()` with `send()` supporting `content`, `html`, and saved-`template` variants (plus `replyTo` and `{{variable}}` substitution)
- Wired into the scoped client (`ctx.waniwani.modules.email`) and `withWaniwani`; rejects with a clear message when `apiUrl` / `apiKey` / `projectId` are missing (set `projectId` in `waniwani.json`)
- Exported types: `EmailModule`, `EmailSendInput`, `EmailSendResult`, `ModulesContext` from `@waniwani/sdk/mcp`
- Docs: `skills/waniwani-sdk/references/modules.md` + SKILL.md export table

Template sends use the template's saved subject when set (with variable substitution applied); the `subject` you pass is the fallback, and is always used for `content` / `html` sends.

## Tier
Free tier — requires `WANIWANI_API_KEY` and a `projectId`.

## Verification
- `bun run typecheck` — clean
- `biome check` — clean
