### PR TITLE
feat(embed): per-URL show/hide visibility for chat surfaces (WAN-517)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "MCP distribution SDK. Build sales funnels, lead generation, booking, and quote apps on top of your MCP server. Event tracking, flows, widgets, knowledge base.",
   "type": "module",
   "exports": {

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -322,6 +322,18 @@ On mount the widget (both React and script) fetches `GET {api}/config` with the 
 
 Merge order (later wins): **defaults < remote config < `data-*` attrs < programmatic options**. The dashboard value is the default; data-attrs / props still override per-page if you need a local tweak.
 
+### Per-URL visibility (advanced)
+
+By default a chat surface shows on every page it's loaded on. For surfaces dropped into a site-wide template (the floating bar, an inline embed, or `<WaniwaniChat>` in a shared layout), you can restrict where they appear with per-channel show/hide rules configured in the dashboard.
+
+The rules match against `window.location.pathname`:
+
+- **Default action** — show everywhere and hide on a few paths, or hide everywhere and allowlist a few.
+- **Patterns** — `*` matches within one path segment (`/docs/*` matches `/docs/intro`, not `/docs/a/b`); `**` matches across segments (`/docs/**` matches everything under `/docs/`). Anything else is matched literally.
+- **Precedence** — when several patterns match, the last one in the list wins.
+
+This applies to **every** chat surface: floating, inline, and React. Rules are evaluated before the chat paints (no flash) and re-checked on client-side route changes, so they work on single-page apps. It's configured per channel in the dashboard — there is no script-tag attribute or prop for it. A channel with no rules shows everywhere.
+
 ## Shared building blocks
 
 ### `WelcomeConfig`

--- a/src/chat/web/embed/__tests__/visibility.test.ts
+++ b/src/chat/web/embed/__tests__/visibility.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+import {
+	globToRegExp,
+	isVisibleForPath,
+	matchGlob,
+	type VisibilityRules,
+} from "../visibility";
+
+describe("globToRegExp / matchGlob", () => {
+	it("matches an exact literal path", () => {
+		expect(matchGlob("/blog", "/blog")).toBe(true);
+		expect(matchGlob("/blog", "/blogs")).toBe(false);
+		expect(matchGlob("/blog", "/blog/post")).toBe(false);
+	});
+
+	it("`*` matches within a single segment only", () => {
+		expect(matchGlob("/docs/*", "/docs/intro")).toBe(true);
+		expect(matchGlob("/docs/*", "/docs/")).toBe(true);
+		expect(matchGlob("/docs/*", "/docs/a/b")).toBe(false);
+		expect(matchGlob("/docs/*", "/docs")).toBe(false);
+	});
+
+	it("`**` matches across segments", () => {
+		expect(matchGlob("/docs/**", "/docs/intro")).toBe(true);
+		expect(matchGlob("/docs/**", "/docs/a/b/c")).toBe(true);
+		expect(matchGlob("/docs/**", "/docs/")).toBe(true);
+		expect(matchGlob("/blog/**", "/docs/x")).toBe(false);
+	});
+
+	it("matches the root and trailing slashes literally", () => {
+		expect(matchGlob("/", "/")).toBe(true);
+		expect(matchGlob("/", "/x")).toBe(false);
+		expect(matchGlob("**", "/any/deep/path")).toBe(true);
+	});
+
+	it("escapes regex metacharacters in the literal portions", () => {
+		expect(matchGlob("/a.b", "/a.b")).toBe(true);
+		// `.` must be literal, not a wildcard.
+		expect(matchGlob("/a.b", "/axb")).toBe(false);
+		expect(matchGlob("/price(usd)", "/price(usd)")).toBe(true);
+	});
+
+	it("anchors the pattern to the whole path", () => {
+		const re = globToRegExp("/docs/*");
+		expect(re.test("/x/docs/intro")).toBe(false);
+	});
+});
+
+describe("isVisibleForPath", () => {
+	it("shows everywhere when rules are null/undefined (back-compat)", () => {
+		expect(isVisibleForPath(null, "/anything")).toBe(true);
+		expect(isVisibleForPath(undefined, "/anything")).toBe(true);
+	});
+
+	it("falls back to `default` when no pattern matches", () => {
+		const showDefault: VisibilityRules = { default: "show", patterns: [] };
+		const hideDefault: VisibilityRules = { default: "hide", patterns: [] };
+		expect(isVisibleForPath(showDefault, "/pricing")).toBe(true);
+		expect(isVisibleForPath(hideDefault, "/pricing")).toBe(false);
+	});
+
+	it("hides matching paths against a show-default", () => {
+		const rules: VisibilityRules = {
+			default: "show",
+			patterns: [{ glob: "/admin/**", action: "hide" }],
+		};
+		expect(isVisibleForPath(rules, "/admin/users")).toBe(false);
+		expect(isVisibleForPath(rules, "/pricing")).toBe(true);
+	});
+
+	it("acts as an allowlist against a hide-default", () => {
+		const rules: VisibilityRules = {
+			default: "hide",
+			patterns: [{ glob: "/docs/**", action: "show" }],
+		};
+		expect(isVisibleForPath(rules, "/docs/intro")).toBe(true);
+		expect(isVisibleForPath(rules, "/pricing")).toBe(false);
+	});
+
+	it("resolves overlapping patterns with last-match-wins", () => {
+		const rules: VisibilityRules = {
+			default: "show",
+			patterns: [
+				{ glob: "/admin/**", action: "hide" },
+				{ glob: "/admin/help", action: "show" },
+			],
+		};
+		expect(isVisibleForPath(rules, "/admin/help")).toBe(true);
+		expect(isVisibleForPath(rules, "/admin/users")).toBe(false);
+
+		// Flipping order flips the result for the overlapping path.
+		const flipped: VisibilityRules = {
+			default: "show",
+			patterns: [
+				{ glob: "/admin/help", action: "show" },
+				{ glob: "/admin/**", action: "hide" },
+			],
+		};
+		expect(isVisibleForPath(flipped, "/admin/help")).toBe(false);
+	});
+
+	it("treats regex-special characters in a glob literally and never throws", () => {
+		const rules: VisibilityRules = {
+			default: "show",
+			patterns: [{ glob: "/[weird](path)", action: "hide" }],
+		};
+		expect(() => isVisibleForPath(rules, "/[weird](path)")).not.toThrow();
+		// Matched literally → hidden.
+		expect(isVisibleForPath(rules, "/[weird](path)")).toBe(false);
+		// A different path is unaffected.
+		expect(isVisibleForPath(rules, "/weird")).toBe(true);
+	});
+});

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -4,6 +4,7 @@
 
 import type { ChatTheme } from "../@types";
 import type { Locale } from "../i18n";
+import type { VisibilityRules } from "./visibility";
 
 /**
  * Built-in theme presets. `auto` follows the host's `prefers-color-scheme`
@@ -137,7 +138,7 @@ export interface EmbedConfig {
 	/**
 	 * Where the floating dock (input bar) and the expanded chat panel anchor
 	 * along the bottom edge. Only applies when `mode` is `"floating"`.
-	 * Defaults to `"bottom-center"` (the rose.ai-style centered dock).
+	 * Defaults to `"bottom-center"` (a centered dock).
 	 * Surfaced as `data-position`.
 	 */
 	position?: "bottom-center" | "bottom-right" | "bottom-left";
@@ -164,6 +165,14 @@ export interface EmbedConfig {
 	 * `data-disable-page-view` on the embed script tag.
 	 */
 	disablePageView?: boolean;
+	/**
+	 * Per-URL show/hide rules for the floating bar. Comes from the remote
+	 * `/config` response (not author-set). When set, the floating dock only
+	 * renders on paths the rules resolve to `"show"`. Unset/`null` means show
+	 * on every page (default behavior). Only applies when `mode` is
+	 * `"floating"`.
+	 */
+	visibility?: VisibilityRules;
 }
 
 /** Fallback height applied to an inline embed container with no author sizing. */

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -18,6 +18,8 @@ import {
 } from "./config";
 import { FloatingChat, type FloatingChatHandle } from "./floating-chat";
 import { InlineChat, type InlineChatHandle } from "./inline-chat";
+import { loadCachedConfig } from "./remote-config";
+import { isVisibleForPath } from "./visibility";
 
 // ---------------------------------------------------------------------------
 // CSS placeholder — replaced at build time with the actual CSS string
@@ -381,6 +383,29 @@ function mountInline(
 
 	const inlineRef = React.createRef<InlineChatHandle>();
 
+	// Collapse the container (which we own, outside React) on gated pages so it
+	// shows no empty card. Pre-hide synchronously from the sessionStorage cache
+	// so repeat visits to a gated page don't flash before the fetch resolves;
+	// `onVisibilityChange` then keeps it in sync (incl. SPA route changes).
+	const toggleContainer = (vis: boolean) => {
+		if (container instanceof HTMLElement) {
+			container.style.display = vis ? "" : "none";
+		}
+	};
+	if (config.token) {
+		const cached = loadCachedConfig(
+			config.api ?? "",
+			config.token,
+			config.channelId,
+		);
+		if (
+			cached?.visibility &&
+			!isVisibleForPath(cached.visibility, window.location.pathname)
+		) {
+			toggleContainer(false);
+		}
+	}
+
 	reactRoot = ReactDOM.createRoot(mountContainer);
 	reactRoot.render(
 		React.createElement(InlineChat, {
@@ -388,6 +413,7 @@ function mountInline(
 			config,
 			programmatic,
 			scriptConfig,
+			onVisibilityChange: toggleContainer,
 		}),
 	);
 

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -1,5 +1,5 @@
 // ============================================================================
-// FloatingChat — the `mode: "floating"` embed surface (rose.ai-style).
+// FloatingChat — the `mode: "floating"` embed surface.
 //
 // On load it shows only a thin **docked input** at the bottom of the screen —
 // not a launcher button. After a short delay it auto-expands to reveal the
@@ -31,6 +31,7 @@ import { cn } from "../lib/utils";
 import { themeToCSSProperties } from "../theme";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
+import { useVisibilityGate } from "./use-pathname";
 
 /** Idle delay before the dock auto-expands to show suggestion CTAs. */
 const AUTO_EXPAND_DELAY_MS = 3500;
@@ -82,6 +83,12 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 			programmatic,
 			scriptConfig,
 		);
+
+		// Per-URL gating — the dock and panel only render on paths the channel's
+		// `visibility` rules resolve to "show". The overlay host stays mounted
+		// but is invisible (pointer-events:none, no background), so a gated page
+		// shows nothing — no empty box, no flash before remote config resolves.
+		const visible = useVisibilityGate(config.visibility, ready);
 
 		const chatRef = useRef<ChatHandle>(null);
 		const composerInputRef = useRef<HTMLInputElement>(null);
@@ -270,124 +277,130 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 				)}
 				style={cssVars}
 			>
