### PR TITLE
docs: fix brand casing WaniWani -> Waniwani in prose and strings

### DIFF
--- a/.claude/commands/project-planning.md
+++ b/.claude/commands/project-planning.md
@@ -136,7 +136,7 @@ Each ticket should include:
 ## Creating Issues
 
 When creating issues, use:
-- `team`: "WaniWani" (or fetch from project)
+- `team`: "Waniwani" (or fetch from project)
 - `project`: The project name from $ARGUMENTS
 - `priority`: 2 (High) for foundational work, 3 (Normal) for features
 - `blocks`: Array of issue identifiers that this ticket blocks

--- a/.claude/skills/create-flow-app/SKILL.md
+++ b/.claude/skills/create-flow-app/SKILL.md
@@ -3,7 +3,7 @@ name: create-flow-app
 description: "Scaffold a new multi-step conversational flow with createFlow from @waniwani/sdk/mcp. Triggers when the user is inside this SDK repo and wants to add a new flow, replace legacy createTool/createResource patterns, or set up an MCP server using the open-source path (no API key required). Defaults to OSS-first: in-memory store for dev, adapter recipes for prod, API key as a one-line upgrade."
 license: MIT
 metadata:
-  author: WaniWani
+  author: Waniwani
 ---
 
 # Create a flow app

--- a/.claude/skills/knowledge-base/SKILL.md
+++ b/.claude/skills/knowledge-base/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: knowledge-base
-description: Set up a knowledge base with search for an MCP project. Creates FAQ tool and ingestion script using the WaniWani KB API via @waniwani/sdk.
+description: Set up a knowledge base with search for an MCP project. Creates FAQ tool and ingestion script using the Waniwani KB API via @waniwani/sdk.
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
 # Set Up Knowledge Base
 
-Add semantic search over markdown documents to an MCP project using the WaniWani KB API (`client.kb`).
+Add semantic search over markdown documents to an MCP project using the Waniwani KB API (`client.kb`).
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ This is an example knowledge base entry. Replace this file with your own .md fil
 
 ## How does it work?
 
-Each .md file is split into chunks by H2 headings. The H1 title provides context for each chunk. Run `bun run kb:ingest` to upload your knowledge files to the WaniWani API.
+Each .md file is split into chunks by H2 headings. The H1 title provides context for each chunk. Run `bun run kb:ingest` to upload your knowledge files to the Waniwani API.
 ```
 
 ### 3. Create the ingestion script

--- a/.claude/skills/translations/SKILL.md
+++ b/.claude/skills/translations/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: translations
-description: Add or update translations for pages and components in the WaniWani app. Use when the user wants to add translations, create translation files, internationalize a page, make text translatable, or update existing translations. Also use proactively when creating new pages or components with user-facing text.
+description: Add or update translations for pages and components in the Waniwani app. Use when the user wants to add translations, create translation files, internationalize a page, make text translatable, or update existing translations. Also use proactively when creating new pages or components with user-facing text.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
-# WaniWani Translation System
+# Waniwani Translation System
 
-Automatically create and manage translations for pages and components using the WaniWani translation system.
+Automatically create and manage translations for pages and components using the Waniwani translation system.
 
 **📚 For real-world examples, see `examples.md` in this directory.**
 

--- a/.claude/skills/visualize-flow/SKILL.md
+++ b/.claude/skills/visualize-flow/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: visualize-flow
-description: Generate a Mermaid diagram from a WaniWani flow definition. Use when the user wants to visualize, diagram, or document a flow's structure and branching logic.
+description: Generate a Mermaid diagram from a Waniwani flow definition. Use when the user wants to visualize, diagram, or document a flow's structure and branching logic.
 allowed-tools: Read, Glob, Grep, Bash
 ---
 
 # Visualize Flow
 
-Generate a Mermaid flowchart diagram from a WaniWani SDK flow file.
+Generate a Mermaid flowchart diagram from a Waniwani SDK flow file.
 
 ## Arguments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# WaniWani SDK
+# Waniwani SDK
 
 SDK for [app.waniwani.ai](https://app.waniwani.ai) — open-source flow engine plus optional hosted tier for tracking, KB, and chat.
 
@@ -40,7 +40,7 @@ Still used by ~14 internal customer MCPs. Kept exported for back-compat. **Never
 
 ### Internal (not part of the public API)
 
-`@waniwani/sdk/internal` is a private entry point for the WaniWani platform (app.waniwani.ai) to reuse SDK primitives that should not be exposed to third-party consumers. **Never document these in user-facing docs. Never suggest them for new code outside the WaniWani monorepo.**
+`@waniwani/sdk/internal` is a private entry point for the Waniwani platform (app.waniwani.ai) to reuse SDK primitives that should not be exposed to third-party consumers. **Never document these in user-facing docs. Never suggest them for new code outside the Waniwani monorepo.**
 
 - `replayScenario`, `ConversationTurnResult`, `ConversationResult`, `EvalScenario`, `ChatResult`, `ToolCallTrace`, `TurnAssertion`, `EvalScenarioType` from `@waniwani/sdk/internal` — replay a recorded UIMessage conversation against an MCP-backed chat server. Used by the compliance/evals features in the app.
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ See [Why MCP funnels](https://docs.waniwani.ai/why-mcp-funnels) for the full arg
 ## How it compares
 
 - **vs the raw MCP SDK.** You would serialize state through the model on every turn. `createFlow` persists state server-side under the session id; the model carries nothing between calls.
-- **vs LangChain or LangGraph.** General-purpose agent graphs. WaniWani is funnel-shaped: interrupts, re-ask on validation, auto-skip pre-filled fields, widget delegation, typed state via Zod. See [vs LangGraph](https://docs.waniwani.ai/compare/vs-langgraph).
+- **vs LangChain or LangGraph.** General-purpose agent graphs. Waniwani is funnel-shaped: interrupts, re-ask on validation, auto-skip pre-filled fields, widget delegation, typed state via Zod. See [vs LangGraph](https://docs.waniwani.ai/compare/vs-langgraph).
 - **vs closed-source platform SDKs.** MIT. The flow engine has zero runtime dependency on `app.waniwani.ai`. The hosted Platform is opt-in via a single env var.
 
 ## Engine + optional Platform
 
 The flow engine is MIT and runs without an API key against any `get` / `set` / `delete` store (Redis, Upstash, Cloudflare KV, DynamoDB, Postgres, in-memory).
 
-Set `WANIWANI_API_KEY` to connect the [WaniWani Platform](https://docs.waniwani.ai/platform/overview):
+Set `WANIWANI_API_KEY` to connect the [Waniwani Platform](https://docs.waniwani.ai/platform/overview):
 
 - Hosted, encrypted-at-rest flow state. No infra to run.
 - Event tracking and funnel analytics.
@@ -119,7 +119,7 @@ git clone https://github.com/WaniWani-AI/mcp-distribution-template.git my-mcp-se
 
 ## CLI
 
-The companion [`@waniwani/cli`](https://www.npmjs.com/package/@waniwani/cli) wires a local repo to a WaniWani agent and runs your MCP server against the hosted playground in one command. Optional — the SDK works without it.
+The companion [`@waniwani/cli`](https://www.npmjs.com/package/@waniwani/cli) wires a local repo to a Waniwani agent and runs your MCP server against the hosted playground in one command. Optional — the SDK works without it.
 
 ```bash
 bun add -g @waniwani/cli
