### PR TITLE
ci: purge jsDelivr @latest cache after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,16 @@ jobs:
         if: steps.check.outputs.published == 'false'
         run: npm publish --access public --tag ${{ steps.channel.outputs.npm_tag }} --provenance --ignore-scripts
 
+      - name: Purge jsDelivr @latest cache
+        if: steps.check.outputs.published == 'false' && steps.channel.outputs.npm_tag == 'latest'
+        run: |
+          for path in \
+            "@waniwani/sdk@latest/dist/chat/embed.js" \
+            "@waniwani/sdk@latest/dist/chat/styles.css"; do
+            echo "Purging $path"
+            curl -sf "https://purge.jsdelivr.net/npm/$path" || echo "::warning::purge failed for $path"
+          done
+
       - name: Create GitHub Release
         if: steps.check.outputs.published == 'false'
         run: |

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check . --write",
     "prepublishOnly": "bun run build",
+    "purge:cdn": "curl -sf https://purge.jsdelivr.net/npm/@waniwani/sdk@latest/dist/chat/embed.js && curl -sf https://purge.jsdelivr.net/npm/@waniwani/sdk@latest/dist/chat/styles.css",
     "release": "npm run release:patch",
     "release:patch": "npm version patch && git push --follow-tags",
     "release:minor": "npm version minor && git push --follow-tags",


### PR DESCRIPTION
@latest CDN URLs carry a 7-day s-maxage, so they served a stale build after publish. Add a purge step that runs after every latest publish, plus a purge:cdn script for manual runs.