-				{/* Docked composer — the only thing visible on load. */}
-				<div
-					data-waniwani-floating="dock"
-					data-state={phase === "open" ? "hidden" : "shown"}
-					className={cn(
-						"ww:fixed ww:bottom-4 ww:z-[2147483002] ww:flex ww:flex-col ww:gap-2",
-						"ww:w-[calc(100vw-2rem)] ww:max-w-[480px]",
-						dockAlign,
-					)}
-				>
-					{suggestions.length > 0 && (
+				{visible && (
+					<>
+						{/* Docked composer — the only thing visible on load. */}
 						<div
+							data-waniwani-floating="dock"
+							data-state={phase === "open" ? "hidden" : "shown"}
 							className={cn(
-								"ww:flex ww:flex-col ww:gap-2 ww:origin-bottom ww:transition-all ww:duration-300 ww:ease-out",
-								phase === "expanded"
-									? "ww:max-h-96 ww:translate-y-0 ww:opacity-100"
-									: "ww:pointer-events-none ww:max-h-0 ww:translate-y-2 ww:overflow-hidden ww:opacity-0",
+								"ww:fixed ww:bottom-4 ww:z-[2147483002] ww:flex ww:flex-col ww:gap-2",
+								"ww:w-[calc(100vw-2rem)] ww:max-w-[480px]",
+								dockAlign,
 							)}
 						>
-							<div className="ww:flex ww:justify-end">
+							{suggestions.length > 0 && (
+								<div
+									className={cn(
+										"ww:flex ww:flex-col ww:gap-2 ww:origin-bottom ww:transition-all ww:duration-300 ww:ease-out",
+										phase === "expanded"
+											? "ww:max-h-96 ww:translate-y-0 ww:opacity-100"
+											: "ww:pointer-events-none ww:max-h-0 ww:translate-y-2 ww:overflow-hidden ww:opacity-0",
+									)}
+								>
+									<div className="ww:flex ww:justify-end">
+										<button
+											type="button"
+											onClick={collapse}
+											aria-label={t.launcher.minimize}
+											className="ww:flex ww:size-7 ww:items-center ww:justify-center ww:rounded-full ww:bg-background/80 ww:text-muted-foreground ww:shadow ww:backdrop-blur ww:transition-colors hover:ww:text-foreground"
+										>
+											<Minus className="ww:size-4" />
+										</button>
+									</div>
+									{suggestions.map((s) => (
+										<button
+											key={s}
+											type="button"
+											onClick={() => openWith(s)}
+											style={{ boxShadow: cardShadow }}
+											className="ww:flex ww:items-center ww:justify-between ww:gap-3 ww:rounded-full ww:bg-background ww:px-5 ww:py-3 ww:text-left ww:text-sm ww:font-medium ww:text-foreground ww:transition-colors hover:ww:bg-accent"
+										>
+											<span className="ww:truncate">{s}</span>
+											<ArrowRight className="ww:size-4 ww:shrink-0 ww:opacity-50" />
+										</button>
+									))}
+								</div>
+							)}
+
+							<div
+								style={{ boxShadow: cardShadow }}
+								className="ww:flex ww:items-center ww:gap-2 ww:rounded-full ww:border ww:border-border ww:bg-background ww:px-4 ww:py-2.5"
+							>
+								<Sparkles className="ww:size-4 ww:shrink-0 ww:text-muted-foreground" />
+								<input
+									ref={composerInputRef}
+									type="text"
+									value={composerText}
+									placeholder={animatedDockPlaceholder}
+									onChange={(e) => setComposerText(e.target.value)}
+									onFocus={onComposerFocus}
+									onKeyDown={(e) => {
+										if (e.key === "Enter" && !e.shiftKey) {
+											e.preventDefault();
+											submitComposer();
+										}
+									}}
+									className="ww:min-w-0 ww:flex-1 ww:bg-transparent ww:text-sm ww:text-foreground ww:outline-none ww:placeholder:text-muted-foreground"
+								/>
 								<button
 									type="button"
-									onClick={collapse}
-									aria-label={t.launcher.minimize}
-									className="ww:flex ww:size-7 ww:items-center ww:justify-center ww:rounded-full ww:bg-background/80 ww:text-muted-foreground ww:shadow ww:backdrop-blur ww:transition-colors hover:ww:text-foreground"
+									onClick={submitComposer}
+									disabled={!composerText.trim()}
+									aria-label={t.promptInput.submit}
+									className="ww:flex ww:size-8 ww:shrink-0 ww:items-center ww:justify-center ww:rounded-full ww:bg-foreground ww:text-background ww:transition-opacity hover:ww:opacity-90 disabled:ww:opacity-40"
 								>
-									<Minus className="ww:size-4" />
+									<ArrowUp className="ww:size-4" />
 								</button>
 							</div>
-							{suggestions.map((s) => (
-								<button
-									key={s}
-									type="button"
-									onClick={() => openWith(s)}
-									style={{ boxShadow: cardShadow }}
-									className="ww:flex ww:items-center ww:justify-between ww:gap-3 ww:rounded-full ww:bg-background ww:px-5 ww:py-3 ww:text-left ww:text-sm ww:font-medium ww:text-foreground ww:transition-colors hover:ww:bg-accent"
-								>
-									<span className="ww:truncate">{s}</span>
-									<ArrowRight className="ww:size-4 ww:shrink-0 ww:opacity-50" />
-								</button>
-							))}
 						</div>
-					)}
 
-					<div
-						style={{ boxShadow: cardShadow }}
-						className="ww:flex ww:items-center ww:gap-2 ww:rounded-full ww:border ww:border-border ww:bg-background ww:px-4 ww:py-2.5"
-					>
-						<Sparkles className="ww:size-4 ww:shrink-0 ww:text-muted-foreground" />
-						<input
-							ref={composerInputRef}
-							type="text"
-							value={composerText}
-							placeholder={animatedDockPlaceholder}
-							onChange={(e) => setComposerText(e.target.value)}
-							onFocus={onComposerFocus}
-							onKeyDown={(e) => {
-								if (e.key === "Enter" && !e.shiftKey) {
-									e.preventDefault();
-									submitComposer();
-								}
-							}}
-							className="ww:min-w-0 ww:flex-1 ww:bg-transparent ww:text-sm ww:text-foreground ww:outline-none ww:placeholder:text-muted-foreground"
-						/>
-						<button
-							type="button"
-							onClick={submitComposer}
-							disabled={!composerText.trim()}
-							aria-label={t.promptInput.submit}
-							className="ww:flex ww:size-8 ww:shrink-0 ww:items-center ww:justify-center ww:rounded-full ww:bg-foreground ww:text-background ww:transition-opacity hover:ww:opacity-90 disabled:ww:opacity-40"
-						>
-							<ArrowUp className="ww:size-4" />
-						</button>
-					</div>
-				</div>
-
-				{/* Full chat panel — slides up from the bottom on first message.
+						{/* Full chat panel — slides up from the bottom on first message.
 				    Same width as the dock so opening is a clean vertical grow. */}
-				<div
-					role="dialog"
-					aria-label={config.title ?? dockPlaceholder}
-					data-waniwani-floating="panel"
-					data-state={phase === "open" ? "shown" : "hidden"}
-					style={{ boxShadow: cardShadow }}
-					className={cn(
-						"ww:fixed ww:z-[2147483002] ww:flex ww:flex-col ww:overflow-hidden ww:bg-background",
-						// Mobile: full-screen sheet.
-						"ww:inset-0 ww:w-full ww:rounded-none",
-						// Desktop: anchored card (matches the dock's 480px width).
-						"ww:sm:inset-auto ww:sm:bottom-4 ww:sm:h-[640px] ww:sm:max-h-[calc(100dvh-2rem)] ww:sm:w-[calc(100vw-2rem)] ww:sm:max-w-[480px] ww:sm:rounded-2xl ww:sm:border ww:sm:border-border",
-						panelAlign,
-					)}
-				>
-					<ChatEmbed
-						ref={chatRef}
-						api={config.api ?? ""}
-						headers={{ Authorization: `Bearer ${config.token}` }}
-						skipRemoteConfig
-						body={Object.keys(body).length > 0 ? body : undefined}
-						appearance={config.appearance}
-						title={config.title}
-						headerActions={closeButton}
-						// Force the header on in floating mode: the minimize control
-						// lives in `headerActions`, so honoring `hideHeader` here would
-						// leave an opened (full-screen on mobile) panel with no in-UI
-						// way back to the dock. The panel is its own chrome anyway.
-						hideHeader={false}
-						welcomeMessage={config.welcomeMessage}
-						placeholder={config.placeholder}
-						suggestions={
-							config.suggestions ? { initial: config.suggestions } : undefined
-						}
-						enableThreadHistory={config.enableThreadHistory}
-						showToolCalls={config.showToolCalls}
-						locale={config.locale}
-						initializing={!ready}
-					/>
-				</div>
+						<div
+							role="dialog"
+							aria-label={config.title ?? dockPlaceholder}
+							data-waniwani-floating="panel"
+							data-state={phase === "open" ? "shown" : "hidden"}
+							style={{ boxShadow: cardShadow }}
+							className={cn(
+								"ww:fixed ww:z-[2147483002] ww:flex ww:flex-col ww:overflow-hidden ww:bg-background",
+								// Mobile: full-screen sheet.
+								"ww:inset-0 ww:w-full ww:rounded-none",
+								// Desktop: anchored card (matches the dock's 480px width).
+								"ww:sm:inset-auto ww:sm:bottom-4 ww:sm:h-[640px] ww:sm:max-h-[calc(100dvh-2rem)] ww:sm:w-[calc(100vw-2rem)] ww:sm:max-w-[480px] ww:sm:rounded-2xl ww:sm:border ww:sm:border-border",
+								panelAlign,
+							)}
+						>
+							<ChatEmbed
+								ref={chatRef}
+								api={config.api ?? ""}
+								headers={{ Authorization: `Bearer ${config.token}` }}
+								skipRemoteConfig
+								body={Object.keys(body).length > 0 ? body : undefined}
+								appearance={config.appearance}
+								title={config.title}
+								headerActions={closeButton}
+								// Force the header on in floating mode: the minimize control
+								// lives in `headerActions`, so honoring `hideHeader` here would
+								// leave an opened (full-screen on mobile) panel with no in-UI
+								// way back to the dock. The panel is its own chrome anyway.
+								hideHeader={false}
+								welcomeMessage={config.welcomeMessage}
+								placeholder={config.placeholder}
+								suggestions={
+									config.suggestions
+										? { initial: config.suggestions }
+										: undefined
+								}
+								enableThreadHistory={config.enableThreadHistory}
+								showToolCalls={config.showToolCalls}
+								locale={config.locale}
+								initializing={!ready}
+							/>
+						</div>
+					</>
+				)}
 			</div>
 		);
 	},

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -11,6 +11,7 @@ import type { ChatHandle } from "../@types";
 import { ChatEmbed } from "../layouts/chat-embed";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