@@ -151,6 +151,6 @@ Found a vulnerability? Please report it privately — see [SECURITY.md](./SECURI
 
 ## License
 
-[MIT](./LICENSE) © WaniWani
+[MIT](./LICENSE) © Waniwani
 
-"WaniWani" is a trademark of WaniWani Inc. The license covers the code, not the name.
+"Waniwani" is a trademark of Waniwani Inc. The license covers the code, not the name.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-We take the security of `@waniwani/sdk` and the WaniWani Platform seriously. Thank you for helping keep our users safe.
+We take the security of `@waniwani/sdk` and the Waniwani Platform seriously. Thank you for helping keep our users safe.
 
 ## Supported versions
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,7 +1,7 @@
 ---
 title: Changelog
-description: "Release notes for the WaniWani SDK, including breaking changes and deprecated APIs."
-keywords: ["WaniWani SDK changelog", "release notes", "SDK migration", "breaking changes"]
+description: "Release notes for the Waniwani SDK, including breaking changes and deprecated APIs."
+keywords: ["Waniwani SDK changelog", "release notes", "SDK migration", "breaking changes"]
 ---
 
 This page tracks API changes that require code updates, organized by the version that introduced them. Deprecations are safe to ignore short-term — the old shape keeps working until the removal version listed in the deprecation notice.
@@ -233,7 +233,7 @@ The first command should produce hits (those are the new paths). The remaining c
 
 ### `ChatCard` → `ChatEmbed`
 
-`ChatCard` is still exported but marked `@deprecated`. It wraps `ChatEmbed` with always-visible card chrome (header, border, fixed dimensions) and assumes the WaniWani-hosted backend.
+`ChatCard` is still exported but marked `@deprecated`. It wraps `ChatEmbed` with always-visible card chrome (header, border, fixed dimensions) and assumes the Waniwani-hosted backend.
 
 ```tsx
 // Before
@@ -258,11 +258,11 @@ import { ChatEmbed } from "@waniwani/sdk/chat";
 />
 ```
 
-`ChatEmbed` does not fetch `/config` or `/tool` against the WaniWani host — you point `api` at your own endpoint and (optionally) supply `mcp.resourceEndpoint` if your backend serves widget resources.
+`ChatEmbed` does not fetch `/config` or `/tool` against the Waniwani host — you point `api` at your own endpoint and (optionally) supply `mcp.resourceEndpoint` if your backend serves widget resources.
 
 ### `evals/*` removed
 
-The `src/evals/*` subtree (chat eval runner, scorers, reporter) was removed entirely. No re-export shim. If you imported `runChatEval`, `createScorer`, or any sibling from `@waniwani/sdk/evals`, the build will fail on upgrade — there is no equivalent in this release. Eval tooling has moved to the WaniWani platform and is no longer shipped in-SDK.
+The `src/evals/*` subtree (chat eval runner, scorers, reporter) was removed entirely. No re-export shim. If you imported `runChatEval`, `createScorer`, or any sibling from `@waniwani/sdk/evals`, the build will fail on upgrade — there is no equivalent in this release. Eval tooling has moved to the Waniwani platform and is no longer shipped in-SDK.
 
 ---
 

--- a/docs/chat/embed.mdx
+++ b/docs/chat/embed.mdx
@@ -4,7 +4,7 @@ description: "Drop-in chat for any website. The dashboard generates the snippet 
 keywords: ["chat widget", "embed chat", "MCP chat widget", "script tag install", "embed.js"]
 ---
 
-The chat embed is a self-contained IIFE bundle that drops the WaniWani chat into any website. It talks directly to `app.waniwani.ai`, so no backend proxy is required on your side.
+The chat embed is a self-contained IIFE bundle that drops the Waniwani chat into any website. It talks directly to `app.waniwani.ai`, so no backend proxy is required on your side.
 
 <Note>
 **Platform feature.** The dashboard generates the embed snippet for your project. [Open app.waniwani.ai](https://app.waniwani.ai) to get yours, or read more about the [Platform](/platform/overview).

--- a/docs/chat/react.mdx
+++ b/docs/chat/react.mdx
@@ -1,13 +1,13 @@
 ---
 title: Chat in React
-description: "Embed the WaniWani chat as a React component in your app."
+description: "Embed the Waniwani chat as a React component in your app."
 keywords: ["React chat", "ChatEmbed component", "React embed", "MCP chat React"]
 ---
 
 For React apps where you want full control over layout, theming, and lifecycle, import the chat directly from `@waniwani/sdk/chat`.
 
 <Note>
-**Platform feature.** Requires a WaniWani project token (`wwp_...`). [Get one at app.waniwani.ai](https://app.waniwani.ai) or read more about the [Platform](/platform/overview).
+**Platform feature.** Requires a Waniwani project token (`wwp_...`). [Get one at app.waniwani.ai](https://app.waniwani.ai) or read more about the [Platform](/platform/overview).
 </Note>
 
 ## Install

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: CLI overview
-description: "The @waniwani/cli connects a local repo to a WaniWani agent and runs your MCP server against the hosted playground in one command."
-keywords: ["WaniWani CLI", "@waniwani/cli", "MCP CLI", "waniwani login", "waniwani connect", "waniwani dev", "MCP dev workflow"]
+description: "The @waniwani/cli connects a local repo to a Waniwani agent and runs your MCP server against the hosted playground in one command."
+keywords: ["Waniwani CLI", "@waniwani/cli", "MCP CLI", "waniwani login", "waniwani connect", "waniwani dev", "MCP dev workflow"]
 ---
 
-`@waniwani/cli` is the official command-line tool for [WaniWani](https://app.waniwani.ai). It wires a local repo to a WaniWani agent, runs your MCP server locally against the hosted playground, and removes the manual steps of provisioning GitHub, Vercel, and API keys.
+`@waniwani/cli` is the official command-line tool for [Waniwani](https://app.waniwani.ai). It wires a local repo to a Waniwani agent, runs your MCP server locally against the hosted playground, and removes the manual steps of provisioning GitHub, Vercel, and API keys.
 
 The CLI is **optional**. [`@waniwani/sdk`](/configuration/installation) works on its own — the CLI is the fastest way to skip the dashboard for project setup and local development.
 
@@ -38,7 +38,7 @@ waniwani connect   # pick an org + agent, writes waniwani.json
 waniwani dev       # run local MCP, open playground bridged to localhost
 ```
 
-Three commands. Your local MCP server is now reachable from ChatGPT, Claude, and Cursor through the WaniWani playground, with no tunnel setup.
+Three commands. Your local MCP server is now reachable from ChatGPT, Claude, and Cursor through the Waniwani playground, with no tunnel setup.
 
 ## Commands
 
@@ -47,7 +47,7 @@ Three commands. Your local MCP server is now reachable from ChatGPT, Claude, and
 | [`waniwani login`](#login) | Browser-based OAuth2 PKCE. Stores tokens in `.waniwani/settings.json`. |
 | [`waniwani logout`](#logout) | Clear local credentials. |
 | [`waniwani connect`](#connect) | Pick an org, pick or create an agent, write the binding to `waniwani.json`. |
-| [`waniwani dev`](#dev) | Run your MCP locally and open the WaniWani playground against it. |
+| [`waniwani dev`](#dev) | Run your MCP locally and open the Waniwani playground against it. |
 
 ### login
 
@@ -76,7 +76,7 @@ waniwani connect
 Interactive only. Walks you through:
 
 1. **Pick an organization.** If you're in one org, it's auto-selected.
-2. **Pick or create an agent.** Either select an existing project, create a new **managed** agent (WaniWani provisions a GitHub repo + Vercel project from the [MCP distribution template](https://github.com/WaniWani-AI/mcp-distribution-template) with API keys pre-wired), or create a new **external** agent (you host the MCP server; the CLI gives you a production API key to set as `WANIWANI_API_KEY`).
+2. **Pick or create an agent.** Either select an existing project, create a new **managed** agent (Waniwani provisions a GitHub repo + Vercel project from the [MCP distribution template](https://github.com/WaniWani-AI/mcp-distribution-template) with API keys pre-wired), or create a new **external** agent (you host the MCP server; the CLI gives you a production API key to set as `WANIWANI_API_KEY`).
 3. **Write the binding.** Writes `waniwani.json` at the repo root with `$schema`, `orgId`, and `projectId`. If the file already exists, the CLI merges the keys in; if the shape isn't recognized, it prints the snippet for you to paste. If a legacy `waniwani.config.ts` is present, it's removed after the JSON file is written.
 
 Re-run anytime to switch the repo to a different agent.
@@ -85,7 +85,7 @@ Re-run anytime to switch the repo to a different agent.
 
 | | Managed | External |
 |---|---|---|
-| Where the server runs | WaniWani-hosted Vercel project | Your infra (Docker, Cloudflare Workers, fly.io, etc.) |
+| Where the server runs | Waniwani-hosted Vercel project | Your infra (Docker, Cloudflare Workers, fly.io, etc.) |
 | Source code | Auto-provisioned from [mcp-distribution-template](https://github.com/WaniWani-AI/mcp-distribution-template) | Yours |
 | API key | Pre-configured in the Vercel env | Printed once by the CLI — save it as `WANIWANI_API_KEY` |
 | Deploys on | Push to `main` | Whatever you already use |
@@ -103,7 +103,7 @@ Interactive only. The end-to-end local dev loop:
 1. Ensures you're logged in (runs `login` if not) and that `waniwani.json` has a `projectId` (runs `connect` if not).
 2. Detects your package manager (`bun` / `pnpm` / `yarn` / `npm`) and spawns the dev script with `PORT` set.
 3. Waits for the local server to bind to the port.
-4. Creates a dev session against the WaniWani API and starts a heartbeat.
+4. Creates a dev session against the Waniwani API and starts a heartbeat.
 5. Opens the playground at `app.waniwani.ai/agents/<projectId>/playground?localMode=1` so chat traffic routes to your local server.
 6. Ctrl-C tears the dev session down cleanly.
 
@@ -191,7 +191,7 @@ waniwani dev
 
 ## For AI coding agents
 
-If you're [Claude Code](https://claude.com/claude-code), Cursor, or another AI agent setting up WaniWani in a user's repo:
+If you're [Claude Code](https://claude.com/claude-code), Cursor, or another AI agent setting up Waniwani in a user's repo:
 
 1. Confirm the user is in an MCP project (`@waniwani/sdk` in `package.json`, or it's the [distribution template](https://github.com/WaniWani-AI/mcp-distribution-template)). If not, scaffold one with the [SDK quickstart](/quickstart) first.
 2. Run `waniwani login` — opens the browser; the user authenticates once.
@@ -201,7 +201,7 @@ If you're [Claude Code](https://claude.com/claude-code), Cursor, or another AI a
 The CLI is interactive — `connect` and `dev` cannot run under `--json`. Pair it with the [agent skill](/guides/skills) for code generation:
 
 ```bash
-bunx skills add WaniWani-AI/sdk -s waniwani-sdk
+bunx skills add Waniwani-AI/sdk -s waniwani-sdk
 ```
 
 The skill teaches your agent the SDK APIs (flows, tracking, widgets, knowledge base). The CLI handles platform wiring. They're independent — install whichever you need.
@@ -209,7 +209,7 @@ The skill teaches your agent the SDK APIs (flows, tracking, widgets, knowledge b
 ## Source
 
 - **npm:** [`@waniwani/cli`](https://www.npmjs.com/package/@waniwani/cli)
-- **GitHub:** [WaniWani-AI/cli](https://github.com/WaniWani-AI/cli)
+- **GitHub:** [Waniwani-AI/cli](https://github.com/WaniWani-AI/cli)
 - **Issues:** [github.com/WaniWani-AI/cli/issues](https://github.com/WaniWani-AI/cli/issues)
 
-MIT licensed, like the rest of the WaniWani stack.
+MIT licensed, like the rest of the Waniwani stack.

--- a/docs/compare/vs-langgraph.mdx
+++ b/docs/compare/vs-langgraph.mdx
@@ -1,7 +1,7 @@
 ---
-title: "WaniWani vs LangGraph"
+title: "Waniwani vs LangGraph"
 description: "When to use createFlow vs LangChain's LangGraph for MCP funnels and multi-step conversational tools."
-keywords: ["LangGraph alternative", "LangGraph MCP", "LangGraph vs WaniWani", "LangChain alternative", "conversational graph SDK", "MCP state machine", "TypeScript LangGraph"]
+keywords: ["LangGraph alternative", "LangGraph MCP", "LangGraph vs Waniwani", "LangChain alternative", "conversational graph SDK", "MCP state machine", "TypeScript LangGraph"]
 ---
 
 LangGraph is LangChain's graph framework for agent workflows. `@waniwani/sdk` is a graph framework specifically for MCP funnels. The two overlap. They are not interchangeable.

--- a/docs/configuration/api-key.mdx
+++ b/docs/configuration/api-key.mdx
@@ -1,10 +1,10 @@
 ---
 title: API Keys
-description: "Create, configure, and rotate WaniWani API keys."
-keywords: ["WaniWani API key", "free tier setup", "wwk key", "API key rotation"]
+description: "Create, configure, and rotate Waniwani API keys."
+keywords: ["Waniwani API key", "free tier setup", "wwk key", "API key rotation"]
 ---
 
-Every WaniWani client authenticates with a single API key scoped to one **MCP environment**. When you create a project, two environments are provisioned automatically: **Staging** and **Production**, each with its own unique API key.
+Every Waniwani client authenticates with a single API key scoped to one **MCP environment**. When you create a project, two environments are provisioned automatically: **Staging** and **Production**, each with its own unique API key.
 
 The key you use determines which environment your data (events, sessions, knowledge base) is stored in. Use the Staging key during development and the Production key for live traffic. This keeps your data cleanly separated.
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Environment Variables
-description: "All environment variables recognized by the WaniWani SDK."
+description: "All environment variables recognized by the Waniwani SDK."
 keywords: ["env vars", "WANIWANI_API_KEY", "WANIWANI_API_URL", "environment configuration"]
 ---
 

--- a/docs/configuration/installation.mdx
+++ b/docs/configuration/installation.mdx
@@ -15,7 +15,7 @@ keywords: ["install SDK", "bun add", "npm install", "@waniwani/sdk install"]
   </Card>
 </CardGroup>
 
-The SDK is open source and works without an API key. Set `WANIWANI_API_KEY` to connect the [WaniWani Platform](/platform/overview) and unlock hosted state, tracking, knowledge base, and the chat widget on top.
+The SDK is open source and works without an API key. Set `WANIWANI_API_KEY` to connect the [Waniwani Platform](/platform/overview) and unlock hosted state, tracking, knowledge base, and the chat widget on top.
 
 ---
 
@@ -63,7 +63,7 @@ The [MCP Distribution Template](https://github.com/WaniWani-AI/mcp-distribution-
   - [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk)
   - [Skybridge](https://github.com/alpic-ai/skybridge) (Alpic)
   - [`@vercel/mcp-handler`](https://www.npmjs.com/package/@vercel/mcp-handler)
-- A WaniWani account at [app.waniwani.ai](https://app.waniwani.ai) — optional, only needed for [Platform](/platform/overview) features.
+- A Waniwani account at [app.waniwani.ai](https://app.waniwani.ai) — optional, only needed for [Platform](/platform/overview) features.
 
 `@modelcontextprotocol/sdk` and `zod` are peer dependencies. Install them in your project if you do not already have them.
 
@@ -145,7 +145,7 @@ withWaniwani(server);
 WANIWANI_API_KEY=wwk_...
 ```
 
-Every wrapped tool call now emits a `tool.called` event to your [WaniWani dashboard](https://app.waniwani.ai). Without an API key, the wrapper still bridges session IDs and forwards widget metadata but emits no events. Safe to wrap unconditionally. See [Wrap your server](/configuration/wrap-server) for all options.
+Every wrapped tool call now emits a `tool.called` event to your [Waniwani dashboard](https://app.waniwani.ai). Without an API key, the wrapper still bridges session IDs and forwards widget metadata but emits no events. Safe to wrap unconditionally. See [Wrap your server](/configuration/wrap-server) for all options.
 
 ## Create a Platform client
 

--- a/docs/configuration/security.mdx
+++ b/docs/configuration/security.mdx
@@ -6,11 +6,11 @@ keywords: ["MCP security", "encryption at rest", "key rotation", "data residency
 
 ## Encryption at rest
 
-Flow state is stored server-side via the WaniWani KV store. The SDK supports **AES-256-GCM encryption** -- values are encrypted before they leave your MCP server process and decrypted on read. The WaniWani server never sees plaintext flow state.
+Flow state is stored server-side via the Waniwani KV store. The SDK supports **AES-256-GCM encryption** -- values are encrypted before they leave your MCP server process and decrypted on read. The Waniwani server never sees plaintext flow state.
 
 <CardGroup cols={2}>
   <Card title="Managed project" icon="cloud" href="#managed-projects">
-    Encryption is automatic. WaniWani generates and manages the key for you -- nothing to configure.
+    Encryption is automatic. Waniwani generates and manages the key for you -- nothing to configure.
   </Card>
   <Card title="Self-hosted project" icon="server" href="#self-hosted-projects">
     You generate a key and add it to your MCP server's environment.
@@ -21,7 +21,7 @@ Flow state is stored server-side via the WaniWani KV store. The SDK supports **A
 
 ### Managed projects
 
-Encryption is enabled automatically. WaniWani generates and stores the encryption key as an environment variable in your deployed instance. No setup is needed -- flow state is encrypted out of the box and the key is never exposed.
+Encryption is enabled automatically. Waniwani generates and stores the encryption key as an environment variable in your deployed instance. No setup is needed -- flow state is encrypted out of the box and the key is never exposed.
 
 ### Self-hosted projects
 
@@ -59,7 +59,7 @@ In practice, the simplest approach is to let existing sessions expire naturally 
 
 ## API key handling
 
-API keys (`WANIWANI_API_KEY`) authenticate your MCP server to the WaniWani platform. Treat them as server-side secrets:
+API keys (`WANIWANI_API_KEY`) authenticate your MCP server to the Waniwani platform. Treat them as server-side secrets:
 
 - Never commit them to version control.
 - Never include them in client-side bundles.
@@ -70,8 +70,8 @@ See [API Keys](/configuration/api-key) for setup and rotation details.
 
 ## Transport security
 
-All communication between the SDK and the WaniWani API uses HTTPS (TLS 1.2+). No additional configuration is needed.
+All communication between the SDK and the Waniwani API uses HTTPS (TLS 1.2+). No additional configuration is needed.
 
 ## Tenant isolation
 
-Each API key is scoped to a single MCP environment. The WaniWani API enforces tenant isolation at the key level -- one key cannot access another environment's data (events, sessions, KV store, knowledge base).
+Each API key is scoped to a single MCP environment. The Waniwani API enforces tenant isolation at the key level -- one key cannot access another environment's data (events, sessions, KV store, knowledge base).

--- a/docs/configuration/wrap-server.mdx
+++ b/docs/configuration/wrap-server.mdx
@@ -76,7 +76,7 @@ withWaniwani(server, {
 </ResponseField>
 
 <ResponseField name="injectWidgetToken" type="boolean" default={true}>
-  Inject a short-lived widget tracking token into tool responses under `_meta.waniwani`, so browser widgets can post events directly to WaniWani without a proxy route. Without an API key, the token is omitted and only the endpoint metadata is injected.
+  Inject a short-lived widget tracking token into tool responses under `_meta.waniwani`, so browser widgets can post events directly to Waniwani without a proxy route. Without an API key, the token is omitted and only the endpoint metadata is injected.
 </ResponseField>
 
 <ResponseField name="onError" type="(error: Error) => void">

--- a/docs/deployment/overview.mdx
+++ b/docs/deployment/overview.mdx
@@ -1,14 +1,14 @@
 ---
 title: Deployment
-description: "Run your WaniWani-powered MCP app on Managed Hosting or self-host it yourself (Docker, Alpic, Vercel)."
+description: "Run your Waniwani-powered MCP app on Managed Hosting or self-host it yourself (Docker, Alpic, Vercel)."
 keywords: ["deploy MCP", "MCP hosting", "Docker MCP", "Vercel MCP", "Alpic MCP", "managed hosting"]
 ---
 
-Where your MCP server runs is independent of whether you connect the [WaniWani Platform](/platform/overview). This page covers the two server-hosting options. The Platform layer (tracking, KB, chat, hosted state) works the same in both.
+Where your MCP server runs is independent of whether you connect the [Waniwani Platform](/platform/overview). This page covers the two server-hosting options. The Platform layer (tracking, KB, chat, hosted state) works the same in both.
 
 <CardGroup cols={2}>
   <Card title="Managed Hosting" icon="cloud" href="#managed-hosting">
-    WaniWani hosts your app. Provisioned, pre-configured, push to main and it deploys. Fastest path.
+    Waniwani hosts your app. Provisioned, pre-configured, push to main and it deploys. Fastest path.
   </Card>
   <Card title="Self-hosted" icon="server" href="#self-hosted-server">
     You host the app yourself. Docker, Alpic, or Vercel. Connect by giving us the MCP URL.
@@ -19,7 +19,7 @@ Both paths use the same [MCP Distribution Template](https://github.com/WaniWani-
 
 ## Managed Hosting
 
-When you create a managed project in the [WaniWani dashboard](https://app.waniwani.ai), we provision a copy of the distribution template fully wired up: API keys set, hosted URL assigned, everything ready. You don't configure anything.
+When you create a managed project in the [Waniwani dashboard](https://app.waniwani.ai), we provision a copy of the distribution template fully wired up: API keys set, hosted URL assigned, everything ready. You don't configure anything.
 
 Typical workflow:
 
@@ -80,13 +80,13 @@ vercel deploy
 
 From the template root. Set `WANIWANI_API_KEY` and any backend secrets in your Vercel project's environment variables.
 
-### Connect to WaniWani
+### Connect to Waniwani
 
-Once your app is deployed, copy its public MCP URL (the endpoint where MCP clients send `initialize` / `tools/call` requests). In the WaniWani dashboard, create a self-hosted project and paste that URL. WaniWani uses it as the entry point for chat requests, widget rendering, and analytics ingestion.
+Once your app is deployed, copy its public MCP URL (the endpoint where MCP clients send `initialize` / `tools/call` requests). In the Waniwani dashboard, create a self-hosted project and paste that URL. Waniwani uses it as the entry point for chat requests, widget rendering, and analytics ingestion.
 
 ### Advanced: bring your own session cache
 
-By default a self-hosted server uses `WaniwaniKvStore` for flow state when `WANIWANI_API_KEY` is set (encrypted at rest, hosted by WaniWani, no infra). That's the recommended setup.
+By default a self-hosted server uses `WaniwaniKvStore` for flow state when `WANIWANI_API_KEY` is set (encrypted at rest, hosted by Waniwani, no infra). That's the recommended setup.
 
 If you want zero dependency on `app.waniwani.ai` for state too, plug in your own `KvStore` adapter at `.compile()` time:
 
@@ -103,4 +103,4 @@ Your server, your state. You can still send tracking events to the Platform by c
 
 ## Platform features are orthogonal
 
-Tracking, KB, chat, funnel analytics, and hosted state are Platform features. They are independent of where your server lives and where your state lives. Both Managed Hosting and self-hosted servers emit events through `withWaniwani(server)` and `client.track()`, and both surface in the same WaniWani dashboard. See the [Platform overview](/platform/overview) for what's included and [Tracking](/tracking/overview) for the event pipeline.
+Tracking, KB, chat, funnel analytics, and hosted state are Platform features. They are independent of where your server lives and where your state lives. Both Managed Hosting and self-hosted servers emit events through `withWaniwani(server)` and `client.track()`, and both surface in the same Waniwani dashboard. See the [Platform overview](/platform/overview) for what's included and [Tracking](/tracking/overview) for the event pipeline.

--- a/docs/deployment/self-hosting.mdx
+++ b/docs/deployment/self-hosting.mdx
@@ -4,12 +4,12 @@ description: "Two pieces you can self-host independently: the MCP app and the KV
 keywords: ["self-host MCP", "self-host KV", "Docker deployment", "on-prem MCP"]
 ---
 
-A WaniWani deployment has **two pieces you can self-host independently**:
+A Waniwani deployment has **two pieces you can self-host independently**:
 
 1. **The MCP app** — the server that hosts your `createFlow` tools and serves MCP clients.
 2. **The KV store** — where flow state lives between tool calls.
 
-These are orthogonal. The most common setup is "self-host the MCP app, let WaniWani host the KV store" — your infra for the server, the [WaniWani Platform](/platform/overview) for state and dashboards. The next step is self-hosting the KV too, eliminating any outbound call to `app.waniwani.ai`.
+These are orthogonal. The most common setup is "self-host the MCP app, let Waniwani host the KV store" — your infra for the server, the [Waniwani Platform](/platform/overview) for state and dashboards. The next step is self-hosting the KV too, eliminating any outbound call to `app.waniwani.ai`.
 
 |  | KV on `WaniwaniKvStore` | KV self-hosted |
 |---|---|---|
@@ -54,9 +54,9 @@ When `.compile()` is called with no `store` and `WANIWANI_API_KEY` is set, the S
 
 Any platform that can run Node 18.17+ works: Vercel, Render, Railway, Fly.io, Cloudflare Workers, AWS Lambda, Google Cloud Run. See [Deployment overview](/deployment/overview) for the choice between this and Managed Hosting.
 
-### Register with WaniWani
+### Register with Waniwani
 
-In the [WaniWani dashboard](https://app.waniwani.ai), create a self-hosted project and paste your deployed MCP URL. WaniWani routes chat requests, widget rendering, and analytics ingestion through that URL.
+In the [Waniwani dashboard](https://app.waniwani.ai), create a self-hosted project and paste your deployed MCP URL. Waniwani routes chat requests, widget rendering, and analytics ingestion through that URL.
 
 ## 2. Self-host the KV store
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
-  "name": "WaniWani SDK",
+  "name": "Waniwani SDK",
   "colors": {
     "primary": "#03d916",
     "light": "#5EFF73",
@@ -67,7 +67,7 @@
             ]
           },
           {
-            "group": "WaniWani Platform",
+            "group": "Waniwani Platform",
             "pages": [
               "platform/overview"
             ]
@@ -195,14 +195,14 @@
     "display": "header"
   },
   "search": {
-    "prompt": "Search the WaniWani SDK..."
+    "prompt": "Search the Waniwani SDK..."
   },
   "seo": {
     "indexing": "all",
     "metatags": {
       "og:type": "website",
-      "og:site_name": "WaniWani SDK",
-      "og:title": "WaniWani SDK — Build MCP funnels",
+      "og:site_name": "Waniwani SDK",
+      "og:title": "Waniwani SDK — Build MCP funnels",
       "og:description": "Open-source SDK for MCP funnels. Build sales funnels, lead generation, booking, and quote flows on top of any MCP server.",
       "twitter:card": "summary_large_image",
       "twitter:site": "@waniwani_ai"

--- a/docs/flows/architecture.mdx
+++ b/docs/flows/architecture.mdx
@@ -104,7 +104,7 @@ The KV powers the flow engine only. The following live in a separate pipeline:
 
 - **Tracking events.** `tool.called`, `quote.succeeded`, etc. are emitted by `withWaniwani(server)` and `client.track()`, batched, and POSTed to the events endpoint. Independent of the KV store.
 - **Funnel analytics and dashboards.** Built from tracking events on the server side. Reading them never touches your KV.
-- **Knowledge base content.** Lives in WaniWani's hosted KB service, unrelated to flow state.
+- **Knowledge base content.** Lives in Waniwani's hosted KB service, unrelated to flow state.
 
 You can self-host the KV and still get hosted dashboards by also calling `withWaniwani(server)` with `WANIWANI_API_KEY` set. The two systems compose.
 
@@ -147,7 +147,7 @@ You can self-host the KV and still get hosted dashboards by also calling `withWa
   <Card title="Tool contract" icon="plug" href="/reference/flow-tool-contract">
     Wire-level reference for `FlowToolInput` and response statuses.
   </Card>
-  <Card title="WaniWani Platform" icon="layer-group" href="/platform/overview">
+  <Card title="Waniwani Platform" icon="layer-group" href="/platform/overview">
     What runs without an API key, what unlocks when you connect the Platform.
   </Card>
 </CardGroup>

--- a/docs/flows/kv-store.mdx
+++ b/docs/flows/kv-store.mdx
@@ -5,7 +5,7 @@ keywords: ["KV store", "Redis adapter", "Upstash adapter", "Cloudflare KV adapte
 ---
 
 <Note>
-**Open source.** The KV store interface works without an API key. The hosted `WaniwaniKvStore` requires the [WaniWani Platform](/platform/overview).
+**Open source.** The KV store interface works without an API key. The hosted `WaniwaniKvStore` requires the [Waniwani Platform](/platform/overview).
 </Note>
 
 A flow needs a place to persist its state between MCP calls. MCP tools are stateless, so without a store the engine has nothing to resume from on the next `continue` call. **Every compiled flow is therefore required to have a store.** `.compile()` throws at compile time if you pass neither a `store` argument nor configure `WANIWANI_API_KEY`.

--- a/docs/flows/overview.mdx
+++ b/docs/flows/overview.mdx
@@ -5,7 +5,7 @@ keywords: ["flow engine", "MCP state machine", "multi-step MCP", "MCP funnel eng
 ---
 
 <Note>
-**Open source.** Works without an API key. Connect the [WaniWani Platform](/platform/overview) to add tracking, knowledge base, chat, and hosted state.
+**Open source.** Works without an API key. Connect the [Waniwani Platform](/platform/overview) to add tracking, knowledge base, chat, and hosted state.
 </Note>
 
 A flow is a graph of nodes that compiles into a single MCP tool. Each tool call runs the engine one step at a time: it asks a question, validates the answer, branches on state, then persists progress server-side under the MCP session id. The model never has to carry a token between calls.

--- a/docs/flows/register.mdx
+++ b/docs/flows/register.mdx
@@ -26,7 +26,7 @@ const onboardingFlow = createFlow({
 .compile({ store: myCustomStore });
 ```
 
-The default is `WaniwaniFlowStore`, which uses the WaniWani API as a key-value store keyed by session id. It reads `WANIWANI_API_KEY` and `WANIWANI_API_URL` from env.
+The default is `WaniwaniFlowStore`, which uses the Waniwani API as a key-value store keyed by session id. It reads `WANIWANI_API_KEY` and `WANIWANI_API_URL` from env.
 
 ## The RegisteredFlow shape
 

--- a/docs/guides/commands.mdx
+++ b/docs/guides/commands.mdx
@@ -1,10 +1,10 @@
 ---
 title: Commands
-description: "Guided commands available with the WaniWani SDK agent skill."
+description: "Guided commands available with the Waniwani SDK agent skill."
 keywords: ["SDK commands", "skill commands", "Claude Code commands", "guided commands"]
 ---
 
-The WaniWani SDK skill ships with guided commands (playbooks) that walk your AI agent through common tasks step by step. After [installing the skill](/guides/skills), invoke them as slash commands in Claude Code, Cursor, or any compatible agent.
+The Waniwani SDK skill ships with guided commands (playbooks) that walk your AI agent through common tasks step by step. After [installing the skill](/guides/skills), invoke them as slash commands in Claude Code, Cursor, or any compatible agent.
 
 ```bash
 /waniwani-sdk <command>
@@ -12,7 +12,7 @@ The WaniWani SDK skill ships with guided commands (playbooks) that walk your AI 
 
 ## initialize
 
-Scaffold a new MCP distribution project from the WaniWani template. The agent interactively gathers your brand, use case, and data source, then generates a production-ready flow with widgets.
+Scaffold a new MCP distribution project from the Waniwani template. The agent interactively gathers your brand, use case, and data source, then generates a production-ready flow with widgets.
 
 ```bash
 /waniwani-sdk initialize

--- a/docs/guides/funnels.mdx
+++ b/docs/guides/funnels.mdx
@@ -6,7 +6,7 @@ keywords: ["MCP funnel", "sales funnel MCP", "lead generation MCP", "booking MCP
 
 An **MCP funnel** is a multi-step conversation, hosted on your MCP server, that drives a user from intent to outcome (a qualified lead, a booking, a quote, a purchase). ChatGPT, Claude, and any other MCP-capable client become the front-end. Your funnel runs as a single MCP tool.
 
-`@waniwani/sdk` is the SDK for building MCP funnels. The engine is open source. The [WaniWani Platform](/platform/overview) adds funnel analytics, hosted state, knowledge base, and a chat widget on top.
+`@waniwani/sdk` is the SDK for building MCP funnels. The engine is open source. The [Waniwani Platform](/platform/overview) adds funnel analytics, hosted state, knowledge base, and a chat widget on top.
 
 ## What you can build
 
@@ -89,7 +89,7 @@ Register it on your MCP server and the funnel is live in ChatGPT, Claude, or any
 
 - **No website, no form, no chatbot widget.** The funnel runs inside the AI client the user already uses.
 - **One tool call, many turns.** The engine handles state, validation, branching, and resumption.
-- **Funnel analytics out of the box.** Connect the [WaniWani Platform](/platform/overview) and every node visit becomes a funnel step in the dashboard.
+- **Funnel analytics out of the box.** Connect the [Waniwani Platform](/platform/overview) and every node visit becomes a funnel step in the dashboard.
 
 ## Next
 

--- a/docs/guides/pet-insurance.mdx
+++ b/docs/guides/pet-insurance.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Pet insurance (real example)"
-description: "Walk-through of a real production pet insurance quoting flow we built for a WaniWani customer. Showcases open-ended questions, validation, conditional branching, widgets, and correction loops."
+description: "Walk-through of a real production pet insurance quoting flow we built for a Waniwani customer. Showcases open-ended questions, validation, conditional branching, widgets, and correction loops."
 keywords: ["pet insurance flow", "production flow example", "real customer example", "validation example", "widget flow example", "case study"]
 ---
 
-This is a real flow shipped in production by a WaniWani customer — a pet insurance distributor selling policies through their own MCP. It's the kind of build we open-sourced WaniWani for: a multi-step quote conversation that has to feel natural, validate input strictly, branch on edge cases (mixed-breed dogs), and let the user correct themselves without restarting.
+This is a real flow shipped in production by a Waniwani customer — a pet insurance distributor selling policies through their own MCP. It's the kind of build we open-sourced Waniwani for: a multi-step quote conversation that has to feel natural, validate input strictly, branch on edge cases (mixed-breed dogs), and let the user correct themselves without restarting.
 
 We're showing it here, simplified and anonymized, because every pattern in it is one we hit repeatedly across customer projects — and the shape of the answer is what `createFlow` was designed around.
 

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -1,13 +1,13 @@
 ---
 title: Agent Skills
-description: "Install the WaniWani SDK skill for Claude Code, Cursor, and other AI agents."
-keywords: ["WaniWani skill", "Claude Code skill", "Cursor skill", "agent skill install"]
+description: "Install the Waniwani SDK skill for Claude Code, Cursor, and other AI agents."
+keywords: ["Waniwani skill", "Claude Code skill", "Cursor skill", "agent skill install"]
 ---
 
-The WaniWani SDK is available as an [agent skill](https://agentskills.io) for Claude Code, Cursor, GitHub Copilot, and 20+ other AI coding agents. Once installed, your agent knows how to integrate the SDK without you having to explain the API.
+The Waniwani SDK is available as an [agent skill](https://agentskills.io) for Claude Code, Cursor, GitHub Copilot, and 20+ other AI coding agents. Once installed, your agent knows how to integrate the SDK without you having to explain the API.
 
 <Columns cols={2}>
-  <Card title="WaniWani SDK" icon="code" href="#waniwani-sdk">
+  <Card title="Waniwani SDK" icon="code" href="#waniwani-sdk">
     Tracking, flows, widgets, knowledge base, and chat components.
   </Card>
   <Card title="OpenAI Submission" icon="file-check" href="#openai-app-submission">
@@ -15,17 +15,17 @@ The WaniWani SDK is available as an [agent skill](https://agentskills.io) for Cl
   </Card>
 </Columns>
 
-## WaniWani SDK
+## Waniwani SDK
 
 ### Install
 
 <CodeGroup>
   ```bash npx
-  npx skills add WaniWani-AI/sdk -s waniwani-sdk
+  npx skills add Waniwani-AI/sdk -s waniwani-sdk
   ```
 
   ```bash bunx
-  bunx skills add WaniWani-AI/sdk -s waniwani-sdk
+  bunx skills add Waniwani-AI/sdk -s waniwani-sdk
   ```
 </CodeGroup>
 
@@ -46,14 +46,14 @@ The skill teaches your agent how to:
 
 After installing, just describe what you want in natural language. Your agent will use the skill automatically:
 
-- *"Add WaniWani tracking to my MCP server"*
+- *"Add Waniwani tracking to my MCP server"*
 - *"Create a multi-step onboarding flow"*
 - *"Add a knowledge base FAQ tool"*
 - *"Embed a chat widget on my landing page"*
 
 ## OpenAI App Submission
 
-When submitting your MCP server to the ChatGPT App Store, you need to provide Tool Justification and Test Cases documents. The WaniWani dashboard handles this for you: go to your project's submission page and use the built-in Codex assistant to generate a `chatgpt-app-submission.json` file, then upload it to auto-fill the form.
+When submitting your MCP server to the ChatGPT App Store, you need to provide Tool Justification and Test Cases documents. The Waniwani dashboard handles this for you: go to your project's submission page and use the built-in Codex assistant to generate a `chatgpt-app-submission.json` file, then upload it to auto-fill the form.
 
 The generated file includes:
 

--- a/docs/guides/tunnel.mdx
+++ b/docs/guides/tunnel.mdx
@@ -97,7 +97,7 @@ Both the dev server and the tunnel must stay running. If either stops, the publi
 
 ## Using the agent skill
 
-If you have the [WaniWani SDK agent skill](/guides/skills) installed, you can run the `/waniwani-sdk tunnel` command and your AI agent will handle the entire setup for you -- detecting the dev server port, picking an available tunnel provider, and printing the public URL. See [Commands](/guides/commands#tunnel) for details.
+If you have the [Waniwani SDK agent skill](/guides/skills) installed, you can run the `/waniwani-sdk tunnel` command and your AI agent will handle the entire setup for you -- detecting the dev server port, picking an available tunnel provider, and printing the public URL. See [Commands](/guides/commands#tunnel) for details.
 
 ## Good to know
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 description: "Open-source SDK for MCP funnels. Build sales funnels, lead generation, booking, and quote flows on top of your MCP server."
-keywords: ["MCP funnel", "MCP SDK", "ChatGPT app", "Claude app", "open source MCP", "createFlow", "WaniWani"]
+keywords: ["MCP funnel", "MCP SDK", "ChatGPT app", "Claude app", "open source MCP", "createFlow", "Waniwani"]
 ---
 
 `@waniwani/sdk` lets you build multi-step conversational funnels on top of any MCP server. A single MCP tool drives the conversation: it asks the next question, validates the answer, branches on state, and persists progress across calls. ChatGPT, Claude, and any other MCP-capable client become the front-end.
@@ -27,7 +27,7 @@ keywords: ["MCP funnel", "MCP SDK", "ChatGPT app", "Claude app", "open source MC
 
 You declare a flow as a typed state graph. The graph compiles to one MCP tool that the model can call. The engine runs the graph, pauses to ask questions, branches on state, and resumes on the next tool call. Nothing in the model has to carry state between turns.
 
-The flow engine is open source. Set `WANIWANI_API_KEY` to connect the [WaniWani Platform](/platform/overview), which adds hosted state, tracking, funnel analytics, knowledge base, and a chat widget on top.
+The flow engine is open source. Set `WANIWANI_API_KEY` to connect the [Waniwani Platform](/platform/overview), which adds hosted state, tracking, funnel analytics, knowledge base, and a chat widget on top.
 
 ## Next
 

--- a/docs/knowledge-base/overview.mdx
+++ b/docs/knowledge-base/overview.mdx
@@ -12,7 +12,7 @@ The SDK includes a knowledge base client for semantic search. Ingest markdown fi
 
 ## Setup
 
-The KB client is available on the WaniWani client instance:
+The KB client is available on the Waniwani client instance:
 
 ```ts
 import { waniwani } from "@waniwani/sdk";
@@ -47,7 +47,7 @@ bun embed
 
 ### Ingest script for self-hosted projects
 
-If you're running your own MCP server, create a simple script to read your docs and push them to WaniWani. This runs standalone and doesn't need to be inside an MCP server.
+If you're running your own MCP server, create a simple script to read your docs and push them to Waniwani. This runs standalone and doesn't need to be inside an MCP server.
 
 ```ts scripts/kb-ingest.ts
 import { readdir, readFile } from "node:fs/promises";

--- a/docs/mcp-server/connect.mdx
+++ b/docs/mcp-server/connect.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connect your AI client
-description: "Add the WaniWani MCP server to claude.ai, Claude Code, Cursor, or ChatGPT and sign in with your WaniWani account — no API keys."
-keywords: ["connect WaniWani MCP", "claude.ai connector", "Claude Code MCP", "Cursor MCP", "ChatGPT connector", "mcp.waniwani.ai", "MCP OAuth"]
+description: "Add the Waniwani MCP server to claude.ai, Claude Code, Cursor, or ChatGPT and sign in with your Waniwani account — no API keys."
+keywords: ["connect Waniwani MCP", "claude.ai connector", "Claude Code MCP", "Cursor MCP", "ChatGPT connector", "mcp.waniwani.ai", "MCP OAuth"]
 ---
 
 One URL works in every client:
@@ -10,14 +10,14 @@ One URL works in every client:
 https://mcp.waniwani.ai/mcp
 ```
 
-It's a remote MCP server (Streamable HTTP) that authenticates with OAuth 2.1. There is no API key to paste: you add the URL, your client opens a browser window, you sign in to WaniWani and approve the requested permissions. From then on the connection acts as *you* — same organizations, same role.
+It's a remote MCP server (Streamable HTTP) that authenticates with OAuth 2.1. There is no API key to paste: you add the URL, your client opens a browser window, you sign in to Waniwani and approve the requested permissions. From then on the connection acts as *you* — same organizations, same role.
 
 ## Claude (claude.ai and desktop)
 
 1. Open **Settings → Connectors**.
 2. Click **Add custom connector**.
 3. Enter `https://mcp.waniwani.ai/mcp` and confirm.
-4. A WaniWani sign-in window opens — sign in and approve the permissions.
+4. A Waniwani sign-in window opens — sign in and approve the permissions.
 
 On Team and Enterprise plans, an admin may need to enable custom connectors for your workspace first.
 
@@ -60,11 +60,11 @@ Client UIs change quickly. If a menu has moved, follow your client's own guide f
 ## What happens when you sign in
 
 <Steps>
-  <Step title="Your client discovers WaniWani">
+  <Step title="Your client discovers Waniwani">
     The client reads the server's metadata and learns that `app.waniwani.ai` handles sign-in. It registers itself automatically — no manual client IDs.
   </Step>
-  <Step title="You sign in to WaniWani">
-    The browser opens your usual WaniWani login. If you're already signed in, you go straight to consent.
+  <Step title="You sign in to Waniwani">
+    The browser opens your usual Waniwani login. If you're already signed in, you go straight to consent.
   </Step>
   <Step title="You approve the permissions">
     The consent screen itemizes exactly what the connection may do (read environments and analytics, create environments and keys, and so on). You only see permissions your account is entitled to.
@@ -76,7 +76,7 @@ Client UIs change quickly. If a menu has moved, follow your client's own guide f
 
 ## First thing to try
 
-> Who am I signed in to WaniWani as, and what can you do for me here?
+> Who am I signed in to Waniwani as, and what can you do for me here?
 
 Your client will call the server's `whoami` and `search` tools and report your account, your organizations, and the available operations. From there, ask for what you want in plain language — see [the overview](/mcp-server/overview) for example prompts.
 
@@ -84,7 +84,7 @@ Your client will call the server's `whoami` and `search` tools and report your a
 
 <AccordionGroup>
   <Accordion title="The consent screen shows fewer permissions than I expected">
-    That's by design. The permission list is narrowed to what your account is entitled to — for example, internal WaniWani staff permissions never appear for customer accounts. Approve what's shown; it's everything available to you.
+    That's by design. The permission list is narrowed to what your account is entitled to — for example, internal Waniwani staff permissions never appear for customer accounts. Approve what's shown; it's everything available to you.
   </Accordion>
   <Accordion title="Calls suddenly fail with an authentication error">
     Your token expired or was invalidated. Most clients refresh automatically; if yours doesn't, disconnect and reconnect the server (re-running the sign-in) to mint a fresh token.

--- a/docs/mcp-server/how-it-works.mdx
+++ b/docs/mcp-server/how-it-works.mdx
@@ -1,7 +1,7 @@
 ---
 title: How it works
-description: "Four tools, OAuth scopes, org context, and sandboxed execution: what happens between your prompt and the WaniWani API."
-keywords: ["WaniWani MCP tools", "whoami", "set_active_org", "search", "execute", "MCP OAuth scopes", "MCP security", "code mode"]
+description: "Four tools, OAuth scopes, org context, and sandboxed execution: what happens between your prompt and the Waniwani API."
+keywords: ["Waniwani MCP tools", "whoami", "set_active_org", "search", "execute", "MCP OAuth scopes", "MCP security", "code mode"]
 ---
 
 The server is deliberately small: four tools that compose, rather than one tool per API endpoint.
@@ -12,7 +12,7 @@ The server is deliberately small: four tools that compose, rather than one tool 
 |---|---|
 | `whoami` | Returns your identity: user id, granted permissions, the organizations you can act on, and which one is active. |
 | `set_active_org` | Switches your active organization for subsequent calls. Membership is enforced server-side. |
-| `search` | Lists the WaniWani API operations available to `execute`, with full TypeScript signatures — inputs *and* response shapes. Takes an optional keyword filter. |
+| `search` | Lists the Waniwani API operations available to `execute`, with full TypeScript signatures — inputs *and* response shapes. Takes an optional keyword filter. |
 | `execute` | Runs a short piece of JavaScript in an isolated sandbox. The code calls operations as `api.<name>(input)` and returns a value. |
 
 ## The loop
@@ -41,7 +41,7 @@ Operations run against your **active organization**:
 
 - When you first connect, it starts as the organization you last used in the dashboard.
 - `set_active_org` switches it, and the switch is enforced server-side: you can only activate organizations you belong to.
-- The switch applies to **this connection only**. The dashboard and any other connected clients each keep their own active organization, so driving WaniWani from your AI client never silently moves your browser session — or vice versa.
+- The switch applies to **this connection only**. The dashboard and any other connected clients each keep their own active organization, so driving Waniwani from your AI client never silently moves your browser session — or vice versa.
 - It takes effect on your next call: the server invalidates the connection's current token and your client silently refreshes into the new organization.
 
 `whoami` always tells you where you currently stand.
@@ -58,8 +58,8 @@ When you connect, the consent screen itemizes the connection's permissions as OA
 
 Two properties worth knowing:
 
-- **You only see what you're entitled to.** The consent screen narrows the list to your account's role — permissions reserved for WaniWani staff never appear for customer accounts.
-- **Scopes are enforced on every API call, server-side.** The MCP server doesn't get to be generous: each `api.*` operation is re-checked against your token's scopes and your org membership by the WaniWani API itself.
+- **You only see what you're entitled to.** The consent screen narrows the list to your account's role — permissions reserved for Waniwani staff never appear for customer accounts.
+- **Scopes are enforced on every API call, server-side.** The MCP server doesn't get to be generous: each `api.*` operation is re-checked against your token's scopes and your org membership by the Waniwani API itself.
 
 ## Security model
 

--- a/docs/mcp-server/overview.mdx
+++ b/docs/mcp-server/overview.mdx
@@ -1,13 +1,13 @@
 ---
-title: WaniWani MCP server
-description: "Connect Claude, Cursor, or ChatGPT to the WaniWani platform and drive it from a conversation — environments, API keys, analytics digests, session breakdowns."
-keywords: ["WaniWani MCP server", "mcp.waniwani.ai", "remote MCP", "MCP connector", "WaniWani from Claude", "platform MCP"]
+title: Waniwani MCP server
+description: "Connect Claude, Cursor, or ChatGPT to the Waniwani platform and drive it from a conversation — environments, API keys, analytics digests, session breakdowns."
+keywords: ["Waniwani MCP server", "mcp.waniwani.ai", "remote MCP", "MCP connector", "Waniwani from Claude", "platform MCP"]
 ---
 
-The WaniWani MCP server lets your AI client operate the WaniWani platform for you. Connect once to `https://mcp.waniwani.ai/mcp`, sign in with your WaniWani account, and ask for the things you would otherwise click through the dashboard for.
+The Waniwani MCP server lets your AI client operate the Waniwani platform for you. Connect once to `https://mcp.waniwani.ai/mcp`, sign in with your Waniwani account, and ask for the things you would otherwise click through the dashboard for.
 
 <Note>
-This is **WaniWani's own MCP server** — the one that drives *the platform*. It is not the MCP funnel server you build with the SDK. Everywhere else in these docs, "your MCP server" means the one you ship to your users; this tab is about the one we host for you at `mcp.waniwani.ai`.
+This is **Waniwani's own MCP server** — the one that drives *the platform*. It is not the MCP funnel server you build with the SDK. Everywhere else in these docs, "your MCP server" means the one you ship to your users; this tab is about the one we host for you at `mcp.waniwani.ai`.
 </Note>
 
 ## What you can ask it
@@ -27,7 +27,7 @@ This is **WaniWani's own MCP server** — the one that drives *the platform*. It
 | **Analytics & sessions** | Activity summaries over a date range, funnel flow breakdowns, per-session drill-downs, event sources |
 | **Organization** | Check who you're signed in as, switch your active org, invite a teammate |
 
-The surface grows over time, so this table stays deliberately coarse. The server's own `search` tool is the live catalog: once connected, ask *"what WaniWani operations are available?"* and your client will list every operation with its exact signature.
+The surface grows over time, so this table stays deliberately coarse. The server's own `search` tool is the live catalog: once connected, ask *"what Waniwani operations are available?"* and your client will list every operation with its exact signature.
 
 ## How you use it
 
@@ -35,4 +35,4 @@ The surface grows over time, so this table stays deliberately coarse. The server
 2. Ask in plain language. The model discovers the right operations and calls them with your identity — every call is permission-checked server-side.
 3. Results come back into the conversation.
 
-Everything the connection can do is bounded by your own WaniWani account: your organizations, your role, the permissions you approved at sign-in. The mechanics are on [How it works](/mcp-server/how-it-works).
+Everything the connection can do is bounded by your own Waniwani account: your organizations, your role, the permissions you approved at sign-in. The mechanics are on [How it works](/mcp-server/how-it-works).

--- a/docs/platform/overview.mdx
+++ b/docs/platform/overview.mdx
@@ -1,7 +1,7 @@
 ---
-title: WaniWani Platform
+title: Waniwani Platform
 description: "Optional hosted layer that adds tracking, knowledge base, chat widget, and hosted flow state to any MCP server you run."
-keywords: ["WaniWani platform", "hosted tier", "MCP analytics", "MCP dashboard", "hosted state"]
+keywords: ["Waniwani platform", "hosted tier", "MCP analytics", "MCP dashboard", "hosted state"]
 ---
 
 The SDK is open source and runs without an API key. The **Platform** is an optional hosted layer at [app.waniwani.ai](https://app.waniwani.ai) that adds features the engine alone doesn't ship: event tracking, funnel analytics, a knowledge base, a chat widget, and hosted flow state.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -53,7 +53,7 @@ bun run hello.ts
 
 That's a complete MCP server with one flow-driven tool. Connect it to ChatGPT, Claude, or any MCP client over stdio.
 
-State lives in memory and resets on restart. Good for development. For production, swap `MemoryKvStore` for a real backend (see [KV store adapters](/flows/kv-store)) or set `WANIWANI_API_KEY` to use the [WaniWani Platform](/platform/overview) for hosted state.
+State lives in memory and resets on restart. Good for development. For production, swap `MemoryKvStore` for a real backend (see [KV store adapters](/flows/kv-store)) or set `WANIWANI_API_KEY` to use the [Waniwani Platform](/platform/overview) for hosted state.
 
 ## Next
 
@@ -64,7 +64,7 @@ State lives in memory and resets on restart. Good for development. For productio
   <Card title="Flow engine" icon="diagram-project" href="/flows/overview">
     Nodes, edges, interrupts, conditional branching.
   </Card>
-  <Card title="WaniWani Platform" icon="layer-group" href="/platform/overview">
+  <Card title="Waniwani Platform" icon="layer-group" href="/platform/overview">
     What the SDK does without a key, and what unlocks when you connect the Platform.
   </Card>
   <Card title="Self-hosting" icon="server" href="/deployment/self-hosting">

--- a/docs/reference/event-schema.mdx
+++ b/docs/reference/event-schema.mdx
@@ -59,7 +59,7 @@ A closed union exported from `@waniwani/sdk`. Only these names are accepted by `
 
 | Event name | Typed properties | Notes |
 | --- | --- | --- |
-| `session.started` | none | Emitted by the WaniWani backend when it sees a new session id. Do not send it yourself. |
+| `session.started` | none | Emitted by the Waniwani backend when it sees a new session id. Do not send it yourself. |
 | `tool.called` | `ToolCalledProperties` | Emitted automatically by `withWaniwani(server)`. Do not send it yourself. |
 | `quote.requested` | none | Top of a pricing funnel. |
 | `quote.succeeded` | `QuoteSucceededProperties` | A quote was produced. |

--- a/docs/reference/kv-store-api.mdx
+++ b/docs/reference/kv-store-api.mdx
@@ -57,7 +57,7 @@ All fields are optional. With no arguments, the client reads `WANIWANI_API_KEY` 
 </ResponseField>
 
 <ResponseField name="apiUrl" type="string" default="https://app.waniwani.ai">
-  Base URL of the WaniWani API. Override for self-hosted deployments or staging backends.
+  Base URL of the Waniwani API. Override for self-hosted deployments or staging backends.
 </ResponseField>
 
 <ResponseField name="tracking" type="object">

--- a/docs/tracking/overview.mdx
+++ b/docs/tracking/overview.mdx
@@ -1,14 +1,14 @@
 ---
 title: Event Tracking Overview
-description: "Send events from your MCP server to the WaniWani dashboard."
-keywords: ["event tracking", "MCP analytics", "WaniWani dashboard", "tool tracking"]
+description: "Send events from your MCP server to the Waniwani dashboard."
+keywords: ["event tracking", "MCP analytics", "Waniwani dashboard", "tool tracking"]
 ---
 
 <Note>
 **Platform feature.** Requires `WANIWANI_API_KEY`. Works whether your MCP server is self-hosted or on Managed Hosting. [About the Platform](/platform/overview).
 </Note>
 
-The tracking module ships events from your MCP server to the WaniWani backend. You call `client.track()`, the SDK enqueues the event in memory, and a background transport batches and posts it to `POST /api/mcp/events/v2/batch`. Tracking never blocks your tool handler.
+The tracking module ships events from your MCP server to the Waniwani backend. You call `client.track()`, the SDK enqueues the event in memory, and a background transport batches and posts it to `POST /api/mcp/events/v2/batch`. Tracking never blocks your tool handler.
 
 ## Mental model
 

--- a/docs/tracking/sessions.mdx
+++ b/docs/tracking/sessions.mdx
@@ -61,7 +61,7 @@ Wherever you see `extra._meta` in these docs, substitute the equivalent for your
 
 ## The scoped client inside tools and flows
 
-When a server is wrapped with `withWaniwani(server)`, each tool invocation receives a request-scoped WaniWani client on `extra["waniwani/client"]`. The scoped client is also surfaced as `context.waniwani` inside `createTool` handlers and as `waniwani` inside flow nodes. Its `track()` and `identify()` methods merge the current request's `_meta` automatically, so you do not pass it yourself.
+When a server is wrapped with `withWaniwani(server)`, each tool invocation receives a request-scoped Waniwani client on `extra["waniwani/client"]`. The scoped client is also surfaced as `context.waniwani` inside `createTool` handlers and as `waniwani` inside flow nodes. Its `track()` and `identify()` methods merge the current request's `_meta` automatically, so you do not pass it yourself.
 
 ```ts
 import { createTool } from "@waniwani/sdk/mcp";
@@ -120,6 +120,6 @@ await wani.track({
 
 ## Session lifecycle
 
-The WaniWani backend emits `session.started` automatically the first time it sees a new `sessionId`. You do not send it yourself, and `session.started` in the SDK's `EventType` union exists only to type the ingestion envelope.
+The Waniwani backend emits `session.started` automatically the first time it sees a new `sessionId`. You do not send it yourself, and `session.started` in the SDK's `EventType` union exists only to type the ingestion envelope.
 
 Sessions do not have a hard close. The backend treats them as closed after an idle window. If the user comes back, they either resume the same session (within the window) or start a fresh one, depending on what the host client sends in `_meta`.

--- a/docs/waniwani.json
+++ b/docs/waniwani.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://docs.waniwani.ai/waniwani.json",
-  "title": "WaniWani project configuration",
-  "description": "Project-level configuration for WaniWani MCP projects. Consumed by @waniwani/sdk at runtime and by @waniwani/cli for local dev, evals, and knowledge-base tooling.",
+  "title": "Waniwani project configuration",
+  "description": "Project-level configuration for Waniwani MCP projects. Consumed by @waniwani/sdk at runtime and by @waniwani/cli for local dev, evals, and knowledge-base tooling.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -12,16 +12,16 @@
     },
     "orgId": {
       "type": "string",
-      "description": "WaniWani organization ID this project belongs to. Written by `waniwani connect`."
+      "description": "Waniwani organization ID this project belongs to. Written by `waniwani connect`."
     },
     "projectId": {
       "type": "string",
-      "description": "WaniWani MCP project ID. Written by `waniwani connect`."
+      "description": "Waniwani MCP project ID. Written by `waniwani connect`."
     },
     "apiUrl": {
       "type": "string",
       "format": "uri",
-      "description": "Base URL of the WaniWani API. Defaults to https://app.waniwani.ai."
+      "description": "Base URL of the Waniwani API. Defaults to https://app.waniwani.ai."
     },
     "devPort": {
       "type": "integer",

--- a/docs/why-mcp-funnels.mdx
+++ b/docs/why-mcp-funnels.mdx
@@ -50,7 +50,7 @@ The cost is that every funnel ergonomic (interrupt on a missing field, re-ask on
 
 `createFlow` is funnel-shaped by design. A node is a step. An interrupt is a form field. An edge is a transition. A conditional edge is a branching question. Typed state via Zod is your lead data. The graph compiles to one MCP tool. The engine runs it.
 
-See [WaniWani vs LangGraph](/compare/vs-langgraph) for a direct comparison.
+See [Waniwani vs LangGraph](/compare/vs-langgraph) for a direct comparison.
 
 ## Production-validated
 

--- a/package.json
+++ b/package.json
@@ -185,6 +185,6 @@
     "tools",
     "widgets"
   ],
-  "author": "WaniWani",
+  "author": "Waniwani",
   "license": "MIT"
 }

--- a/skills/waniwani-sdk/SKILL.md
+++ b/skills/waniwani-sdk/SKILL.md
@@ -3,10 +3,10 @@ name: waniwani-sdk
 description: "MCP distribution SDK: build sales funnels, lead generation, booking flows, insurance quote flows, pricing quote flows, and any multi-step conversational MCP app with @waniwani/sdk. Open source createFlow engine (no API key required) with pluggable state backends (in-memory, Redis, Upstash, Cloudflare KV, DynamoDB, or hosted). Optional free tier adds a revenue-first event taxonomy (track leads, prices shown/compared, options selected, and conversions — including off-platform purchases), funnel analytics, knowledge base, and a chat widget. Trigger when the user wants to add an MCP funnel, sales funnel, lead gen flow, booking flow, quote flow, knowledge base / FAQ tool, or embedded chat to an MCP server — or to instrument tracking on a @waniwani/sdk app: emit or track events, record a conversion or revenue, attribute an off-platform purchase back to a lead, or measure where users drop off in a funnel."
 license: MIT
 metadata:
-  author: WaniWani
+  author: Waniwani
 ---
 
-# WaniWani SDK (`@waniwani/sdk`)
+# Waniwani SDK (`@waniwani/sdk`)
 
 The MCP distribution SDK. Build sales funnels, lead generation, booking, insurance quote, and pricing quote apps on top of your MCP server. Open-source flow engine, with an optional free tier for hosted state, event tracking, funnel analytics, knowledge base, and a playground. The split:
 

--- a/skills/waniwani-sdk/references/_legacy/chat-server.md
+++ b/skills/waniwani-sdk/references/_legacy/chat-server.md
@@ -46,7 +46,7 @@ Nested under the `chat` key:
 
 ### `beforeRequest` Hook
 
-Called before each request is forwarded to the WaniWani API. Use it to override messages, inject a custom system prompt, or reject requests.
+Called before each request is forwarded to the Waniwani API. Use it to override messages, inject a custom system prompt, or reject requests.
 
 ```typescript
 chat: {
@@ -98,6 +98,6 @@ export const { GET, POST, PATCH, OPTIONS } = toNextJsHandler(wani, {
 ## Common Mistakes
 
 - **Wrong route path** -- Must be a catch-all: `app/api/waniwani/[[...path]]/route.ts`. A non-catch-all route will not handle sub-paths like `/resource`.
-- **Missing `source`** -- The `source` field is required. It identifies this chat instance in the WaniWani dashboard.
+- **Missing `source`** -- The `source` field is required. It identifies this chat instance in the Waniwani dashboard.
 - **Forgetting `maxDuration`** -- Chat responses stream and can take time. Set `export const maxDuration = 60` to avoid Vercel timeouts on longer conversations.
 - **Client created inline** -- Import the shared client from `lib/waniwani.ts` instead of calling `waniwani()` in the route file.

--- a/skills/waniwani-sdk/references/_legacy/tools-and-widgets.md
+++ b/skills/waniwani-sdk/references/_legacy/tools-and-widgets.md
@@ -109,7 +109,7 @@ isMCPApps();      // true if running inside Claude (MCP Apps)
 
 ## `createTrackingRoute(options?)`
 
-Creates a server-side API route that receives batched events from browser widgets (via `useWaniwani`) and forwards them to the WaniWani backend. Returns a web-standard `Request -> Response` handler compatible with Next.js App Router.
+Creates a server-side API route that receives batched events from browser widgets (via `useWaniwani`) and forwards them to the Waniwani backend. Returns a web-standard `Request -> Response` handler compatible with Next.js App Router.
 
 ```typescript
 import { createTrackingRoute } from "@waniwani/sdk/mcp";

--- a/skills/waniwani-sdk/references/_legacy/widget-react-hooks.md
+++ b/skills/waniwani-sdk/references/_legacy/widget-react-hooks.md
@@ -52,7 +52,7 @@ Patches Next.js so the app works correctly inside a cross-origin iframe (ChatGPT
 
 **What it patches:**
 - `history.pushState` / `replaceState` -- prevents cross-origin URL errors in sandboxed iframes
-- `window.fetch` -- rewrites *relative* same-origin requests to the widget's real `baseUrl` so relative `/api/...` calls don't 404. Absolute URLs (string with scheme, `URL`, `Request`) are left alone, so SDK transports can hit the WaniWani API even when it shares an origin with the iframe.
+- `window.fetch` -- rewrites *relative* same-origin requests to the widget's real `baseUrl` so relative `/api/...` calls don't 404. Absolute URLs (string with scheme, `URL`, `Request`) are left alone, so SDK transports can hit the Waniwani API even when it shares an origin with the iframe.
 - `<html>` attribute observer -- strips host-injected attributes while preserving `class`/`style`/`lang`
 
 ```tsx
@@ -131,7 +131,7 @@ export default function PricingWidget() {
 
 ## `useWaniwani` -- Automatic Event Tracking
 
-Auto-captures user interactions from widget UIs and provides manual tracking methods for custom events. Events are sent directly to the WaniWani backend using a JWT token injected by `withWaniwani` on the server side.
+Auto-captures user interactions from widget UIs and provides manual tracking methods for custom events. Events are sent directly to the Waniwani backend using a JWT token injected by `withWaniwani` on the server side.
 
 ```tsx
 import { useWaniwani } from "@waniwani/sdk/mcp/react";

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -1,6 +1,6 @@
 # Chat Widget (`@waniwani/sdk/chat`)
 
-Embed a WaniWani-powered AI chat widget on any page. Two equivalent surfaces:
+Embed a Waniwani-powered AI chat widget on any page. Two equivalent surfaces:
 
 | | Use when |
 |---|---|
@@ -22,7 +22,7 @@ Peer dependencies: `react`, `react-dom`, `@ai-sdk/react`, `ai`. All other depend
 
 ## `<WaniwaniChat>` (React)
 
-Configure the agent (title, welcome message, suggestions, theme, tool behavior) in the WaniWani dashboard. The component fetches that config on mount — you just hand it a token and a channel ID.
+Configure the agent (title, welcome message, suggestions, theme, tool behavior) in the Waniwani dashboard. The component fetches that config on mount — you just hand it a token and a channel ID.
 
 ```tsx
 import { WaniwaniChat } from "@waniwani/sdk/chat";
@@ -164,9 +164,9 @@ Two render modes, chosen with `data-mode`:
 
 ### Prerequisites
 
-1. Generate an embed token in the WaniWani dashboard (Environment → Embed → Generate Token).
+1. Generate an embed token in the Waniwani dashboard (Environment → Embed → Generate Token).
 
-No MCP app changes needed — the embed talks to the WaniWani API directly.
+No MCP app changes needed — the embed talks to the Waniwani API directly.
 
 ### Script tag (declarative)
 
@@ -217,7 +217,7 @@ The chat fits within whatever bound you set and scrolls internally — no need t
 | Attribute | Required | Description |
 |-----------|----------|-------------|
 | `data-api` | No | Chat API URL (defaults to `https://app.waniwani.ai/api/mcp/chat`) |
-| `data-token` | Yes | Embed token (`wwp_...`) from WaniWani dashboard |
+| `data-token` | Yes | Embed token (`wwp_...`) from Waniwani dashboard |
 | `data-channel-id` | No | Agent channel ID — routes the conversation to the right agent |
 | `data-title` | No | Chat header title (default: `"Assistant"`) |
 | `data-welcome-message` | No | Greeting shown before first message |
@@ -310,11 +310,11 @@ Pre-mount, write methods no-op silently and read methods return `undefined` / `[
 
 ### How auth works
 
-The embed sends `Authorization: Bearer wwp_...` on every request directly to the WaniWani API. The token is verified server-side against the `embed_tokens` table. No customer MCP app changes needed — generate tokens in the dashboard, paste the `<script>` tag.
+The embed sends `Authorization: Bearer wwp_...` on every request directly to the Waniwani API. The token is verified server-side against the `embed_tokens` table. No customer MCP app changes needed — generate tokens in the dashboard, paste the `<script>` tag.
 
 ### Remote config
 
-On mount the widget (both React and script) fetches `GET {api}/config` with the embed token and merges the response into its settings. Configure the agent from the WaniWani dashboard (Environment → Embed Chat Config):
+On mount the widget (both React and script) fetches `GET {api}/config` with the embed token and merges the response into its settings. Configure the agent from the Waniwani dashboard (Environment → Embed Chat Config):
 
 | Server-only | Display-only |
 |---|---|
@@ -536,7 +536,7 @@ The event goes to the same canonical ingest every other event uses (`POST /api/m
 
 **Most apps should use `WaniwaniChat` or the `<script>` embed.** `ChatEmbed` is the bare-bones primitive underneath both of them: no token, no remote config, no defaults, no built-in MCP resource endpoint. You wire up `api`, `headers`, `body`, `theme`, and (optionally) `mcp` yourself.
 
-Reach for it when you self-host the chat backend (your own Next.js/Express route, your own provider) and don't want WaniWani's hosted features.
+Reach for it when you self-host the chat backend (your own Next.js/Express route, your own provider) and don't want Waniwani's hosted features.
 
 ```tsx
 import { ChatEmbed } from "@waniwani/sdk/chat";

--- a/skills/waniwani-sdk/references/flows-api-reference.md
+++ b/skills/waniwani-sdk/references/flows-api-reference.md
@@ -134,7 +134,7 @@ The positional form `showWidget(tool, config)` is **deprecated** but still suppo
 
 ## FlowStore Interface
 
-Interface for server-side flow state persistence. Implement this to use a custom store instead of the default WaniWani API store.
+Interface for server-side flow state persistence. Implement this to use a custom store instead of the default Waniwani API store.
 
 ```ts
 import type { FlowStore } from "@waniwani/sdk/mcp";

--- a/skills/waniwani-sdk/references/knowledge-base.md
+++ b/skills/waniwani-sdk/references/knowledge-base.md
@@ -1,6 +1,6 @@
 # Knowledge Base (`@waniwani/sdk/kb`)
 
-The KB client is available as `client.kb` on the WaniWani client. It calls the server-side KB API -- no local embeddings or `ai` dependency needed.
+The KB client is available as `client.kb` on the Waniwani client. It calls the server-side KB API -- no local embeddings or `ai` dependency needed.
 
 ## Setup
 

--- a/skills/waniwani-sdk/scripts/initialize.md
+++ b/skills/waniwani-sdk/scripts/initialize.md
@@ -1,6 +1,6 @@
 # Initialize MCP Distribution
 
-Step-by-step playbook for initializing a new MCP distribution project from the WaniWani template. Gathers context about the user's business, brand, and use case, then scaffolds a production-ready conversational flow with widgets.
+Step-by-step playbook for initializing a new MCP distribution project from the Waniwani template. Gathers context about the user's business, brand, and use case, then scaffolds a production-ready conversational flow with widgets.
 
 ## Step 1: Gather Context (Interactive)
 
@@ -358,7 +358,7 @@ Test the flow:
 2. Trigger the flow by describing the use case naturally
 3. Walk through each step, verify widgets render correctly
 4. Check branding matches the user's website
-5. Verify the WaniWani dashboard receives events at [app.waniwani.ai](https://app.waniwani.ai)
+5. Verify the Waniwani dashboard receives events at [app.waniwani.ai](https://app.waniwani.ai)
 
 ## Step 10: Print Summary
 

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -89,9 +89,9 @@ export interface SuggestionsConfig {
 // ============================================================================
 
 export interface ChatBaseProps {
-	/** WaniWani project API key */
+	/** Waniwani project API key */
 	apiKey?: string;
-	/** Chat API endpoint URL. Defaults to WaniWani hosted endpoint */
+	/** Chat API endpoint URL. Defaults to Waniwani hosted endpoint */
 	api?: string;
 	/** Pre-loaded messages to display when the chat mounts. */
 	initialMessages?: import("ai").UIMessage[];
@@ -162,7 +162,7 @@ export interface ChatBaseProps {
 	/**
 	 * Skip fetching `/config` and `/tools` from the API on mount.
 	 * Use when the chat endpoint doesn't serve these routes (e.g. embed widgets
-	 * talking directly to the WaniWani app).
+	 * talking directly to the Waniwani app).
 	 * @internal
 	 */
 	skipRemoteConfig?: boolean;
@@ -235,7 +235,7 @@ export type CallToolHandler = (params: {
 
 /**
  * **Advanced / bare-bones primitive.** Most apps should use
- * `WaniwaniChat` instead — it wires up the hosted WaniWani backend
+ * `WaniwaniChat` instead — it wires up the hosted Waniwani backend
  * (`app.waniwani.ai`) from a single `wwp_...` token and applies the
  * dashboard's display config automatically.
  *
@@ -246,7 +246,7 @@ export type CallToolHandler = (params: {
  * Reach for it when:
  *
  * - You self-host the chat backend (Next.js/Express route, your own
- *   provider) and don't want WaniWani's hosted features.
+ *   provider) and don't want Waniwani's hosted features.
  * - You need full control over headers, body, and tool-call dispatch.
  *
  * The component fills its parent container (`width: 100%; height: 100%`)

--- a/src/chat/web/ai-elements/tool.tsx
+++ b/src/chat/web/ai-elements/tool.tsx
@@ -503,7 +503,7 @@ function extractAutoHeightFromMeta(
  * Prefers the tool **definition**'s `_meta` (spec-canonical, matches how
  * stateful MCP hosts like Claude and MCP Jam work) and falls back to the
  * tool **result**'s `_meta` (legacy path for servers that echo widget
- * metadata into the result, e.g. WaniWani's own `createTool` or the
+ * metadata into the result, e.g. Waniwani's own `createTool` or the
  * `withWaniwani` compat shim).
  *
  * @param toolName - The tool name, used to look up definition metadata in

--- a/src/chat/web/components/mcp-app-frame.tsx
+++ b/src/chat/web/components/mcp-app-frame.tsx
@@ -273,7 +273,7 @@ export function McpAppFrame({
 					id,
 					result: {
 						protocolVersion: data.params?.protocolVersion ?? PROTOCOL_VERSION,
-						hostInfo: { name: "WaniWani Chat", version: "1.0.0" },
+						hostInfo: { name: "Waniwani Chat", version: "1.0.0" },
 						hostCapabilities: {
 							openLinks: {},
 							message: {

--- a/src/chat/web/components/powered-by.tsx
+++ b/src/chat/web/components/powered-by.tsx
@@ -6,9 +6,9 @@ const LOGO_URL = "https://app.waniwani.ai/assets/waniwani-logo.svg";
 const HREF = "https://waniwani.ai";
 
 /**
- * Small "powered by WaniWani" link rendered under the chat input. Mirrors
+ * Small "powered by Waniwani" link rendered under the chat input. Mirrors
  * the attribution pattern of other embedded chat widgets and links back to
- * the WaniWani site.
+ * the Waniwani site.
  */
 export function PoweredBy() {
 	const { t } = useTranslation();
@@ -22,7 +22,7 @@ export function PoweredBy() {
 			<span>{t.poweredBy.label}</span>
 			<img
 				src={LOGO_URL}
-				alt="WaniWani"
+				alt="Waniwani"
 				width={72}
 				height={10}
 				data-waniwani-logo=""

--- a/src/chat/web/components/widget-error-boundary.tsx
+++ b/src/chat/web/components/widget-error-boundary.tsx
@@ -35,7 +35,7 @@ export class WidgetErrorBoundary extends Component<Props, State> {
 	}
 
 	componentDidCatch(error: Error) {
-		console.warn("[WaniWani] Widget failed to render:", error.message);
+		console.warn("[Waniwani] Widget failed to render:", error.message);
 	}
 
 	render() {

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -51,14 +51,14 @@ export type ShowToolCalls = boolean | "titles-only";
  * placeholder, suggestions) — system prompt and step budget stay server-side.
  */
 export interface EmbedConfig {
-	/** WaniWani chat API URL. Defaults to `https://app.waniwani.ai/api/mcp/chat`. */
+	/** Waniwani chat API URL. Defaults to `https://app.waniwani.ai/api/mcp/chat`. */
 	api?: string;
 	/** Public token (wwp_...) for authentication (required). */
 	token: string;
 	/** Override MCP server URL (optional — resolved from environment by default). */
 	mcpServerUrl?: string;
 	/**
-	 * Agent channel ID. Sent to the chat API so the WaniWani app routes the
+	 * Agent channel ID. Sent to the chat API so the Waniwani app routes the
 	 * conversation to the right agent. Surfaced as `data-channel-id` on the
 	 * embed script tag.
 	 */
@@ -398,8 +398,8 @@ export function resolveConfig(
 
 	if (!merged.token) {
 		throw new Error(
-			"[WaniWani] Missing required config: `token`. " +
-				"Set data-token on the script tag or pass it to WaniWani.chat.init().",
+			"[Waniwani] Missing required config: `token`. " +
+				"Set data-token on the script tag or pass it to Waniwani.chat.init().",
 		);
 	}
 

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -1,5 +1,5 @@
 // ============================================================================
-// WaniWani Chat Embed — IIFE entry point
+// Waniwani Chat Embed — IIFE entry point
 //
 // Drop a <script> tag with `data-token` on any page; the chat mounts inside
 // the first `[data-waniwani-embed]` element on the page, rendered inside a
@@ -209,11 +209,11 @@ function injectStyles(shadowRoot: ShadowRoot, config: EmbedConfig): void {
 				shadowRoot.appendChild(link);
 			} else {
 				console.warn(
-					"[WaniWani] Custom CSS URL must use http or https protocol.",
+					"[Waniwani] Custom CSS URL must use http or https protocol.",
 				);
 			}
 		} catch {
-			console.warn("[WaniWani] Invalid custom CSS URL:", config.css);
+			console.warn("[Waniwani] Invalid custom CSS URL:", config.css);
 		}
 	}
 }
@@ -497,7 +497,7 @@ function mountFloating(
 function init(options?: Partial<EmbedConfig>): EmbedInstance {
 	if (currentInstance) {
 		console.warn(
-			"[WaniWani] Chat widget is already initialized. Call destroy() first to re-initialize.",
+			"[Waniwani] Chat widget is already initialized. Call destroy() first to re-initialize.",
 		);
 		return currentInstance;
 	}
@@ -575,7 +575,7 @@ function autoInit(): void {
 	try {
 		init();
 	} catch (err) {
-		console.error("[WaniWani] Auto-initialization failed:", err);
+		console.error("[Waniwani] Auto-initialization failed:", err);
 	}
 }
 

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -116,7 +116,7 @@ export async function fetchRemoteConfig(
 		if (!res.ok) {
 			return {};
 		}
-		// The WaniWani API wraps payloads in `{ success, message, data }`.
+		// The Waniwani API wraps payloads in `{ success, message, data }`.
 		// Accept either shape so we stay compatible with raw endpoints too.
 		const raw = (await res.json()) as
 			| RemoteConfigResponse
@@ -229,13 +229,13 @@ export function useRemoteEmbedConfig(
 						// `resolveConfig` throws if token is missing. Shouldn't happen
 						// here (initial resolve already validated), but swallow so a
 						// late failure doesn't become an unhandled rejection.
-						console.error("[WaniWani] Failed to apply remote config:", err);
+						console.error("[Waniwani] Failed to apply remote config:", err);
 					}
 				}
 				setReady(true);
 			})
 			.catch((err) => {
-				console.error("[WaniWani] Remote config fetch failed:", err);
+				console.error("[Waniwani] Remote config fetch failed:", err);
 				setReady(true);
 			})
 			.finally(() => clearTimeout(safety));

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -91,7 +91,7 @@ async function fetchToolDefinitions(
 	});
 	if (!response.ok) {
 		throw new Error(
-			`[WaniWani] Failed to fetch /tools: ${response.status} ${response.statusText}`,
+			`[Waniwani] Failed to fetch /tools: ${response.status} ${response.statusText}`,
 		);
 	}
 	const data = (await response.json()) as ToolsListResponse;
@@ -414,7 +414,7 @@ export function useChatEngine(props: ChatBaseProps) {
 			setToolDefinitionsRevision((r) => r + 1);
 		} catch (error) {
 			console.warn(
-				"[WaniWani] Failed to fetch tool definitions:",
+				"[Waniwani] Failed to fetch tool definitions:",
 				error instanceof Error ? error.message : error,
 			);
 		}
@@ -436,7 +436,7 @@ export function useChatEngine(props: ChatBaseProps) {
 			}
 		},
 		onError(error) {
-			console.warn("[WaniWani] Chat error:", error.message);
+			console.warn("[Waniwani] Chat error:", error.message);
 			if (pendingWaitRef.current) {
 				pendingWaitRef.current.reject(error);
 				pendingWaitRef.current = null;

--- a/src/chat/web/i18n/locales/en.ts
+++ b/src/chat/web/i18n/locales/en.ts
@@ -119,7 +119,7 @@ export const en: Messages = {
 		saved: "saved",
 		error: "error",
 		export: "export",
-		tooltip: "Save scenario to WaniWani",
+		tooltip: "Save scenario to Waniwani",
 	},
 	widgetErrorBoundary: {
 		failedToLoad: "Widget failed to load",

--- a/src/chat/web/i18n/locales/es.ts
+++ b/src/chat/web/i18n/locales/es.ts
@@ -52,7 +52,7 @@ export const es: Messages = {
 		saved: "guardado",
 		error: "error",
 		export: "exportar",
-		tooltip: "Guardar escenario en WaniWani",
+		tooltip: "Guardar escenario en Waniwani",
 	},
 	widgetErrorBoundary: {
 		failedToLoad: "No se pudo cargar el widget",

--- a/src/chat/web/i18n/locales/fr.ts
+++ b/src/chat/web/i18n/locales/fr.ts
@@ -52,7 +52,7 @@ export const fr: Messages = {
 		saved: "enregistré",
 		error: "erreur",
 		export: "exporter",
-		tooltip: "Enregistrer le scénario dans WaniWani",
+		tooltip: "Enregistrer le scénario dans Waniwani",
 	},
 	widgetErrorBoundary: {
 		failedToLoad: "Échec du chargement du widget",

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -26,7 +26,7 @@ import { ChatEmbed } from "./chat-embed";
 const READINESS_TIMEOUT_MS = 600;
 
 /**
- * Per-page overrides for `WaniwaniChat`. The WaniWani dashboard is the
+ * Per-page overrides for `WaniwaniChat`. The Waniwani dashboard is the
  * source of truth for the agent's display config; reach for these only
  * when you need a local tweak that doesn't justify cloning an agent.
  *
@@ -97,10 +97,10 @@ export interface WaniwaniChatOverrides {
 }
 
 /**
- * Hosted-tier WaniWani chat. The React counterpart to the `<script>` embed.
+ * Hosted-tier Waniwani chat. The React counterpart to the `<script>` embed.
  *
  * Configure the agent (title, welcome message, suggestions, theme, tool
- * behavior) in the WaniWani dashboard — the component fetches that config
+ * behavior) in the Waniwani dashboard — the component fetches that config
  * on mount. Pass a `wwp_...` token and the `channelId` of the agent, and
  * you're done.
  *
@@ -137,7 +137,7 @@ export interface WaniwaniChatOverrides {
  * ```
  */
 export interface WaniwaniChatProps {
-	/** Public token (`wwp_...`) from the WaniWani dashboard. */
+	/** Public token (`wwp_...`) from the Waniwani dashboard. */
 	token: string;
 	/** Agent channel ID — routes the conversation to the right agent. */
 	channelId?: string;
@@ -231,7 +231,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 					setReady(true);
 				})
 				.catch((err) => {
-					console.error("[WaniWani] Remote config fetch failed:", err);
+					console.error("[Waniwani] Remote config fetch failed:", err);
 					setReady(true);
 				})
 				.finally(() => clearTimeout(safety));

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,4 +1,4 @@
-// WaniWani SDK - Errors
+// Waniwani SDK - Errors
 
 export class WaniWaniError extends Error {
 	constructor(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-// WaniWani SDK
+// Waniwani SDK
 
 // Error
 export { WaniWaniError } from "./error.js";

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,5 +1,5 @@
 // Internal SDK surface, mounted at `@waniwani/sdk/internal`. NOT part of the
-// public API — this entry point exists for the WaniWani platform (the app at
+// public API — this entry point exists for the Waniwani platform (the app at
 // app.waniwani.ai) to reuse SDK primitives that are not appropriate for
 // third-party consumers.
 //

--- a/src/legacy/chat/express-js/@types.ts
+++ b/src/legacy/chat/express-js/@types.ts
@@ -1,4 +1,4 @@
-// WaniWani SDK - Express Adapter Types
+// Waniwani SDK - Express Adapter Types
 
 import type { ChatOptions } from "../server/@types.js";
 
@@ -65,7 +65,7 @@ export interface ExpressLikeResponse {
 export interface ExpressJsHandlerResult {
 	/** GET handler: routes sub-paths (e.g. /resource for MCP widget content) */
 	get: ExpressMiddleware;
-	/** POST handler: proxies chat messages to the WaniWani API */
+	/** POST handler: proxies chat messages to the Waniwani API */
 	post: ExpressMiddleware;
 	/** PATCH handler: routes updates (e.g. /scenarios/:id) */
 	patch: ExpressMiddleware;

--- a/src/legacy/chat/express-js/index.ts
+++ b/src/legacy/chat/express-js/index.ts
@@ -1,4 +1,4 @@
-// WaniWani SDK - Express Adapter
+// Waniwani SDK - Express Adapter
 
 import { Readable } from "node:stream";
 import type { WaniWaniClient } from "../../../types.js";
@@ -20,7 +20,7 @@ export type {
 } from "./@types.js";
 
 /**
- * Create Express middleware from a WaniWani client.
+ * Create Express middleware from a Waniwani client.
  *
  * Returns `{ get, post, patch, options }` — each is an Express-compatible
  * middleware (`(req, res, next) => void`). Mount on a router/path of your choice.

--- a/src/legacy/chat/next-js/@types.ts
+++ b/src/legacy/chat/next-js/@types.ts
@@ -1,4 +1,4 @@
-// WaniWani SDK - Next.js Adapter Types
+// Waniwani SDK - Next.js Adapter Types
 
 import type { ChatOptions } from "../server/@types.js";
 
@@ -33,7 +33,7 @@ export interface NextJsHandlerOptions {
 export interface NextJsHandlerResult {
 	/** GET handler: routes sub-paths (e.g. /resource for MCP widget content) */
 	GET: (request: Request) => Promise<Response>;
-	/** POST handler: proxies chat messages to the WaniWani API */
+	/** POST handler: proxies chat messages to the Waniwani API */
 	POST: (request: Request) => Promise<Response>;
 	/** PATCH handler: routes updates (e.g. /scenarios/:id) */
 	PATCH: (request: Request) => Promise<Response>;

--- a/src/legacy/chat/next-js/index.ts
+++ b/src/legacy/chat/next-js/index.ts
@@ -1,4 +1,4 @@
-// WaniWani SDK - Next.js Adapter
+// Waniwani SDK - Next.js Adapter
 
 import type { WaniWaniClient } from "../../../types.js";
 import { createApiHandler } from "../server/api-handler.js";
@@ -9,12 +9,12 @@ export type { NextJsHandlerOptions, NextJsHandlerResult } from "./@types.js";
 let deprecationWarned = false;
 
 /**
- * Create Next.js route handlers from a WaniWani client.
+ * Create Next.js route handlers from a Waniwani client.
  *
  * Returns `{ GET, POST }` for use with catch-all routes.
  * Mount at `app/api/waniwani/[[...path]]/route.ts`:
  *
- * - `POST /api/waniwani`              → chat (proxied to WaniWani API)
+ * - `POST /api/waniwani`              → chat (proxied to Waniwani API)
  * - `GET  /api/waniwani/resource?uri=…` → MCP resource content
  *
  * @deprecated The chat-server catch-all adapters are being phased out. The chat widget

--- a/src/legacy/chat/server/@types.ts
+++ b/src/legacy/chat/server/@types.ts
@@ -1,4 +1,4 @@
-// WaniWani SDK - Chat Server Types
+// Waniwani SDK - Chat Server Types
 
 import type { UIMessage } from "ai";
 import type { ModelContextUpdate } from "../../../shared/model-context";
@@ -80,7 +80,7 @@ export interface ChatOptions {
 	maxSteps?: number;
 
 	/**
-	 * Hook called before each request is forwarded to the WaniWani API.
+	 * Hook called before each request is forwarded to the Waniwani API.
 	 * - Return void to use defaults.
 	 * - Return an object to override messages, systemPrompt, or sessionId.
 	 * - Throw to reject the request (the error message is returned as JSON).
@@ -117,13 +117,13 @@ export interface ApiHandlerOptions {
 	source?: string;
 
 	/**
-	 * Your WaniWani API key.
+	 * Your Waniwani API key.
 	 * Defaults to process.env.WANIWANI_API_KEY.
 	 */
 	apiKey?: string;
 
 	/**
-	 * The base URL of the WaniWani API.
+	 * The base URL of the Waniwani API.
 	 * Defaults to https://app.waniwani.ai.
 	 */
 	apiUrl?: string;
@@ -140,7 +140,7 @@ export interface ApiHandlerOptions {
 	maxSteps?: number;
 
 	/**
-	 * Hook called before each request is forwarded to the WaniWani API.
+	 * Hook called before each request is forwarded to the Waniwani API.
 	 * - Return void to use defaults.
 	 * - Return an object to override messages, systemPrompt, or sessionId.
 	 * - Throw to reject the request (the error message is returned as JSON).
@@ -176,7 +176,7 @@ export interface ApiHandlerOptions {
 // ============================================================================
 
 export interface ApiHandler {
-	/** Proxies chat messages to the WaniWani API */
+	/** Proxies chat messages to the Waniwani API */
 	handleChat: (request: Request) => Promise<Response>;
 	/** Serves MCP resource content (HTML widgets) */
 	handleResource: (url: URL) => Promise<Response>;

--- a/src/legacy/chat/server/handle-chat.ts
+++ b/src/legacy/chat/server/handle-chat.ts
@@ -1,4 +1,4 @@
-// Handle Chat - Proxies chat requests to the WaniWani API
+// Handle Chat - Proxies chat requests to the Waniwani API
 
 import { WaniWaniError } from "../../../error";
 import { createLogger } from "../../../utils/logger.js";
@@ -109,7 +109,7 @@ export function createChatRequestHandler(deps: ApiHandlerDeps) {
 				modelContext,
 			);
 
-			// 4. Forward to WaniWani API
+			// 4. Forward to Waniwani API
 			const upstreamUrl = `${apiUrl}/api/mcp/chat`;
 			log("forwarding to", upstreamUrl);
 			const clientUserAgent = request.headers.get("user-agent");

--- a/src/legacy/mcp/react/components/initialize-next-in-iframe.tsx
+++ b/src/legacy/mcp/react/components/initialize-next-in-iframe.tsx
@@ -130,7 +130,7 @@ export function applyIframePatches(): void {
 			// Rewrite *relative* same-origin requests to the widget's real
 			// `baseUrl`. Absolute URLs are left alone — they're the
 			// caller's explicit target (e.g. SDK transport posting to the
-			// WaniWani API on the same origin as the iframe).
+			// Waniwani API on the same origin as the iframe).
 			if (isRelativeString && url.origin === window.location.origin) {
 				const newUrl = new URL(baseUrl);
 				newUrl.pathname = url.pathname;

--- a/src/legacy/mcp/react/hooks/unstable-use-send-follow-up.tsx
+++ b/src/legacy/mcp/react/hooks/unstable-use-send-follow-up.tsx
@@ -138,7 +138,7 @@ export interface UnstableSendFollowUpWithGhostGuardResult {
  * on mount — if it sees a record set by a different `mountId` within
  * `ADVANCED_WINDOW_MS`, it collapses the iframe to 0×0.
  *
- * On every other host (WaniWani embed, MCP Apps, etc.) the hook is a
+ * On every other host (Waniwani embed, MCP Apps, etc.) the hook is a
  * pure pass-through: `sendFollowUp` is your function unchanged and
  * `Guard` is a transparent fragment.
  *

--- a/src/legacy/mcp/react/widgets/mcp-apps-client.ts
+++ b/src/legacy/mcp/react/widgets/mcp-apps-client.ts
@@ -32,7 +32,7 @@ export class MCPAppsWidgetClient implements UnifiedWidgetClient {
 
 	constructor() {
 		this.app = new App(
-			{ name: "WaniWani Widget", version: "1.0.0" },
+			{ name: "Waniwani Widget", version: "1.0.0" },
 			{}, // capabilities
 			{ autoResize: false },
 		);

--- a/src/legacy/mcp/react/widgets/openai-client.ts
+++ b/src/legacy/mcp/react/widgets/openai-client.ts
@@ -62,7 +62,7 @@ export class OpenAIWidgetClient implements UnifiedWidgetClient {
 
 	constructor() {
 		this.app = new App(
-			{ name: "WaniWani Widget", version: "1.0.0" },
+			{ name: "Waniwani Widget", version: "1.0.0" },
 			{},
 			{ autoResize: false },
 		);

--- a/src/legacy/mcp/tools/types.ts
+++ b/src/legacy/mcp/tools/types.ts
@@ -16,7 +16,7 @@ export type ToolHandlerContext = {
 	extra?: {
 		_meta?: Record<string, unknown>;
 	};
-	/** Session-scoped WaniWani client — available when the server is wrapped with withWaniwani() */
+	/** Session-scoped Waniwani client — available when the server is wrapped with withWaniwani() */
 	waniwani?: ScopedWaniWaniClient;
 };
 

--- a/src/mcp/react/hooks/use-waniwani.ts
+++ b/src/mcp/react/hooks/use-waniwani.ts
@@ -7,7 +7,7 @@ import type { WidgetEvent } from "./widget-transport";
 import { WidgetTransport } from "./widget-transport";
 
 /**
- * WaniWani widget config injected into tool response `_meta.waniwani`
+ * Waniwani widget config injected into tool response `_meta.waniwani`
  * by `withWaniwani` on the server side.
  */
 interface WaniwaniMeta {
@@ -26,7 +26,7 @@ interface WaniwaniConfig {
 
 interface BaseUseWaniwaniOptions {
 	/**
-	 * JWT widget token for authenticating directly with the WaniWani backend.
+	 * JWT widget token for authenticating directly with the Waniwani backend.
 	 * If omitted, the hook resolves from tool response metadata
 	 * (`toolResponseMetadata.waniwani` or `toolResponseMetadata._meta.waniwani`).
 	 */
@@ -142,7 +142,7 @@ function captureKeyOf(capture?: AutoCaptureToggles): string {
 }
 
 /**
- * Try to extract WaniWani config from the WidgetProvider context.
+ * Try to extract Waniwani config from the WidgetProvider context.
  * Returns the config from `toolResponseMetadata.waniwani` (or nested `_meta`) if available.
  */
 function resolveConfigFromContext(
@@ -311,7 +311,7 @@ function createState(
 }
 
 /**
- * React hook for WaniWani widget tracking.
+ * React hook for Waniwani widget tracking.
  *
  * Auto-captures DOM events (clicks, link clicks, errors, scrolls, form
  * interactions) and provides manual tracking methods. Returns a singleton

--- a/src/mcp/react/hooks/widget-transport.ts
+++ b/src/mcp/react/hooks/widget-transport.ts
@@ -3,7 +3,7 @@
 /**
  * Lightweight client-side transport for widget event tracking.
  *
- * Sends events directly to the WaniWani backend V2 batch endpoint
+ * Sends events directly to the Waniwani backend V2 batch endpoint
  * using a short-lived JWT for authentication.
  * Falls back to `navigator.sendBeacon()` on page teardown.
  */

--- a/src/mcp/server/__tests__/tracking-route.test.ts
+++ b/src/mcp/server/__tests__/tracking-route.test.ts
@@ -83,7 +83,7 @@ describe("createTrackingRoute", () => {
 		expect(body.accepted).toBe(1);
 	});
 
-	it("forwards events to the WaniWani backend", async () => {
+	it("forwards events to the Waniwani backend", async () => {
 		const handler = createTrackingRoute({
 			apiKey: "test-key",
 			apiUrl: "http://localhost:3000",

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -359,7 +359,7 @@ export type NodeContext<TState> = {
 	interrupt: TypedInterrupt<TState>;
 	/** Create a widget signal — pause and show a UI widget */
 	showWidget: TypedShowWidget<TState>;
-	/** Session-scoped WaniWani client — available when the server is wrapped with withWaniwani() */
+	/** Session-scoped Waniwani client — available when the server is wrapped with withWaniwani() */
 	waniwani?: ScopedWaniWaniClient;
 };
 

--- a/src/mcp/server/flows/README.md
+++ b/src/mcp/server/flows/README.md
@@ -12,7 +12,7 @@ You define a state graph, compile it into a tool, and the engine advances it ste
 4. Interrupt nodes pause and ask a question.
 5. Widget nodes pause and delegate rendering to a display tool.
 
-State is stored server-side via the WaniWani API, keyed by the session ID from `_meta`. The model doesn't need to round-trip any token — state is recovered automatically on every call.
+State is stored server-side via the Waniwani API, keyed by the session ID from `_meta`. The model doesn't need to round-trip any token — state is recovered automatically on every call.
 
 ## Contract
 

--- a/src/mcp/server/flows/flow-store.ts
+++ b/src/mcp/server/flows/flow-store.ts
@@ -1,7 +1,7 @@
 /**
  * Server-side flow state store.
  *
- * Flow state is stored via the WaniWani API, keyed by session ID.
+ * Flow state is stored via the Waniwani API, keyed by session ID.
  * Config comes from env vars (WANIWANI_API_KEY, WANIWANI_API_URL).
  */
 
@@ -23,7 +23,7 @@ export interface FlowStore {
 }
 
 // ============================================================================
-// WaniWani API implementation
+// Waniwani API implementation
 // ============================================================================
 
 export class WaniwaniFlowStore implements FlowStore {

--- a/src/mcp/server/flows/redacted.ts
+++ b/src/mcp/server/flows/redacted.ts
@@ -8,7 +8,7 @@ function isRecord(value: unknown): value is UnknownRecord {
 
 /**
  * Mark a Zod schema as PII — its value will be replaced with `"REDACTED"` in
- * any `tool.called` event payload sent to the WaniWani API. The handler still
+ * any `tool.called` event payload sent to the Waniwani API. The handler still
  * receives the original value; only the tracked copy is scrubbed.
  *
  * Apply at the end of the schema chain so the marker is attached to the final

--- a/src/mcp/server/kv/crypto.ts
+++ b/src/mcp/server/kv/crypto.ts
@@ -2,7 +2,7 @@
  * AES-256-GCM encryption for KV store values.
  *
  * When `WANIWANI_ENCRYPTION_KEY` is set, values are encrypted before
- * being sent to the WaniWani API and decrypted on read. The server
+ * being sent to the Waniwani API and decrypted on read. The server
  * never sees plaintext flow state.
  *
  * Key format: base64-encoded 32-byte (256-bit) key.
@@ -54,7 +54,7 @@ async function importKey(keyBase64: string): Promise<CryptoKey> {
 	const raw = Buffer.from(keyBase64, "base64");
 	if (raw.length !== 32) {
 		throw new Error(
-			"[WaniWani KV] WANIWANI_ENCRYPTION_KEY must be a base64-encoded 32-byte (256-bit) key.",
+			"[Waniwani KV] WANIWANI_ENCRYPTION_KEY must be a base64-encoded 32-byte (256-bit) key.",
 		);
 	}
 
@@ -112,7 +112,7 @@ export async function decryptValue<T = Record<string, unknown>>(
 		);
 	} catch {
 		throw new Error(
-			"[WaniWani KV] Decryption failed. The encryption key may be incorrect or the data may be corrupted.",
+			"[Waniwani KV] Decryption failed. The encryption key may be incorrect or the data may be corrupted.",
 		);
 	}
 

--- a/src/mcp/server/kv/kv-store.ts
+++ b/src/mcp/server/kv/kv-store.ts
@@ -1,5 +1,5 @@
 /**
- * Generic key-value store backed by the WaniWani API.
+ * Generic key-value store backed by the Waniwani API.
  *
  * Values are stored as JSON objects (`Record<string, unknown>`) in the
  * `/api/mcp/redis/*` endpoints. Tenant isolation is handled by the API key.
@@ -33,7 +33,7 @@ export interface KvStore<T = Record<string, unknown>> {
 }
 
 // ============================================================================
-// WaniWani API implementation
+// Waniwani API implementation
 // ============================================================================
 
 const SDK_NAME = "@waniwani/sdk";
@@ -62,7 +62,7 @@ export class WaniwaniKvStore<T = Record<string, unknown>>
 	async get(key: string): Promise<T | null> {
 		if (!this.apiKey) {
 			throw new Error(
-				"[WaniWani KV] No API key configured. Set WANIWANI_API_KEY env var.",
+				"[Waniwani KV] No API key configured. Set WANIWANI_API_KEY env var.",
 			);
 		}
 		const data = await this.request<Record<string, unknown> | null>(
@@ -75,7 +75,7 @@ export class WaniwaniKvStore<T = Record<string, unknown>>
 		if (isEncryptedEnvelope(data)) {
 			if (!this.encryptionKey) {
 				throw new Error(
-					"[WaniWani KV] Encrypted data found but WANIWANI_ENCRYPTION_KEY is not set.",
+					"[Waniwani KV] Encrypted data found but WANIWANI_ENCRYPTION_KEY is not set.",
 				);
 			}
 			return decryptValue<T>(data, this.encryptionKey);
@@ -86,7 +86,7 @@ export class WaniwaniKvStore<T = Record<string, unknown>>
 	async set(key: string, value: T, options?: KvStoreSetOptions): Promise<void> {
 		if (!this.apiKey) {
 			throw new Error(
-				"[WaniWani KV] No API key configured. Set WANIWANI_API_KEY env var.",
+				"[Waniwani KV] No API key configured. Set WANIWANI_API_KEY env var.",
 			);
 		}
 		const encKey = this.encryptionKey;
@@ -110,7 +110,7 @@ export class WaniwaniKvStore<T = Record<string, unknown>>
 		try {
 			await this.request("/api/mcp/redis/delete", { key });
 		} catch (error) {
-			console.error("[WaniWani KV] delete failed for key:", key, error);
+			console.error("[Waniwani KV] delete failed for key:", key, error);
 		}
 	}
 

--- a/src/mcp/server/scoped-client.ts
+++ b/src/mcp/server/scoped-client.ts
@@ -14,7 +14,7 @@ import { createRevenueApi } from "../../tracking/revenue.js";
 export const SCOPED_CLIENT_KEY = "waniwani/client";
 
 /**
- * A request-scoped WaniWani client with meta pre-attached.
+ * A request-scoped Waniwani client with meta pre-attached.
  *
  * Available as `context.waniwani` inside `createTool` handlers and flow nodes
  * when the server is wrapped with `withWaniwani()`.

--- a/src/mcp/server/tracking-route.ts
+++ b/src/mcp/server/tracking-route.ts
@@ -2,7 +2,7 @@
  * Server-side API route handler for widget tracking events.
  *
  * Receives batched events from the `useWaniwani` React hook and forwards them
- * to the WaniWani backend using the server-side SDK.
+ * to the Waniwani backend using the server-side SDK.
  *
  * @example Next.js App Router
  * ```typescript
@@ -23,9 +23,9 @@ import type { WaniWaniConfig } from "../../types.js";
 import { waniwani } from "../../waniwani.js";
 
 export interface TrackingRouteOptions {
-	/** API key for the WaniWani backend. Defaults to WANIWANI_API_KEY env var. */
+	/** API key for the Waniwani backend. Defaults to WANIWANI_API_KEY env var. */
 	apiKey?: string;
-	/** Base URL for the WaniWani backend. Defaults to https://app.waniwani.ai. */
+	/** Base URL for the Waniwani backend. Defaults to https://app.waniwani.ai. */
 	apiUrl?: string;
 }
 
@@ -85,7 +85,7 @@ function mapWidgetEvent(ev: WidgetEventPayload): TrackInput {
 
 /**
  * Creates a POST handler that receives tracking events from `useWaniwani`
- * and forwards them to the WaniWani backend.
+ * and forwards them to the Waniwani backend.
  */
 export function createTrackingRoute(options?: TrackingRouteOptions) {
 	const config: WaniWaniConfig = {

--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -92,7 +92,7 @@ export function extractCorrelationId(
 
 /**
  * Number of user messages in the current chat session, as counted by the
- * WaniWani app before dispatching the MCP request. Useful for MCPs that
+ * Waniwani app before dispatching the MCP request. Useful for MCPs that
  * gate behavior on conversation length (e.g. compulsory email verification
  * after N turns) without each MCP having to track turn state itself.
  *

--- a/src/mcp/server/widget-token.ts
+++ b/src/mcp/server/widget-token.ts
@@ -1,5 +1,5 @@
 /**
- * Widget token minting — fetches short-lived JWTs from the WaniWani backend
+ * Widget token minting — fetches short-lived JWTs from the Waniwani backend
  * so browser widgets can POST events directly.
  */
 

--- a/src/mcp/server/with-waniwani/helpers.ts
+++ b/src/mcp/server/with-waniwani/helpers.ts
@@ -286,7 +286,7 @@ export async function injectWidgetConfig(
  *
  * Forwarding these keys into every tool result makes widgets registered via
  * any MCP framework (skybridge, raw `@modelcontextprotocol/sdk`, etc.) render
- * in WaniWani chat without the handler having to set them manually.
+ * in Waniwani chat without the handler having to set them manually.
  *
  * Keys:
  * - `openai/outputTemplate` — OpenAI Apps SDK widget URI (ChatGPT).

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -46,7 +46,7 @@ type MaybeWrappedHandler = RawHandler & { [WRAPPED_HANDLER]?: true };
  */
 export type WithWaniwaniOptions = {
 	/**
-	 * The WaniWani client instance. When omitted, a client is created
+	 * The Waniwani client instance. When omitted, a client is created
 	 * automatically using the global config registered by `defineConfig()`,
 	 * falling back to env vars.
 	 */
@@ -71,7 +71,7 @@ export type WithWaniwaniOptions = {
 	onError?: (error: Error) => void;
 	/**
 	 * Inject widget tracking config into tool response `_meta.waniwani` so browser
-	 * widgets can send events directly to the WaniWani backend.
+	 * widgets can send events directly to the Waniwani backend.
 	 *
 	 * Always injects `endpoint`. Injects `token` when an API key is configured
 	 * and token minting succeeds.
@@ -82,7 +82,7 @@ export type WithWaniwaniOptions = {
 	/**
 	 * List of field names to strip from known location `_meta` entries
 	 * (`openai/userLocation`, `waniwani/geoLocation`, `waniwani/userLocation`)
-	 * before events are sent to the WaniWani API. Applied to both the
+	 * before events are sent to the Waniwani API. Applied to both the
 	 * request-level `_meta` and any `_meta` on the tool response.
 	 *
 	 * Pass e.g. `["latitude", "longitude"]` to drop coordinates only, or
@@ -340,7 +340,7 @@ function createWrappedHandler(
  *
  * When `injectWidgetToken` is enabled (default), tracking config is injected
  * into tool response `_meta.waniwani` so browser widgets can post events
- * directly to the WaniWani backend without a server-side proxy.
+ * directly to the Waniwani backend without a server-side proxy.
  *
  * Widget metadata declared on the tool **definition** (e.g. skybridge's
  * `registerWidget`, raw MCP `_meta["ui/resourceUri"]` / `_meta.ui.resourceUri`,

--- a/src/project-config.ts
+++ b/src/project-config.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 /**
- * Project-level configuration for WaniWani MCP projects.
+ * Project-level configuration for Waniwani MCP projects.
  *
  * Mirrors the JSON Schema hosted at https://docs.waniwani.ai/waniwani.json.
  * The canonical config file is `waniwani.json` at the project root:
@@ -21,12 +21,12 @@ import { resolve } from "node:path";
 export interface WaniWaniProjectConfig {
 	/** URL of the JSON Schema for editor autocomplete. Ignored at runtime. */
 	$schema?: string;
-	/** WaniWani organization ID this project belongs to. */
+	/** Waniwani organization ID this project belongs to. */
 	orgId?: string;
-	/** WaniWani MCP project ID. */
+	/** Waniwani MCP project ID. */
 	projectId?: string;
 	/**
-	 * The base URL of the WaniWani API.
+	 * The base URL of the Waniwani API.
 	 * Defaults to `https://app.waniwani.ai`.
 	 */
 	apiUrl?: string;
@@ -90,7 +90,7 @@ export function resetProjectConfigCache(): void {
 const GLOBAL_KEY = "__waniwani_config__" as const;
 
 /**
- * Register a WaniWani project configuration on `globalThis`.
+ * Register a Waniwani project configuration on `globalThis`.
  *
  * @deprecated Create a `waniwani.json` at the project root instead. The SDK
  *   and CLI both auto-load that file — no `defineConfig` call required.

--- a/src/tracking/transport.ts
+++ b/src/tracking/transport.ts
@@ -135,7 +135,7 @@ class BatchingV2Transport implements V2BatchTransport {
 	enqueue(event: V2EventEnvelope): void {
 		if (this.isStopped || this.isShuttingDown) {
 			this.logger.warn(
-				"[WaniWani] Tracking transport is stopped, dropping event %s",
+				"[Waniwani] Tracking transport is stopped, dropping event %s",
 				event.id,
 			);
 			return;
@@ -145,7 +145,7 @@ class BatchingV2Transport implements V2BatchTransport {
 			const dropCount = this.buffer.length - this.maxBufferSize + 1;
 			this.buffer.splice(0, dropCount);
 			this.logger.warn(
-				"[WaniWani] Tracking buffer overflow, dropped %d oldest event(s)",
+				"[Waniwani] Tracking buffer overflow, dropped %d oldest event(s)",
 				dropCount,
 			);
 		}
@@ -248,7 +248,7 @@ class BatchingV2Transport implements V2BatchTransport {
 					return;
 				case "permanent":
 					this.logger.error(
-						"[WaniWani] Dropping %d event(s) after permanent failure: %s",
+						"[Waniwani] Dropping %d event(s) after permanent failure: %s",
 						pendingBatch.length,
 						result.reason,
 					);
@@ -256,7 +256,7 @@ class BatchingV2Transport implements V2BatchTransport {
 				case "retryable":
 					if (attempt >= this.maxRetries) {
 						this.logger.error(
-							"[WaniWani] Dropping %d event(s) after retry exhaustion: %s",
+							"[Waniwani] Dropping %d event(s) after retry exhaustion: %s",
 							pendingBatch.length,
 							result.reason,
 						);
@@ -268,7 +268,7 @@ class BatchingV2Transport implements V2BatchTransport {
 				case "partial":
 					if (result.permanent.length > 0) {
 						this.logger.error(
-							"[WaniWani] Dropping %d event(s) rejected as permanent",
+							"[Waniwani] Dropping %d event(s) rejected as permanent",
 							result.permanent.length,
 						);
 					}
@@ -277,7 +277,7 @@ class BatchingV2Transport implements V2BatchTransport {
 					}
 					if (attempt >= this.maxRetries) {
 						this.logger.error(
-							"[WaniWani] Dropping %d retryable event(s) after retry exhaustion",
+							"[Waniwani] Dropping %d retryable event(s) after retry exhaustion",
 							result.retryable.length,
 						);
 						return;
@@ -397,7 +397,7 @@ class BatchingV2Transport implements V2BatchTransport {
 		const buffered = this.buffer.length;
 		this.buffer.splice(0, buffered);
 		this.logger.error(
-			"[WaniWani] Auth failure (HTTP %d). Stopping tracking transport and dropping %d queued event(s)",
+			"[Waniwani] Auth failure (HTTP %d). Stopping tracking transport and dropping %d queued event(s)",
 			status,
 			rejectedCount + buffered,
 		);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-// WaniWani SDK - Core Types
+// Waniwani SDK - Core Types
 
 import type { KbClient } from "./kb/types.js";
 import type { TrackingClient, TrackingConfig } from "./tracking/@types.js";
@@ -18,7 +18,7 @@ export interface WaniWaniConfig {
 	 */
 	apiKey?: string;
 	/**
-	 * The base URL of the WaniWani API
+	 * The base URL of the Waniwani API
 	 *
 	 * Defaults to https://app.waniwani.ai
 	 */
@@ -34,7 +34,7 @@ export interface WaniWaniConfig {
 // ============================================================================
 
 /**
- * WaniWani SDK Client
+ * Waniwani SDK Client
  *
  * Extends with each module:
  * - TrackingClient: track(), flush(), shutdown()

--- a/src/waniwani.ts
+++ b/src/waniwani.ts
@@ -1,4 +1,4 @@
-// WaniWani SDK - Main Entry
+// Waniwani SDK - Main Entry
 
 import { createKbClient } from "./kb/client.js";
 import {
@@ -10,11 +10,11 @@ import { createTrackingClient } from "./tracking/index.js";
 import type { WaniWaniClient, WaniWaniConfig } from "./types.js";
 
 /**
- * Create a WaniWani SDK client
+ * Create a Waniwani SDK client
  *
  * @param config - Configuration options. When omitted, reads `waniwani.json`
  *   from the current working directory, then falls back to env vars.
- * @returns A fully typed WaniWani client
+ * @returns A fully typed Waniwani client
  *
  * @example
  * ```typescript

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -154,7 +154,7 @@ export default defineConfig([
 		],
 	},
 	// Internal SDK surface (mounted at @waniwani/sdk/internal — not public).
-	// Used by the WaniWani platform (app.waniwani.ai). Not for third parties.
+	// Used by the Waniwani platform (app.waniwani.ai). Not for third parties.
 	{
 		entry: { "internal/index": "src/internal/index.ts" },
 		format: ["esm"],


### PR DESCRIPTION
Corrects 278 standalone brand mentions across docs, READMEs, skill files, comments, and display strings. Leaves public code identifiers (WaniWaniError, WaniWaniClient, etc.), the window.WaniWani global, the X-WaniWani-* HTTP headers, and github.com/WaniWani URLs untouched to avoid breaking changes.