### PR TITLE
feat(chat): appear-after scroll trigger for the floating bar

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -333,6 +333,20 @@ The rules match against `window.location.pathname`:
 
 This applies to **every** chat surface: floating, inline, and React. Rules are evaluated before the chat paints (no flash) and re-checked on client-side route changes, so they work on single-page apps. It's configured per channel in the dashboard — there is no script-tag attribute or prop for it. A channel with no rules shows everywhere.
 
+### Appear after scrolling (floating only, advanced)
+
+On pages where the floating bar shows, you can hold it back until the visitor scrolls past a specific element instead of using the fixed `data-appear-delay` timer — handy when the bar would otherwise overlap an above-the-fold hero.
+
+Configured per channel in the dashboard as **appear-after** rules, alongside the visibility rules. Each rule is a URL pattern (same glob dialect as visibility) plus a **CSS selector** on your page:
+
+- On a matching path, the bar stays hidden until that element is scrolled above the top of the viewport, then slides in.
+- It's **reactive** — scroll back up and the bar hides again, so it never re-collides with the element.
+- Paths with no matching rule keep the default `data-appear-delay` behavior.
+- These rules are independent of show/hide: adding one never changes *whether* the bar appears on a page, only *when*. A hidden page stays hidden.
+- If the selector matches nothing on the page, the bar fails open (shows) rather than staying hidden.
+
+Example: on `/`, hold the bar until the visitor scrolls past `#hero`. Everywhere else, the timer applies as usual.
+
 ## Shared building blocks
 
 ### `WelcomeConfig`

