### PR TITLE
feat(mcp): add extractChannelId and stamp waniwani/channelId in withWaniwani

### DIFF
--- a/skills/waniwani-sdk/SKILL.md
+++ b/skills/waniwani-sdk/SKILL.md
@@ -82,7 +82,7 @@ Get a free key at [app.waniwani.ai](https://app.waniwani.ai). See [setup.md](ref
 | Export | Purpose | Tier | Reference |
 |---|---|---|---|
 | `@waniwani/sdk` | `waniwani()` client, `track.*` event helpers, `WaniWaniError` | Free tier | [setup.md](references/setup.md), [events.md](references/events.md) |
-| `@waniwani/sdk/mcp` | `createFlow`, `KvStore`, `MemoryKvStore`, `withWaniwani`, tracking helpers | OSS + Free tier | [flows.md](references/flows.md), [kv-store.md](references/kv-store.md), [events.md](references/events.md) |
+| `@waniwani/sdk/mcp` | `createFlow`, `KvStore`, `MemoryKvStore`, `withWaniwani`, `extractChannelId`, tracking helpers | OSS + Free tier | [flows.md](references/flows.md), [kv-store.md](references/kv-store.md), [events.md](references/events.md) |
 | `@waniwani/sdk/mcp/react` | `useWaniwani` host-agnostic tracking hook (takes `toolResponseMetadata` or explicit `{ endpoint, source }`) | OSS + Free tier | [events.md](references/events.md) (rest of this entry point is legacy) |
 | `@waniwani/sdk/mcp/react/skybridge` | `useWaniwani` skybridge adapter — bare call resolves config from skybridge's `useToolInfo()` | OSS + Free tier | [events.md](references/events.md) |
 | `@waniwani/sdk/chat` | `ChatEmbed`, themes | Free tier | [chat-widget.md](references/chat-widget.md) |
@@ -114,7 +114,7 @@ Adds hosted features on top of the OSS flow engine.
 - **Funnel analytics** — flow graphs auto-sync to the dashboard.
 - **Chat widget** — `ChatEmbed` talks directly to `app.waniwani.ai`.
 
-`withWaniwani(server)` is safe to call with or without an API key — its auto-captured `tool.called` events are internally guarded, and session-ID bridging and widget metadata forwarding still happen. Your own tracking calls are **not** guarded: `client.track.*`, `identify()`, and the scoped `context.waniwani` throw `WANIWANI_API_KEY is not set` when no key is configured, so guard them in code paths that must also run keyless. See [events.md](references/events.md).
+`withWaniwani(server)` is safe to call with or without an API key — its auto-captured `tool.called` events are internally guarded, and session-ID bridging and widget metadata forwarding still happen. When the calling host forwards a channel (the WaniWani app sends the channel UUID as `waniwani/channelId`), read it with `extractChannelId` — it returns undefined when no channel was sent; there is no synthetic fallback. Your own tracking calls are **not** guarded: `client.track.*`, `identify()`, and the scoped `context.waniwani` throw `WANIWANI_API_KEY is not set` when no key is configured, so guard them in code paths that must also run keyless. See [events.md](references/events.md).
 
 ### Legacy
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -38,6 +38,8 @@ export type { TrackingRouteOptions } from "./server/tracking-route";
 export { createTrackingRoute } from "./server/tracking-route";
 // Shared MCP server types (non-legacy)
 export type { McpServer, ZodRawShapeCompat } from "./server/types";
+// Request `_meta` extraction helpers — OSS
+export { extractChannelId } from "./server/utils";
 export type { WithWaniwaniOptions } from "./server/with-waniwani/index";
 export { withWaniwani } from "./server/with-waniwani/index";
 

--- a/src/mcp/server/__tests__/utils.test.ts
+++ b/src/mcp/server/__tests__/utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { extractSource, extractSourceFromHeaders } from "../utils";
+import {
+	extractChannelId,
+	extractSource,
+	extractSourceFromHeaders,
+} from "../utils";
 
 describe("extractSource", () => {
 	it("returns undefined for missing meta", () => {
@@ -120,6 +124,39 @@ describe("extractSource", () => {
 				extractSource({ "waniwani/source": "playground" }, { name: "Claude" }),
 			).toBe("playground");
 		});
+	});
+});
+
+describe("extractChannelId", () => {
+	it("returns undefined for missing meta", () => {
+		expect(extractChannelId(undefined)).toBeUndefined();
+		expect(extractChannelId({})).toBeUndefined();
+	});
+
+	it("returns the namespaced waniwani/channelId when set", () => {
+		expect(
+			extractChannelId({
+				"waniwani/channelId": "5d7a2c9e-1234-4f00-9a9b-000000000000",
+			}),
+		).toBe("5d7a2c9e-1234-4f00-9a9b-000000000000");
+	});
+
+	it("falls back to the generic channelId key", () => {
+		expect(extractChannelId({ channelId: "chan-1" })).toBe("chan-1");
+	});
+
+	it("namespaced key wins over the generic key", () => {
+		expect(
+			extractChannelId({
+				"waniwani/channelId": "chan-namespaced",
+				channelId: "chan-generic",
+			}),
+		).toBe("chan-namespaced");
+	});
+
+	it("ignores non-string and empty values", () => {
+		expect(extractChannelId({ "waniwani/channelId": 42 })).toBeUndefined();
+		expect(extractChannelId({ "waniwani/channelId": "" })).toBeUndefined();
 	});
 });
 

