### PR TITLE
feat(chat): tag chat requests with embed surface mode (WAN-597)

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -578,6 +578,8 @@ This is the top of the funnel: it counts everyone who *landed* on a page where t
 
 The event goes to the same canonical ingest every other event uses (`POST /api/mcp/events/v2/batch`, the V2 batch envelope), authenticated with the same public `wwp_...` token the widget already uses for `/chat` and `/config` (no API key, no separate JWT in the browser). Tracking is fire-and-forget — failures never break the chat.
 
+**Surface attribution.** Every event the widget produces carries `properties.mode`, the embed surface it came from: `"floating"` for the floating bar, `"inline"` for an in-page mount (`<WaniwaniChat>` or the inline `<script>` embed). `page.viewed` sets it directly; chat requests send the same value with every turn, so the server-logged `chat.user_message` and `chat.assistant_message` events carry it too. Use it to slice analytics by surface, for example floating-bar conversations vs inline ones on the same channel.
+
 **Opting out.** On surfaces where a page view is meaningless — an already-authenticated app shell, an internal tool, a staging preview — suppress the event so it doesn't inflate the customer's funnel. Set `overrides={{ disablePageView: true }}` on `<WaniwaniChat>`, or `data-disable-page-view="true"` (a bare `data-disable-page-view` works too) on the `<script>` embed. The rest of the widget is unaffected; only the `page.viewed` event is skipped.
 
 ## `ChatEmbed` (advanced)

--- a/skills/waniwani-sdk/references/events.md
+++ b/skills/waniwani-sdk/references/events.md
@@ -32,6 +32,10 @@ Think of instrumentation as three stages. Emit at least the **start** and the
 | **Step** | `option_selected` | `track.optionSelected({ id, amount, currency })` | The user picked one of those options. |
 | **Conversion** | `converted` | `track.converted({ amount, currency })` | The user became paying — possibly later, off-platform. |
 
+Events produced by the chat widget (`page.viewed`, `chat.user_message`,
+`chat.assistant_message`) also carry `properties.mode` (`"floating"` for the floating
+bar, `"inline"` for an in-page mount) so funnels can be sliced by embed surface.
+
 The conceptual "start / step / conversion" maps onto these concrete events. There is
 **no generic `step()` helper and no arbitrary custom event name** in the typed surface —
 model your funnel steps with the revenue events above. Emitting `track.lead(...)` once

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -297,7 +297,9 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 			}
 		}, []);
 
-		const body: Record<string, unknown> = {};
+		// `mode` tags every chat request with the embed surface so server-logged
+		// chat events carry it in `properties.mode`, matching `page.viewed`.
+		const body: Record<string, unknown> = { mode: "floating" };
 		if (config.mcpServerUrl) {
 			body.mcpServerUrl = config.mcpServerUrl;
 		}
@@ -467,7 +469,7 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 								api={config.api ?? ""}
 								headers={{ Authorization: `Bearer ${config.token}` }}
 								skipRemoteConfig
-								body={Object.keys(body).length > 0 ? body : undefined}
+								body={body}
 								appearance={config.appearance}
 								title={config.title}
 								headerActions={closeButton}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -74,7 +74,9 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 			[],
 		);
 
-		const body: Record<string, unknown> = {};
+		// `mode` tags every chat request with the embed surface so server-logged
+		// chat events carry it in `properties.mode`, matching `page.viewed`.
+		const body: Record<string, unknown> = { mode: "inline" };
 		if (config.mcpServerUrl) {
 			body.mcpServerUrl = config.mcpServerUrl;
 		}
@@ -88,7 +90,7 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 				api={config.api ?? ""}
 				headers={{ Authorization: `Bearer ${config.token}` }}
 				skipRemoteConfig
-				body={Object.keys(body).length > 0 ? body : undefined}
+				body={body}
 				appearance={config.appearance}
 				title={config.title}
 				hideHeader={config.hideHeader}

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -272,7 +272,10 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 		// re-evaluates on SPA route changes.
 		const visible = useVisibilityGate(config.visibility, ready);
 
-		const body: Record<string, unknown> = {};
+		// `mode` tags every chat request with the embed surface so server-logged
+		// chat events carry it in `properties.mode`, matching `page.viewed`.
+		// `WaniwaniChat` is always an in-page mount, so it reports "inline".
+		const body: Record<string, unknown> = { mode: "inline" };
 		if (config.mcpServerUrl) {
 			body.mcpServerUrl = config.mcpServerUrl;
 		}
@@ -290,7 +293,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 				api={config.api ?? DEFAULT_API}
 				headers={{ Authorization: `Bearer ${config.token}` }}
 				skipRemoteConfig
-				body={Object.keys(body).length > 0 ? body : undefined}
+				body={body}
 				appearance={config.appearance}
 				title={config.title}
 				hideHeader={config.hideHeader}


### PR DESCRIPTION
## What

Every chat request sent by the web chat widget now carries the embed surface it came from, as `mode: "floating" | "inline"` in the request body:

- **Floating bar** (`FloatingChat`) sends `mode: "floating"`
- **Inline embed** (`InlineChat`) sends `mode: "inline"`
- **`<WaniwaniChat>`** (React, always an in-page mount) sends `mode: "inline"`

`page.viewed` already carried `properties.mode`; this uses the same key and values so all widget events line up.

## Why

Analytics needs to slice web-channel events by surface (floating-bar conversations vs inline ones on the same channel). The server logs `chat.user_message` and `chat.assistant_message`, so the widget has to report its surface with every turn.

## How

The three surfaces already build a `body` object that the chat engine spreads into every request, so `mode` is added there. Since the body is now never empty, the `Object.keys(body).length > 0` guards became dead code and were removed.

Requires the app-side counterpart to land: the chat route must accept `mode` in `chatRequestSchema` and stamp it onto the logged events, otherwise Zod strips the unknown key. Until then the field is sent and harmlessly ignored, so there is no ordering constraint.

## Docs

Updated `skills/waniwani-sdk/references/chat-widget.md` (new Surface attribution section) and `events.md` to document `properties.mode`.

Closes WAN-597

🤖 Generated with [Claude Code](https://claude.com/claude-code)