--- a/src/chat/web/embed/__tests__/use-scroll-appearance.test.ts
+++ b/src/chat/web/embed/__tests__/use-scroll-appearance.test.ts
@@ -1,0 +1,176 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+
+// ---------------------------------------------------------------------------
+// DOM setup before importing React (mirrors use-chat-engine.test.tsx)
+// ---------------------------------------------------------------------------
+
+const win = new Window({ url: "https://localhost" });
+for (const key of [
+	"document",
+	"navigator",
+	"HTMLElement",
+	"HTMLDivElement",
+	"Element",
+	"Node",
+	"Text",
+	"Comment",
+	"DocumentFragment",
+	"Event",
+	"CustomEvent",
+	"requestAnimationFrame",
+	"cancelAnimationFrame",
+	"getComputedStyle",
+] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any)[key] = (win as any)[key];
+}
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).window = win;
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Controllable IntersectionObserver + querySelector
+// ---------------------------------------------------------------------------
+
+type IOEntry = {
+	isIntersecting: boolean;
+	boundingClientRect: { bottom: number };
+};
+let ioCallback: ((entries: IOEntry[]) => void) | null = null;
+let observedCount = 0;
+
+class MockIntersectionObserver {
+	constructor(cb: (entries: IOEntry[]) => void) {
+		ioCallback = cb;
+	}
+	observe() {
+		observedCount += 1;
+	}
+	disconnect() {}
+	unobserve() {}
+	takeRecords() {
+		return [];
+	}
+}
+// Capture originals so we can restore them and not leak into other test files
+// (bun runs the suite in one shared process).
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+const originalIO = (globalThis as any).IntersectionObserver;
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+const originalQuerySelector = (globalThis as any).document.querySelector;
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).IntersectionObserver = MockIntersectionObserver;
+
+// Swap in a controllable querySelector so tests decide "found" / "missing" /
+// "invalid selector" without depending on happy-dom's CSS engine.
+let querySelectorImpl: (selector: string) => Element | null = () =>
+	({}) as Element;
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).document.querySelector = (selector: string) =>
+	querySelectorImpl(selector);
+
+afterAll(() => {
+	// biome-ignore lint/suspicious/noExplicitAny: test teardown
+	(globalThis as any).IntersectionObserver = originalIO;
+	// biome-ignore lint/suspicious/noExplicitAny: test teardown
+	(globalThis as any).document.querySelector = originalQuerySelector;
+});
+
+const { act, createElement } = await import("react");
+const { createRoot } = await import("react-dom/client");
+const { useScrollAppearance } = await import("../use-scroll-appearance");
+
+// Render harness: mount a probe that surfaces the hook's return value.
+async function mount(selector: string | null) {
+	const container = win.document.createElement("div");
+	let latest = false;
+	function Probe() {
+		latest = useScrollAppearance(selector);
+		return null;
+	}
+	// biome-ignore lint/suspicious/noExplicitAny: happy-dom Element vs DOM Element
+	const root = createRoot(container as any);
+	await act(async () => {
+		root.render(createElement(Probe));
+	});
+	return {
+		get value() {
+			return latest;
+		},
+		async fire(entry: IOEntry) {
+			await act(async () => {
+				ioCallback?.([entry]);
+			});
+		},
+		unmount() {
+			act(() => root.unmount());
+		},
+	};
+}
+
+beforeEach(() => {
+	ioCallback = null;
+	observedCount = 0;
+	querySelectorImpl = () => ({}) as Element;
+});
+
+describe("useScrollAppearance", () => {
+	test("returns false and observes nothing when selector is null", async () => {
+		const h = await mount(null);
+		expect(h.value).toBe(false);
+		expect(observedCount).toBe(0);
+		h.unmount();
+	});
+
+	test("stays hidden while the target element is in view", async () => {
+		const h = await mount("#hero");
+		expect(observedCount).toBe(1);
+		await h.fire({ isIntersecting: true, boundingClientRect: { bottom: 400 } });
+		expect(h.value).toBe(false);
+		h.unmount();
+	});
+
+	test("reveals once the element is scrolled above the viewport", async () => {
+		const h = await mount("#hero");
+		await h.fire({
+			isIntersecting: false,
+			boundingClientRect: { bottom: -20 },
+		});
+		expect(h.value).toBe(true);
+		h.unmount();
+	});
+
+	test("stays hidden while the element is still below the fold", async () => {
+		const h = await mount("#hero");
+		await h.fire({
+			isIntersecting: false,
+			boundingClientRect: { bottom: 900 },
+		});
+		expect(h.value).toBe(false);
+		h.unmount();
+	});
+
+	test("hides again reactively when scrolled back up into view", async () => {
+		const h = await mount("#hero");
+		await h.fire({
+			isIntersecting: false,
+			boundingClientRect: { bottom: -20 },
+		});
+		expect(h.value).toBe(true);
+		await h.fire({ isIntersecting: true, boundingClientRect: { bottom: 300 } });
+		expect(h.value).toBe(false);
+		h.unmount();
+	});
+
+	test("fails open (shows) on an invalid selector", async () => {
+		querySelectorImpl = () => {
+			throw new SyntaxError("bad selector");
+		};
+		const h = await mount("#(*&bad");
+		expect(h.value).toBe(true);
+		expect(observedCount).toBe(0);
+		h.unmount();
+	});
+});

--- a/src/chat/web/embed/__tests__/visibility.test.ts
+++ b/src/chat/web/embed/__tests__/visibility.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	appearTriggerForPath,
 	globToRegExp,
 	isVisibleForPath,
 	matchGlob,