--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -55,6 +55,8 @@ const VISITOR_ID_KEYS = ["waniwani/visitorId", "visitorId"] as const;
 
 const CORRELATION_ID_KEYS = ["correlationId", "openai/requestId"] as const;
 
+const CHANNEL_ID_KEYS = ["waniwani/channelId", "channelId"] as const;
+
 const TURN_COUNT_KEYS = ["waniwani/turnCount"] as const;
 
 /** Meta key for flow execution path (nodesVisited, flowId). */
@@ -104,6 +106,21 @@ export function extractCorrelationId(
 	meta: Record<string, unknown> | undefined,
 ): string | undefined {
 	return meta ? pickFirst(meta, CORRELATION_ID_KEYS) : undefined;
+}
+
+/**
+ * Channel the conversation belongs to, as forwarded by the calling host.
+ *
+ * The WaniWani app forwards the channel UUID as `waniwani/channelId` when the
+ * request resolved a real channel; there is deliberately no synthetic
+ * fallback. Hosts that talk to the server directly (Claude, ChatGPT) send no
+ * channel, so this returns undefined for them — derive coarse attribution
+ * from `extractSource` / `waniwani/authSource` instead.
+ */
+export function extractChannelId(
+	meta: Record<string, unknown> | undefined,
+): string | undefined {
+	return meta ? pickFirst(meta, CHANNEL_ID_KEYS) : undefined;
 }
 
 /**

--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -228,6 +228,54 @@ describe("withWaniwani", () => {
 		expect(tracked[0]?.source).toBe("claude");
 	});
 
+	test("does not stamp any waniwani/channelId when the host sends none", async () => {
+		const { client } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, { client });
+
+		mock.registerTool("search", { description: "Search" }, async () => ({
+			text: "ok",
+		}));
+
+		const handler = mock.registered[0]?.[2];
+		const extra = {
+			_meta: {},
+			requestInfo: { headers: { "user-agent": "Claude-User" } },
+		} as Record<string, unknown>;
+		await handler?.({}, extra);
+
+		// No synthetic fallback: the key is absent unless the calling host
+		// (e.g. the WaniWani app) forwarded a real channel id.
+		expect(
+			(extra._meta as Record<string, unknown>)["waniwani/channelId"],
+		).toBeUndefined();
+	});
+
+	test("keeps a host-forwarded waniwani/channelId readable via _meta", async () => {
+		const { client, tracked } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, { client });
+
+		mock.registerTool("search", { description: "Search" }, async () => ({
+			text: "ok",
+		}));
+
+		const handler = mock.registered[0]?.[2];
+		const extra = {
+			_meta: { "waniwani/channelId": "chan-uuid-1" },
+		} as Record<string, unknown>;
+		await handler?.({}, extra);
+
+		expect((extra._meta as Record<string, unknown>)["waniwani/channelId"]).toBe(
+			"chan-uuid-1",
+		);
+		expect(tracked[0]?.meta).toMatchObject({
+			"waniwani/channelId": "chan-uuid-1",
+		});
+	});
+
 	test("does not override an explicit _meta source with header detection", async () => {
 		const { client, tracked } = mockClient();
 		const mock = mockServer();


### PR DESCRIPTION
New `extractChannelId` export from `@waniwani/sdk/mcp`: a pure reader for the channel the calling host forwards in `_meta` (`waniwani/channelId`, then `channelId`). The WaniWani app sends the channel UUID when the request resolves a real channel; when no channel was sent the helper returns `undefined` — no synthetic fallback is written into `_meta`. Coarse attribution for direct hosts comes from the existing `waniwani/source` / `waniwani/authSource` keys.

Docs updated in `skills/waniwani-sdk/SKILL.md`. The `wrap-server`/`sessions` MDX pages moved to the external docs repository with fec6b2f, so the channel-id section needs a follow-up PR there.

Pairs with the app PR that injects the channel UUID (WaniWani-AI/app#800). Part of WAN-565.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive OSS helper plus documentation and tests; no changes to auth, billing, or default tracking behavior beyond preserving existing `_meta` channel keys.
> 
> **Overview**
> Adds **`extractChannelId`** on `@waniwani/sdk/mcp`, a small `_meta` reader that returns the conversation channel when the host sends `waniwani/channelId` (preferred) or `channelId`. Missing or invalid values yield **`undefined`**—there is no synthetic channel id invented by the SDK.
> 
> **`withWaniwani`** behavior is documented and tested: it does **not** inject `waniwani/channelId` when the host omits one; when the WaniWani app (or another host) forwards a channel UUID, that value stays on request `_meta` and flows into **`tool.called`** tracking meta.
> 
> `skills/waniwani-sdk/SKILL.md` lists the new export and points integrators at `extractChannelId` for channel attribution alongside existing source/session helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83acc6bffbf5b63397f89c345de2b720408cfd26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->