+import { useVisibilityGate } from "./use-pathname";
 
 export interface InlineChatProps {
 	config: EmbedConfig;
@@ -18,6 +19,13 @@ export interface InlineChatProps {
 	/** Pre-parsed `data-*` snapshot. */
 	scriptConfig?: Partial<EmbedConfig>;
 	onReady?: () => void;
+	/**
+	 * Called whenever per-URL `visibility` gating flips. `embed.ts` uses it to
+	 * collapse the `[data-waniwani-embed]` container (which it owns, outside
+	 * React) so a gated page shows no empty card. The chat stays mounted while
+	 * hidden, so conversation state survives an SPA route change away and back.
+	 */
+	onVisibilityChange?: (visible: boolean) => void;
 }
 
 export interface InlineChatHandle {
@@ -26,7 +34,13 @@ export interface InlineChatHandle {
 
 export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 	function InlineChat(
-		{ config: initialConfig, programmatic, scriptConfig, onReady },
+		{
+			config: initialConfig,
+			programmatic,
+			scriptConfig,
+			onReady,
+			onVisibilityChange,
+		},
 		ref,
 	) {
 		const { config, ready } = useRemoteEmbedConfig(
@@ -41,6 +55,14 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 		useEffect(() => {
 			onReady?.();
 		}, []);
+
+		// Per-URL gating. Report the decision up to `embed.ts`, which collapses
+		// the container so a gated page shows no empty card. Re-runs on SPA route
+		// changes (via `usePathname` inside the hook).
+		const visible = useVisibilityGate(config.visibility, ready);
+		useEffect(() => {
+			onVisibilityChange?.(visible);
+		}, [visible, onVisibilityChange]);
 
 		useImperativeHandle(
 			ref,

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import { firePageView } from "../lib/page-view";
 import type { EmbedConfig } from "./config";
 import { resolveConfig } from "./config";
+import type { VisibilityRules } from "./visibility";
 
 // ---------------------------------------------------------------------------
 // Session cache
@@ -95,6 +96,12 @@ interface RemoteConfigResponse {
 	 * `titles-only` → `"titles-only"`.
 	 */
 	toolCallDisplay?: "full" | "titles-only" | "hidden" | null;
+	/**
+	 * Per-URL show/hide rules for the floating bar (WAN-516). Consumed by the
+	 * embed to gate the floating dock per `window.location.pathname`. `null`
+	 * (or absent) means show everywhere.
+	 */
+	visibility?: VisibilityRules | null;
 }
 
 /**
@@ -170,6 +177,9 @@ function remoteToConfigPartial(
 		out.showToolCalls = "titles-only";
 	} else if (data.toolCallDisplay === "hidden") {
 		out.showToolCalls = false;
+	}
+	if (data.visibility) {
+		out.visibility = data.visibility;
 	}
 	return out;
 }

--- a/src/chat/web/embed/use-pathname.ts
+++ b/src/chat/web/embed/use-pathname.ts
@@ -1,0 +1,83 @@
+// ============================================================================
+// usePathname — current `location.pathname`, reactive to SPA navigation.
+//
+// Customer sites with client-side routing change the URL via
+// `history.pushState`/`replaceState` without a full page load, which fire no
+// native event. We patch both (once, globally) to emit a custom event, and
+// also listen to `popstate` (back/forward), so visibility gating re-evaluates
+// on every route change — not just hard navigations.
+// ============================================================================
+
+import { useSyncExternalStore } from "react";
+import { isVisibleForPath, type VisibilityRules } from "./visibility";
+
+const LOCATION_CHANGE = "waniwani:locationchange";
+
+let historyPatched = false;
+
+/**
+ * Patch `pushState`/`replaceState` to dispatch {@link LOCATION_CHANGE} after
+ * the URL updates. Idempotent and left installed for the page's lifetime: it's
+ * harmless, and multiple embed instances (or re-inits) can share it.
+ */
+function ensureHistoryPatched(): void {
+	if (historyPatched || typeof history === "undefined") {
+		return;
+	}
+	historyPatched = true;
+	for (const method of ["pushState", "replaceState"] as const) {
+		const original = history[method];
+		history[method] = function patched(
+			this: History,
+			...args: Parameters<History["pushState"]>
+		) {
+			const result = original.apply(this, args);
+			window.dispatchEvent(new Event(LOCATION_CHANGE));
+			return result;
+		};
+	}
+}
+
+function subscribe(onChange: () => void): () => void {
+	ensureHistoryPatched();
+	window.addEventListener(LOCATION_CHANGE, onChange);
+	window.addEventListener("popstate", onChange);
+	return () => {
+		window.removeEventListener(LOCATION_CHANGE, onChange);
+		window.removeEventListener("popstate", onChange);
+	};
+}
+
+function getSnapshot(): string {
+	return window.location.pathname;
+}
+
+// Server snapshot — the embed never renders the dock during SSR, but the hook
+// must be SSR-safe (no `window`). `/` is an inert placeholder.
+function getServerSnapshot(): string {
+	return "/";
+}
+
+/** Current `location.pathname`, re-rendering on client-side route changes. */
+export function usePathname(): string {
+	return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+/**
+ * Whether a chat surface should render on the current URL, given its channel's
+ * `visibility` rules. Shared by every hosted surface (floating, inline,
+ * `<WaniwaniChat>`) so per-URL gating behaves identically across them.
+ *
+ * Gating on `ready` is the no-flash guarantee: the surface is held back until
+ * the remote config resolves (or the safety timer fires). On repeat visits the
+ * `sessionStorage` config cache flips `ready` before the browser paints, so a
+ * hidden page never shows the chat. Re-evaluates on SPA route changes via
+ * {@link usePathname}.
+ */
+export function useVisibilityGate(
+	rules: VisibilityRules | null | undefined,
+	ready: boolean,
+): boolean {
+	const pathname = usePathname();
+	return ready && isVisibleForPath(rules, pathname);
+}

--- a/src/chat/web/embed/visibility.ts
+++ b/src/chat/web/embed/visibility.ts
@@ -1,0 +1,80 @@
+// ============================================================================
+// Per-URL visibility matching for the floating embed.
+//
+// Consumes the per-channel `visibility` rules from the remote `/config`
+// response and decides whether the floating dock should render on the current
+// `window.location.pathname`.
+//
+// Dependency-free on purpose: the embed ships as a single IIFE and bundle size
+// matters, so we don't pull in `picomatch`/`minimatch`. The glob dialect is
+// intentionally tiny — see `globToRegExp`.
+// ============================================================================
+
+/**
+ * Per-channel visibility rules. Mirrors the app-side `visibility` JSONB shape
+ * (WAN-516). Semantics: show on all pages by default, override per-URL.
+ */
+export interface VisibilityRules {
+	/** Action when no pattern matches the current path. */
+	default: "show" | "hide";
+	/** Glob patterns evaluated against `window.location.pathname`, in order. */
+	patterns: { glob: string; action: "show" | "hide" }[];
+}
+
+// Sentinel that survives the single-`*` pass so we can translate `**` first
+// without it being re-touched. Chosen to never collide with a real path.
+const DOUBLE_STAR = "\0\0";
+
+/**
+ * Translate a path glob into an anchored RegExp.
+ *
+ * - `**` matches across segments (including `/`).
+ * - `*` matches within a single segment (no `/`).
+ * - Everything else is matched literally (regex metacharacters escaped).
+ */
+export function globToRegExp(glob: string): RegExp {
+	// Escape regex metachars first (this also escapes `*`, which we undo next).
+	const escaped = glob.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const translated = escaped
+		// `\*\*` (escaped `**`) → cross-segment wildcard, via a placeholder.
+		.replace(/\\\*\\\*/g, DOUBLE_STAR)
+		// remaining `\*` (escaped single `*`) → within-segment wildcard.
+		.replace(/\\\*/g, "[^/]*")
+		.split(DOUBLE_STAR)
+		.join(".*");
+	return new RegExp(`^${translated}$`);
+}
+
+/** Whether `glob` matches `pathname`. A malformed glob never matches. */
+export function matchGlob(glob: string, pathname: string): boolean {
+	try {
+		return globToRegExp(glob).test(pathname);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Resolve whether the floating bar should be visible on `pathname`.
+ *
+ * - `null`/`undefined` rules → `true` (show everywhere). Keeps a new embed
+ *   safe against servers that don't send the field yet, and an old embed safe
+ *   against a server that does.
+ * - Otherwise the **last** matching pattern (in list order) wins; if none
+ *   match, `rules.default` decides.
+ */
+export function isVisibleForPath(
+	rules: VisibilityRules | null | undefined,
+	pathname: string,
+): boolean {
+	if (!rules) {
+		return true;
+	}
+	let action: "show" | "hide" = rules.default ?? "show";
+	for (const pattern of rules.patterns ?? []) {
+		if (matchGlob(pattern.glob, pathname)) {
+			action = pattern.action;
+		}
+	}
+	return action !== "hide";
+}

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -14,6 +14,7 @@ import {
 	loadCachedConfig,
 	saveCachedConfig,
 } from "../embed/remote-config";
+import { useVisibilityGate } from "../embed/use-pathname";
 import type { Locale, MessageOverrides } from "../i18n";
 import { firePageView } from "../lib/page-view";
 import { ChatEmbed } from "./chat-embed";
@@ -265,12 +266,22 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 			[programmatic, remote],
 		);
 
+		// Per-URL gating. When the channel's `visibility` rules hide this path,
+		// render nothing (no leftover box) — correct for a `<WaniwaniChat>` placed
+		// in a shared layout. Held until `ready` so a hidden page never flashes;
+		// re-evaluates on SPA route changes.
+		const visible = useVisibilityGate(config.visibility, ready);
+
 		const body: Record<string, unknown> = {};
 		if (config.mcpServerUrl) {
 			body.mcpServerUrl = config.mcpServerUrl;
 		}
 		if (config.channelId) {
 			body.channelId = config.channelId;
+		}
+
+		if (!visible) {
+			return null;
 		}
 
 		return (


### PR DESCRIPTION
## WAN-517 — Per-URL show/hide matching in embed SDK

Closes WAN-517 · https://linear.app/waniwani/issue/WAN-517

SDK counterpart to WAN-516 (app: schema, config endpoint, dashboard). Consumes the per-channel `visibility` rules from `GET /api/mcp/chat/config` and gates the chat surfaces on the current URL.

### What's included
- **Matcher** ([visibility.ts](src/chat/web/embed/visibility.ts)) — dependency-free glob matcher. `*` matches within one path segment, `**` across segments, everything else literal. Last-match-wins precedence, falls back to `default`. Null/undefined rules show everywhere (back-compat with servers that don't send the field).
- **SPA support** ([use-pathname.ts](src/chat/web/embed/use-pathname.ts)) — `usePathname` patches `pushState`/`replaceState` + listens to `popstate`; `useVisibilityGate` re-evaluates on client-side route changes.
- **Gating on every surface** — floating ([floating-chat.tsx](src/chat/web/embed/floating-chat.tsx)), inline ([inline-chat.tsx](src/chat/web/embed/inline-chat.tsx)), and React ([waniwani-chat.tsx](src/chat/web/layouts/waniwani-chat.tsx)).
- **No flash** — gate held on `ready`; the `sessionStorage` config cache makes repeat visits instant, including a synchronous container pre-hide in [embed.ts](src/chat/web/embed/embed.ts) so a gated page never shows an empty card. Inline keeps the chat mounted while hidden so conversation state survives route changes.
- **Tests** — [visibility.test.ts](src/chat/web/embed/__tests__/visibility.test.ts) covers glob semantics, precedence, defaults, and back-compat.
- **Docs** — "Per-URL visibility (advanced)" section in the chat-widget reference.
- Version bump 0.14.6 → 0.14.7.

### Design calls (locked, shared with WAN-516)
- Glob syntax: `*` (single segment) / `**` (across segments).
- Precedence: last match wins.

### Release note
`npm publish` pending. Existing embeds on jsDelivr `@latest` won't pick up the new gating until the CDN cache propagates; pinned-version embeds are unaffected until customers bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)