@@ -147,5 +148,55 @@ describe("isVisibleForPath", () => {
 		expect(isVisibleForPath(rules, "/[weird](path)")).toBe(false);
 		// A different path is unaffected.
 		expect(isVisibleForPath(rules, "/weird")).toBe(true);
+	});
+});
+
+describe("appearTriggerForPath", () => {
+	it("returns null when there are no appear rules", () => {
+		expect(appearTriggerForPath(null, "/")).toBeNull();
+		expect(appearTriggerForPath(undefined, "/")).toBeNull();
+		const rules: VisibilityRules = { default: "show", rules: [] };
+		expect(appearTriggerForPath(rules, "/")).toBeNull();
+	});
+
+	it("returns the selector of the first matching rule", () => {
+		const rules: VisibilityRules = {
+			default: "show",
+			appearRules: [
+				{ glob: "/", appearAfter: "#hero" },
+				{ glob: "/pricing", appearAfter: "#pricing-table" },
+			],
+		};
+		expect(appearTriggerForPath(rules, "/")).toBe("#hero");
+		expect(appearTriggerForPath(rules, "/pricing")).toBe("#pricing-table");
+	});
+
+	it("returns null on a path no appear rule matches (falls back to the timer)", () => {
+		const rules: VisibilityRules = {
+			default: "show",
+			appearRules: [{ glob: "/", appearAfter: "#hero" }],
+		};
+		expect(appearTriggerForPath(rules, "/about")).toBeNull();
+	});
+
+	it("resolves overlapping rules by order (first match wins)", () => {
+		const rules: VisibilityRules = {
+			default: "show",
+			appearRules: [
+				{ glob: "/docs/**", appearAfter: "#docs-hero" },
+				{ glob: "/docs/api", appearAfter: "#api-hero" },
+			],
+		};
+		// `/docs/api` matches both; the earlier rule wins.
+		expect(appearTriggerForPath(rules, "/docs/api")).toBe("#docs-hero");
+	});
+
+	it("supports glob wildcards the same way visibility does", () => {
+		const rules: VisibilityRules = {
+			default: "show",
+			appearRules: [{ glob: "/blog/*", appearAfter: ".post-header" }],
+		};
+		expect(appearTriggerForPath(rules, "/blog/hello")).toBe(".post-header");
+		expect(appearTriggerForPath(rules, "/blog/a/b")).toBeNull();
 	});
 });

--- a/src/chat/web/embed/floating-chat.stories.tsx
+++ b/src/chat/web/embed/floating-chat.stories.tsx
@@ -144,6 +144,81 @@ function FakePage({ dark }: { dark: boolean }) {
 	);
 }
 
