### PR TITLE
feat(mcp): detect ChatGPT/OpenAI + Gemini source from clientInfo and headers (WAN-592)

### DIFF
--- a/src/mcp/server/__tests__/utils.test.ts
+++ b/src/mcp/server/__tests__/utils.test.ts
@@ -96,6 +96,16 @@ describe("extractSource", () => {
 			expect(extractSource({}, { name: "CLAUDE" })).toBe("claude");
 		});
 
+		it("derives chatgpt from an openai/chatgpt clientInfo.name", () => {
+			expect(extractSource({}, { name: "ChatGPT" })).toBe("chatgpt");
+			expect(extractSource({}, { name: "openai-mcp" })).toBe("chatgpt");
+			expect(extractSource(undefined, { name: "OpenAI" })).toBe("chatgpt");
+		});
+
+		it("derives gemini from a gemini clientInfo.name", () => {
+			expect(extractSource({}, { name: "Gemini" })).toBe("gemini");
+		});
+
 		it("returns undefined for unknown clientInfo.name", () => {
 			expect(extractSource({}, { name: "some-other-client" })).toBeUndefined();
 			expect(extractSource({}, { name: "" })).toBeUndefined();
@@ -146,7 +156,16 @@ describe("extractSourceFromHeaders", () => {
 		);
 	});
 
-	it("returns undefined for non-Claude user agents", () => {
+	it("derives chatgpt from an openai/chatgpt user-agent", () => {
+		expect(extractSourceFromHeaders({ "user-agent": "ChatGPT-User/1.0" })).toBe(
+			"chatgpt",
+		);
+		expect(
+			extractSourceFromHeaders({ "user-agent": "OpenAI-Python/1.2" }),
+		).toBe("chatgpt");
+	});
+
+	it("returns undefined for unrecognized user agents", () => {
 		expect(
 			extractSourceFromHeaders({ "user-agent": "Mozilla/5.0" }),
 		).toBeUndefined();

--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -123,11 +123,21 @@ const SOURCE_SESSION_KEYS = [
  * the SDK maps to a known source. Match is case-insensitive substring on the
  * advertised name, so this catches "Claude", "Claude Code", "claude-ai", etc.
  * without having to enumerate every surface.
+ *
+ * ChatGPT is primarily identified by its `openai/*` session key (see
+ * SOURCE_SESSION_KEYS), but a session without that key still resolves here from
+ * the advertised client name so assistant traffic is attributed consistently.
+ * First match wins, so order the needles most-specific first.
  */
 const CLIENT_INFO_NAME_SOURCES: ReadonlyArray<{
 	needle: string;
 	source: string;
-}> = [{ needle: "claude", source: "claude" }];
+}> = [
+	{ needle: "claude", source: "claude" },
+	{ needle: "chatgpt", source: "chatgpt" },
+	{ needle: "openai", source: "chatgpt" },
+	{ needle: "gemini", source: "gemini" },
+];
 
 export type ExtractSourceClientInfo = {
 	name?: string;
@@ -208,6 +218,11 @@ export function extractSourceFromHeaders(
 		(anthropicClient && /claude|anthropic/i.test(anthropicClient))
 	) {
 		return "claude";
+	}
+	// ChatGPT / OpenAI surfaces without an `openai/*` session key still send an
+	// OpenAI user-agent (e.g. `ChatGPT-User`), so attribute them here too.
+	if (userAgent && /chatgpt|openai/i.test(userAgent)) {
+		return "chatgpt";
 	}
 	return undefined;
 }


### PR DESCRIPTION
Hardens assistant source detection so write-time channel attribution (WAN-592, app side) reliably credits ChatGPT traffic — not just Claude.

Previously `extractSource` recognized ChatGPT **only** via the `openai/sessionId` / `openai/session` `_meta` key. A ChatGPT/OpenAI MCP session without that key resolved to `undefined` and ended up sourced as `"widget"`, so the app could never attribute it to the ChatGPT channel. Claude, by contrast, was caught three ways (meta, clientInfo, headers).

Changes (`src/mcp/server/utils.ts`):
- `CLIENT_INFO_NAME_SOURCES`: add `chatgpt` / `openai` → `chatgpt` and `gemini` → `gemini` (first-match-wins, Claude still first).
- `extractSourceFromHeaders`: also map an OpenAI/ChatGPT `User-Agent` (e.g. `ChatGPT-User`) to `chatgpt`.

The explicit `_meta` keys still win over both, so existing behavior is unchanged. Tests added in `utils.test.ts`.

No app changes required — the app's `classifySource` already maps these keywords.