+// A host page with a full-height hero up top, then long scrollable content.
+// The floating bar is configured to appear only after `#ww-hero` scrolls above
+// the viewport — mimicking a site whose hero already has its own floating card.
+function HeroPage({ dark }: { dark: boolean }) {
+	const border = dark ? "#1f2530" : "#e5e7eb";
+	const sections = Array.from({ length: 6 }, (_, i) => i);
+	return (
+		<div
+			style={{
+				background: dark ? "#0f1115" : "#f7f7f8",
+				color: dark ? "#e5e7eb" : "#1f2937",
+				fontFamily: "system-ui, sans-serif",
+			}}
+		>
+			{/* While any part of this hero is on screen the bar stays hidden. */}
+			<section
+				id="ww-hero"
+				style={{
+					minHeight: "92vh",
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					justifyContent: "center",
+					textAlign: "center",
+					padding: "48px 24px",
+					borderBottom: `1px solid ${border}`,
+				}}
+			>
+				<span
+					style={{
+						fontSize: 13,
+						textTransform: "uppercase",
+						letterSpacing: 1,
+						opacity: 0.6,
+					}}
+				>
+					#ww-hero
+				</span>
+				<h1 style={{ fontSize: 40, fontWeight: 800, marginTop: 12 }}>
+					Hero section
+				</h1>
+				<p
+					style={{
+						maxWidth: 520,
+						marginTop: 12,
+						lineHeight: 1.6,
+						opacity: 0.8,
+					}}
+				>
+					The floating bar is held back while this hero is in view — imagine a
+					floating card living here. Scroll down past it and the bar slides in;
+					scroll back up and it hides again (reactive).
+				</p>
+				<p style={{ marginTop: 24, fontSize: 13, opacity: 0.6 }}>
+					↓ scroll down
+				</p>
+			</section>
+
+			<div
+				style={{ maxWidth: 640, margin: "0 auto", padding: "48px 24px 200px" }}
+			>
+				{sections.map((i) => (
+					<section key={i} style={{ marginTop: i === 0 ? 0 : 40 }}>
+						<h2 style={{ fontSize: 22, fontWeight: 700 }}>Section {i + 1}</h2>
+						<p style={{ marginTop: 10, lineHeight: 1.7, opacity: 0.85 }}>
+							Body content below the hero. The bar is visible here because
+							`#ww-hero` has scrolled above the top of the viewport.
+						</p>
+					</section>
+				))}
+			</div>
+		</div>
+	);
+}
+
 const meta: Meta<FloatingArgs> = {
 	title: "Chat/FloatingChat",
 	// Each story re-creates the component from args; this render is shared.
@@ -201,6 +276,31 @@ export const DarkTheme: Story = {
 /** No suggestions — clicking the bar just widens it; the chat opens on send. */
 export const NoSuggestions: Story = {
 	args: { suggestions: [] },
+};
+
+/**
+ * Appear-after-a-section: the bar is hidden while the `#ww-hero` section is in
+ * view and slides in only once you scroll past it (reactive — it hides again on
+ * the way back up). Configured via the channel's `visibility.appearRules`
+ * (`glob: "**"` matches Storybook's iframe path). The `appearDelay` timer is
+ * ignored while a scroll rule applies. Scroll the preview to try it.
+ */
+export const AppearAfterSection: Story = {
+	args: { appearDelay: 0 },
+	render: (args) => (
+		<>
+			<HeroPage dark={args.theme === "dark"} />
+			<FloatingChat
+				config={{
+					...buildConfig(args),
+					visibility: {
+						default: "show",
+						appearRules: [{ glob: "**", appearAfter: "#ww-hero" }],
+					},
+				}}
+			/>
+		</>
+	),
 };
 
 /**

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -35,7 +35,9 @@ import { cn } from "../lib/utils";
 import { themeToCSSProperties } from "../theme";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
-import { useVisibilityGate } from "./use-pathname";
+import { usePathname, useVisibilityGate } from "./use-pathname";
+import { useScrollAppearance } from "./use-scroll-appearance";
+import { appearTriggerForPath } from "./visibility";
 
 /** Default delay before the docked input animates into view on load. */
 const DEFAULT_APPEAR_DELAY_MS = 2000;
@@ -97,6 +99,16 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 		// shows nothing — no empty box, no flash before remote config resolves.
 		const visible = useVisibilityGate(config.visibility, ready);
 
+		// Per-URL "appear after" trigger. On paths with a matching rule the dock
+		// holds back until the visitor scrolls past the configured element,
+		// replacing the timer below; `null` (no rule / hidden page) keeps the
+		// timer. Resolved from the same `visibility` config as the gate.
+		const pathname = usePathname();
+		const appearAfter = visible
+			? appearTriggerForPath(config.visibility, pathname)
+			: null;
+		const scrolledPast = useScrollAppearance(appearAfter);
+
 		const chatRef = useRef<ChatHandle>(null);
 		const composerInputRef = useRef<HTMLInputElement>(null);
 		const dockRef = useRef<HTMLDivElement>(null);
@@ -145,15 +157,23 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 		// visitor navigates (SPA route change) to a page that shows the dock, the
 		// delay runs again and the bar slides in — rather than popping in already
 		// "appeared" from an earlier page.
+		//
+		// When an "appear after" rule matches this path, the scroll trigger owns
+		// `appeared` instead of the timer: the bar tracks `scrolledPast`
+		// reactively (revealed once past the element, hidden again on scroll up).
 		useEffect(() => {
 			if (!visible) {
 				setAppeared(false);
 				return;
 			}
+			if (appearAfter) {
+				setAppeared(scrolledPast);
+				return;
+			}
 			const delay = config.appearDelay ?? DEFAULT_APPEAR_DELAY_MS;
 			const id = setTimeout(() => setAppeared(true), Math.max(0, delay));
 			return () => clearTimeout(id);
-		}, [visible, config.appearDelay]);
+		}, [visible, config.appearDelay, appearAfter, scrolledPast]);
 
 		// Focus the chat input after the panel has opened. Runs post-commit, so
 		// the (previously hidden) textarea is in layout and can take focus.

--- a/src/chat/web/embed/use-scroll-appearance.ts
+++ b/src/chat/web/embed/use-scroll-appearance.ts
@@ -1,0 +1,113 @@
+// ============================================================================
+// useScrollAppearance — reactive "appear after scrolling past an element".
+//
+// Given a CSS selector on the host page, reports whether the floating bar
+// should be revealed: hidden while the target element is in (or below) the
+// viewport, shown once it's scrolled above the top. Reactive on purpose — the
+// bar hides again on the way back up, so it never re-collides with the element
+// it was told to clear (e.g. a hero card).
+//
+// A single IntersectionObserver does the work. A small bottom `rootMargin`
+// adds hysteresis so the trigger doesn't thrash right at the element's edge.
+// If the selector matches nothing (typo, or host markup that never renders),
+// we fail *open* after a short grace period — showing the bar beats hiding it
+// forever on a bad selector.
+// ============================================================================
+
+import { useEffect, useState } from "react";
+
+/** Give the host page this long to render the target before failing open. */
+const ELEMENT_LOOKUP_TIMEOUT_MS = 3000;
+
+/** Poll interval while waiting for the target element to appear in the DOM. */
+const ELEMENT_POLL_INTERVAL_MS = 120;
+
+/**
+ * Hysteresis band (px) at the element's bottom edge, so scrolling across the
+ * boundary doesn't flip the bar on and off repeatedly.
+ */
+const HYSTERESIS_PX = 24;
+
+/**
+ * Whether the bar should be revealed on the current path, given an "appear
+ * after" CSS selector. `null` selector → always `false` (the caller uses the
+ * default timer instead). Re-evaluates whenever the selector changes.
+ */
+export function useScrollAppearance(selector: string | null): boolean {
+	const [appeared, setAppeared] = useState(false);
+
+	useEffect(() => {
+		if (!selector || typeof document === "undefined") {
+			setAppeared(false);
+			return;
+		}
+
+		let cancelled = false;
+		let observer: IntersectionObserver | null = null;
+		let pollId: ReturnType<typeof setTimeout> | null = null;
+		let failOpenId: ReturnType<typeof setTimeout> | null = null;
+
+		const observe = (el: Element) => {
+			observer = new IntersectionObserver(
+				(entries) => {
+					const entry = entries[0];
+					if (!entry) {
+						return;
+					}
+					// In view → keep the bar back so it doesn't overlap the element.
+					// Out of view → reveal only once scrolled *past* it (its bottom is
+					// above the viewport top), not while it's still below the fold.
+					setAppeared(
+						!entry.isIntersecting && entry.boundingClientRect.bottom <= 0,
+					);
+				},
+				{ rootMargin: `0px 0px -${HYSTERESIS_PX}px 0px`, threshold: 0 },
+			);
+			observer.observe(el);
+		};
+
+		const find = () => {
+			if (cancelled) {
+				return;
+			}
+			let el: Element | null = null;
+			try {
+				el = document.querySelector(selector);
+			} catch {
+				// Invalid selector — fail open immediately rather than retry-then-hide.
+				setAppeared(true);
+				return;
+			}
+			if (el) {
+				observe(el);
+				return;
+			}
+			pollId = setTimeout(find, ELEMENT_POLL_INTERVAL_MS);
+		};
+
+		find();
+		failOpenId = setTimeout(() => {
+			if (cancelled || observer) {
+				return;
+			}
+			// Never found the element — show the bar rather than hide it forever.
+			if (pollId) {
+				clearTimeout(pollId);
+			}
+			setAppeared(true);
+		}, ELEMENT_LOOKUP_TIMEOUT_MS);
+
+		return () => {
+			cancelled = true;
+			observer?.disconnect();
+			if (pollId) {
+				clearTimeout(pollId);
+			}
+			if (failOpenId) {
+				clearTimeout(failOpenId);
+			}
+		};
+	}, [selector]);
+
+	return appeared;
+}

--- a/src/chat/web/embed/visibility.ts
+++ b/src/chat/web/embed/visibility.ts
@@ -17,6 +17,17 @@ export interface VisibilityPattern {
 }
 
 /**
+ * One glob → "appear after" mapping. Orthogonal to {@link VisibilityPattern}:
+ * it never affects whether the bar shows on a page, only *when* it appears on
+ * pages where it's already visible. `appearAfter` is a CSS selector on the host
+ * page; the bar holds back until that element is scrolled above the viewport.
+ */
+export interface AppearPattern {
+	glob: string;
+	appearAfter: string;
+}
+
+/**
  * Per-channel visibility rules. Mirrors the app-side `visibility` JSONB shape
  * (WAN-516). Semantics: show on all pages by default, override per-URL.
  *
@@ -32,6 +43,13 @@ export interface VisibilityRules {
 	patterns?: VisibilityPattern[];
 	/** Glob patterns, in order. Key the app/dashboard persists. */
 	rules?: VisibilityPattern[];
+	/**
+	 * Per-URL "appear after" timing, in order. Independent of the show/hide
+	 * patterns above: the first rule whose glob matches the current path holds
+	 * the bar back until its `appearAfter` element is scrolled past. Pages with
+	 * no matching rule keep the default appear-delay timer.
+	 */
+	appearRules?: AppearPattern[];
 }
 
 /** The glob list from a rules object, under whichever key it arrived. */
@@ -106,4 +124,25 @@ export function isVisibleForPath(
 		return true; // a show match beats the default
 	}
 	return (rules.default ?? "show") !== "hide";
+}
+
+/**
+ * The "appear after" CSS selector for `pathname`, or `null` if none applies.
+ *
+ * Returns the `appearAfter` of the first {@link AppearPattern} whose glob
+ * matches — order decides ties. `null` (no rules, or no match) means the caller
+ * falls back to the default appear-delay timer. Only meaningful on paths where
+ * {@link isVisibleForPath} is already true; a hidden page never renders the bar
+ * regardless.
+ */
+export function appearTriggerForPath(
+	rules: VisibilityRules | null | undefined,
+	pathname: string,
+): string | null {
+	for (const pattern of rules?.appearRules ?? []) {
+		if (matchGlob(pattern.glob, pathname)) {
+			return pattern.appearAfter;
+		}
+	}
+	return null;
 }


### PR DESCRIPTION
## What

On pages where the floating bar shows, hold it back until the visitor scrolls **past a configured element** instead of the fixed `appear-delay` timer. Solves the case where the bar overlaps an above-the-fold hero card: suppress it while the hero is on screen, reveal it once scrolled past.

## How

- **`visibility.ts`** — new `appearRules` (`{ glob, appearAfter }[]`) on the visibility config + `appearTriggerForPath()`. Orthogonal to show/hide: it only decides *when* the bar appears on a page, never *whether*. First matching rule wins; no match → falls back to the timer.
- **`use-scroll-appearance.ts`** — reactive `IntersectionObserver` hook. Reveals once the target is scrolled above the viewport top, hides again on scroll back up (so it never re-collides with the element it was told to clear), and **fails open** (shows) on a missing/invalid selector so a typo never hides the bar forever. Small bottom `rootMargin` for hysteresis.
- **`floating-chat.tsx`** — when a rule matches the current path, the scroll trigger owns `appeared`; the `appear-delay` timer stays the default everywhere else. `+24/-2`, no other behavior touched.

## Contract

Matches the app-side contract shipped in **PR #747** — `appearRules` rides along on the `GET /api/mcp/chat/config` visibility payload, so no `config.ts`/`remote-config.ts` changes are needed. Related: WAN-526.

## Testing

- `bun run typecheck` clean, `bun biome check .` clean.
- 26 targeted tests pass (6 `useScrollAppearance` hook cases + 5 `appearTriggerForPath` cases).
- Full suite: 343 pass; the only 2 failures are the pre-existing `useChatEngine – thread history` flakes, unrelated to this change.

Note: the frosted-glass suggestion-card redesign that was in the same working tree is intentionally **not** here — it lives on `floating-bar-glass-suggestions` for its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)