### PR TITLE
feat(chat): live single-line tool-chain ticker, accordion when done (WAN-601)

### DIFF
--- a/src/chat/web/ai-elements/chain-of-thought.stories.tsx
+++ b/src/chat/web/ai-elements/chain-of-thought.stories.tsx
@@ -1,0 +1,286 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ToolUIPart } from "ai";
+import {
+	ClockIcon,
+	GlobeIcon,
+	type LucideIcon,
+	WrenchIcon,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+	ChainOfThought,
+	ChainOfThoughtContent,
+	ChainOfThoughtHeader,
+	ChainOfThoughtReasoning,
+	ChainOfThoughtStep,
+} from "./chain-of-thought";
+import { ToolInput, ToolOutput } from "./tool";
+
+// ============================================================================
+// ChainOfThought stories — the redesigned tool-chain display.
+//
+// While the turn is working the chain stays collapsed and the header is a
+// single live line: the active step's icon + a shimmering label that swaps
+// cleanly as the model moves from one tool call to the next. The timeline
+// never expands on its own. Once work ends the header settles into a
+// clickable "Thought process" accordion that reveals the full step timeline.
+//
+// These stories drive that lifecycle on a timer so the transitions are
+// visible without a live backend.
+// ============================================================================
+
+/** `get_price_estimate` → `Get price estimate` */
+function formatToolName(name: string): string {
+	return name.replace(/[-_]/g, " ").replace(/^\w/, (c) => c.toUpperCase());
+}
+
+/** Globe for search-like tools, wrench otherwise — mirrors message-list. */
+function pickStepIcon(name: string): LucideIcon {
+	return /search|find|lookup|query|web|browse|google/i.test(name)
+		? GlobeIcon
+		: WrenchIcon;
+}
+
+type ScenarioStep =
+	| { kind: "reasoning"; text: string }
+	| {
+			kind: "tool";
+			toolName: string;
+			title?: string;
+			input: Record<string, unknown>;
+			output: Record<string, unknown>;
+	  };
+
+// A believable multi-tool turn: think, quote, search providers, compare.
+const SCENARIO: ScenarioStep[] = [
+	{
+		kind: "reasoning",
+		text: "The user wants renters insurance in Austin. I'll pull a quote for their coverage level, then look up nearby providers and compare the options before answering.",
+	},
+	{
+		kind: "tool",
+		toolName: "get_price_estimate",
+		title: "Getting you a quote",
+		input: { city: "Austin, TX", coverage: "renters", deductible: 500 },
+		output: {
+			monthlyPremium: 14.5,
+			currency: "USD",
+			coverageLimit: 30000,
+			carrier: "Canopy",
+		},
+	},
+	{
+		kind: "tool",
+		toolName: "search_providers",
+		title: "Searching providers nearby",
+		input: { region: "TX", radiusMiles: 25 },
+		output: {
+			results: [
+				{ name: "Canopy", rating: 4.7 },
+				{ name: "Lemonade", rating: 4.5 },
+				{ name: "Assurant", rating: 4.1 },
+			],
+		},
+	},
+	{
+		kind: "tool",
+		toolName: "compare_prices",
+		title: "Comparing the best offers",
+		input: { candidates: ["Canopy", "Lemonade", "Assurant"] },
+		output: {
+			cheapest: "Canopy",
+			monthly: 14.5,
+			runnerUp: { name: "Lemonade", monthly: 15.9 },
+		},
+	},
+];
+
+const STEP_INTERVAL_MS = 1700;
+const RESTART_PAUSE_MS = 2600;
+
+/** Maps a scenario step to the ticker's `activeStep` (icon + label). */
+function toActiveStep(step: ScenarioStep): { icon: LucideIcon; label: string } {
+	if (step.kind === "reasoning") {
+		return { icon: ClockIcon, label: "Thinking…" };
+	}
+	return {
+		icon: pickStepIcon(step.toolName),
+		label: step.title ?? formatToolName(step.toolName),
+	};
+}
+
+interface PlayerProps {
+	/** Loop the lifecycle so the transitions replay without interaction. */
+	loop?: boolean;
+	/** Start already finished (settled accordion, click to expand). */
+	startSettled?: boolean;
+}
+
+/**
+ * Drives the ChainOfThought through the scenario on a timer. `index` is how
+ * many steps have started; the step at `index - 1` is running while the turn
+ * is working, everything before it is done. `index > length` marks the turn
+ * finished, which flips `isWorking` false and lets the chain settle.
+ */
+function ChainPlayer({ loop = true, startSettled = false }: PlayerProps) {
+	const total = SCENARIO.length;
+	const [index, setIndex] = useState(startSettled ? total + 1 : 0);
+
+	useEffect(() => {
+		if (index > total) {
+			if (!loop) {
+				return;
+			}
+			const t = setTimeout(() => setIndex(0), RESTART_PAUSE_MS);
+			return () => clearTimeout(t);
+		}
+		const t = setTimeout(() => setIndex((i) => i + 1), STEP_INTERVAL_MS);
+		return () => clearTimeout(t);
+	}, [index, loop]);
+
+	const isWorking = index >= 1 && index <= total;
+	// Steps that have started, in document order.
+	const started = SCENARIO.slice(0, Math.min(index, total));
+	const runningIndex = isWorking ? index - 1 : -1;
+	const activeStep = isWorking
+		? toActiveStep(SCENARIO[Math.min(index - 1, total - 1)])
+		: undefined;
+
+	// Before the first step lands there's nothing to show — mimic the
+	// pre-stream gap where the working indicator would cover things.
+	if (started.length === 0) {
+		return (
+			<p className="ww:text-sm ww:text-muted-foreground ww:italic">
+				waiting for the first step…
+			</p>
+		);
+	}
+
+	return (
+		<ChainOfThought isWorking={isWorking} activeStep={activeStep}>
+			<ChainOfThoughtHeader
+				workingLabel="Working on it…"
+				label="Thought process"
+			/>
+			<ChainOfThoughtContent>
+				{started.map((step, i) => {
+					const isLast = i === started.length - 1;
+					const state: ToolUIPart["state"] =
+						i === runningIndex ? "input-available" : "output-available";
+					if (step.kind === "reasoning") {
+						return (
+							<ChainOfThoughtReasoning
+								key={`r-${i}`}
+								isStreaming={i === runningIndex}
+								isLast={isLast}
+							>
+								{step.text}
+							</ChainOfThoughtReasoning>
+						);
+					}
+					return (
+						<ChainOfThoughtStep
+							key={step.toolName}
+							icon={pickStepIcon(step.toolName)}
+							title={step.title ?? formatToolName(step.toolName)}
+							state={state}
+							isLast={isLast}
+						>
+							<ToolInput input={step.input} />
+							{i !== runningIndex && (
+								<ToolOutput output={step.output} errorText={undefined} />
+							)}
+						</ChainOfThoughtStep>
+					);
+				})}
+			</ChainOfThoughtContent>
+		</ChainOfThought>
+	);
+}
+
+/**
+ * Frames the player like a chat message column: the `[data-waniwani-chat]`
+ * wrapper supplies the CSS variables (and `dark` swaps the palette), matching
+ * how the component renders inside the real widget.
+ */
+function Stage({
+	dark,
+	children,
+}: {
+	dark?: boolean;
+	children: React.ReactNode;
+}) {
+	return (
+		<div
+			data-waniwani-chat=""
+			className={dark ? "dark" : undefined}
+			style={{
+				minHeight: "100vh",
+				background: "var(--ww-color-background)",
+				color: "var(--ww-color-foreground)",
+				fontFamily: "var(--ww-font-sans)",
+				padding: "48px",
+			}}
+		>
+			<div style={{ maxWidth: 560, margin: "0 auto" }}>
+				<p
+					className="ww:mb-6 ww:text-sm ww:text-muted-foreground"
+					style={{ lineHeight: 1.6 }}
+				>
+					While working, the tool chain stays on one shimmering line and
+					transitions between actions. When it finishes it collapses into a
+					clickable “Thought process” accordion — open it to see the full chain.
+				</p>
+				{children}
+			</div>
+		</div>
+	);
+}
+
+interface Args {
+	loop: boolean;
+	dark: boolean;
+}
+
+const meta: Meta<Args> = {
+	title: "Chat/ChainOfThought",
+	render: (args) => (
+		<Stage dark={args.dark}>
+			<ChainPlayer loop={args.loop} />
+		</Stage>
+	),
+	args: { loop: true, dark: false },
+	argTypes: {
+		loop: { control: "boolean" },
+		dark: { control: "boolean" },
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<Args>;
+
+/** Light theme, looping lifecycle: watch the single-line ticker swap between
+ *  tool calls, then settle into the accordion (which reopens the loop). */
+export const Live: Story = {};
+
+/** Dark theme, looping lifecycle. */
+export const Dark: Story = {
+	args: { dark: true },
+};
+
+/** Plays once and stops on the settled accordion — good for inspecting the
+ *  final collapsed state and clicking to expand the full timeline. */
+export const PlayOnce: Story = {
+	args: { loop: false },
+};
+
+/** Starts already settled: the accordion is closed from first paint. Click the
+ *  header to expand the full step timeline with request/response detail. */
+export const Settled: Story = {
+	render: (args) => (
+		<Stage dark={args.dark}>
+			<ChainPlayer startSettled loop={false} />
+		</Stage>
+	),
+};

--- a/src/chat/web/ai-elements/chain-of-thought.tsx
+++ b/src/chat/web/ai-elements/chain-of-thought.tsx
@@ -9,25 +9,34 @@ import {
 	useContext,
 	useEffect,
 	useMemo,
-	useRef,
 	useState,
 } from "react";
 import { cn } from "../lib/utils";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "./reasoning";
 import { Shimmer } from "./shimmer";
 
-const AUTO_CLOSE_DELAY = 1000;
-// Delay after the auto-close fires before swapping the header label, so the
-// text change trails the collapse animation instead of racing it (smoother).
-const SETTLE_AFTER_CLOSE = 240;
+// After work ends, hold the last action on the single-line ticker for a beat
+// (shimmer off, label static) before swapping to the settled accordion header,
+// so the transition reads as "landed" rather than an abrupt cut.
+const SETTLE_DELAY = 500;
+
+/** A single live action shown on the collapsed chain's one-line ticker: the
+ * step's timeline icon plus a short label (e.g. a wrench + "Getting a quote"). */
+export type ChainStep = {
+	icon: LucideIcon;
+	label: string;
+};
 
 interface ChainContextValue {
 	open: boolean;
 	setOpen: (open: boolean) => void;
 	isWorking: boolean;
-	/** Latches true only after the chain has finished its post-work collapse,
-	 * so the header label swaps after the thread closes — not mid-collapse. */
+	/** Latches true once the run is done (after {@link SETTLE_DELAY}). While
+	 * false the header is the live single-line ticker; once true it becomes the
+	 * clickable "Thought process" accordion. */
 	settled: boolean;
+	/** The in-flight step — drives the ticker while unsettled. */
+	activeStep?: ChainStep;
 }
 
 const ChainContext = createContext<ChainContextValue | null>(null);
@@ -43,26 +52,36 @@ function useChain(): ChainContextValue {
 }
 
 export type ChainOfThoughtProps = HTMLAttributes<HTMLDivElement> & {
-	/** True while any step is still running (no output yet). Drives the
-	 * shimmering header and the auto open/close behavior. */
+	/** True while the turn is still in flight. While true the chain stays
+	 * collapsed and the header is a live single-line ticker of {@link activeStep};
+	 * when it flips false the chain settles into a clickable accordion. */
 	isWorking?: boolean;
+	/** The step being executed. While working, the collapsed chain shows this
+	 * as one shimmering line, swapping cleanly as the step changes. Ignored once
+	 * the chain has settled. */
+	activeStep?: ChainStep;
 	open?: boolean;
 	defaultOpen?: boolean;
 	onOpenChange?: (open: boolean) => void;
 };
 
 /**
- * Compound root that groups a run of tool-call steps into a single
- * collapsible "chain of thought". Mirrors the {@link Reasoning} lifecycle:
- * auto-opens while work is in flight so the live steps are visible, then
- * auto-collapses ~1s after the last step completes, leaving a tidy header.
+ * Compound root that groups a run of tool-call steps into a single "chain of
+ * thought". While working it stays collapsed and the header shows the live
+ * action on one line (icon + shimmering label) that transitions as steps
+ * advance — the timeline never expands on its own. Once work ends the header
+ * settles into a clickable "Thought process" accordion the user can open to
+ * reveal the full step timeline.
  *
  * ```tsx
- * <ChainOfThought isWorking={anyRunning}>
- *   <ChainOfThoughtHeader label="Canopy offer" />
+ * <ChainOfThought
+ *   isWorking={anyRunning}
+ *   activeStep={{ icon: WrenchIcon, label: "Canopy offer" }}
+ * >
+ *   <ChainOfThoughtHeader label="Thought process" />
  *   <ChainOfThoughtContent>
  *     <ChainOfThoughtStep icon={WrenchIcon} title="Getting you a quote" state="output-available" />
- *     <ChainOfThoughtStep icon={WrenchIcon} title="Canopy offer" state="input-available" isLast />
+ *     <ChainOfThoughtStep icon={WrenchIcon} title="Canopy offer" state="output-available" isLast />
  *   </ChainOfThoughtContent>
  * </ChainOfThought>
  * ```
@@ -70,16 +89,15 @@ export type ChainOfThoughtProps = HTMLAttributes<HTMLDivElement> & {
 export function ChainOfThought({
 	className,
 	isWorking = false,
+	activeStep,
 	open,
-	defaultOpen,
+	defaultOpen = false,
 	onOpenChange,
 	children,
 	...props
 }: ChainOfThoughtProps) {
-	const resolvedDefaultOpen = defaultOpen ?? isWorking;
-
 	const isControlled = open !== undefined;
-	const [internalOpen, setInternalOpen] = useState(resolvedDefaultOpen);
+	const [internalOpen, setInternalOpen] = useState(defaultOpen);
 	const isOpen = isControlled ? open : internalOpen;
 	const setOpen = useCallback(
 		(next: boolean) => {
@@ -91,48 +109,23 @@ export function ChainOfThought({
 		[isControlled, onOpenChange],
 	);
 
-	const wasWorkingRef = useRef(isWorking);
-	const [hasAutoClosed, setHasAutoClosed] = useState(false);
+	// `settled` gates the header between its two modes. It starts true for a
+	// chain that mounts already done (e.g. a historical message), flips false
+	// the moment work starts, and latches true again a beat after work ends.
 	const [settled, setSettled] = useState(!isWorking);
 
-	// Auto-open whenever work (re)starts; allow a fresh auto-close after.
 	useEffect(() => {
 		if (isWorking) {
-			wasWorkingRef.current = true;
-			setHasAutoClosed(false);
 			setSettled(false);
-			if (!isControlled) {
-				setInternalOpen(true);
-			}
+			return;
 		}
-	}, [isWorking, isControlled]);
-
-	// Auto-close ~1s after work ends (once per work burst).
-	useEffect(() => {
-		if (wasWorkingRef.current && !isWorking && isOpen && !hasAutoClosed) {
-			const timer = setTimeout(() => {
-				setOpen(false);
-				setHasAutoClosed(true);
-			}, AUTO_CLOSE_DELAY);
-			return () => clearTimeout(timer);
-		}
-	}, [isWorking, isOpen, hasAutoClosed, setOpen]);
-
-	// Latch `settled` only after the close has had time to animate, so the
-	// header swaps to the done label *after* the thread collapses.
-	useEffect(() => {
-		if (wasWorkingRef.current && !isWorking && !settled) {
-			const timer = setTimeout(
-				() => setSettled(true),
-				AUTO_CLOSE_DELAY + SETTLE_AFTER_CLOSE,
-			);
-			return () => clearTimeout(timer);
-		}
-	}, [isWorking, settled]);
+		const timer = setTimeout(() => setSettled(true), SETTLE_DELAY);
+		return () => clearTimeout(timer);
+	}, [isWorking]);
 
 	const contextValue = useMemo<ChainContextValue>(
-		() => ({ open: isOpen, setOpen, isWorking, settled }),
-		[isOpen, setOpen, isWorking, settled],
+		() => ({ open: isOpen, setOpen, isWorking, settled, activeStep }),
+		[isOpen, setOpen, isWorking, settled, activeStep],
 	);
 
 	return (
@@ -153,15 +146,20 @@ export type ChainOfThoughtHeaderProps = HTMLAttributes<HTMLButtonElement> & {
 	/** Generic header label for the settled chain (e.g. "Thought process").
 	 * Deliberately not a per-turn summary — just a stable label. */
 	label?: string;
-	/** Shimmering label while the chain is still working (e.g. "Working on it…").
-	 * Falls back to `label`. */
+	/** Fallback ticker label while working when no {@link ChainStep} is set
+	 * (e.g. "Working on it…"). Falls back to `label`. */
 	workingLabel?: string;
 };
 
 /**
- * Clickable header that toggles the chain. No leading icon — just the label
- * and a trailing chevron, the cleaner Claude-style treatment. While the chain
- * is working the label shimmers. The step icons live on the timeline below.
+ * The chain header, which renders in one of two modes:
+ *
+ * - **Working** (before the chain settles): a single, non-interactive line
+ *   showing the active step — its icon plus a shimmering label. The label is
+ *   keyed on its text so each new step animates in, giving a clean transition
+ *   between tool calls. There is no chevron; the timeline stays collapsed.
+ * - **Settled** (once work is done): a clickable "Thought process" accordion
+ *   header with a trailing chevron that toggles the step timeline below.
  */
 export function ChainOfThoughtHeader({
 	className,
@@ -170,19 +168,41 @@ export function ChainOfThoughtHeader({
 	children,
 	...props
 }: ChainOfThoughtHeaderProps) {
-	const { open, setOpen, isWorking, settled } = useChain();
-	// Working label (shimmering while active, static while collapsing) until the
-	// chain has fully settled, then the done label. Keeps the text swap from
-	// racing the collapse.
-	const content =
-		children ??
-		(settled ? (
-			label
-		) : isWorking ? (
-			<Shimmer duration={1.6}>{workingLabel ?? label ?? ""}</Shimmer>
-		) : (
-			(workingLabel ?? label)
-		));
+	const { open, setOpen, isWorking, settled, activeStep } = useChain();
+
+	if (!settled) {
+		const Icon = activeStep?.icon;
+		const text = activeStep?.label ?? workingLabel ?? label ?? "";
+		return (
+			<div
+				className={cn(
+					"ww:flex ww:min-h-5 ww:w-full ww:items-center ww:gap-1.5 ww:text-sm ww:text-muted-foreground",
+					className,
+				)}
+			>
+				{/* Keyed on the label so a new action fades/slides in as one unit —
+				    the "clean transition between tool calls". While work is live the
+				    label shimmers; during the settle beat it holds static. */}
+				<span
+					key={text}
+					className="ww:flex ww:min-w-0 ww:items-center ww:gap-1.5"
+					style={{ animation: "ww-fade-in 0.25s ease-out" }}
+				>
+					{Icon && (
+						<Icon
+							className={cn(
+								"ww:size-4 ww:shrink-0",
+								isWorking && "ww:animate-pulse",
+							)}
+						/>
+					)}
+					<span className="ww:truncate">
+						{isWorking ? <Shimmer duration={2.6}>{text}</Shimmer> : text}
+					</span>
+				</span>
+			</div>
+		);
+	}
 
 	return (
 		<button
@@ -190,12 +210,13 @@ export function ChainOfThoughtHeader({
 			onClick={() => setOpen(!open)}
 			aria-expanded={open}
 			className={cn(
-				"ww:flex ww:w-full ww:items-center ww:gap-1.5 ww:text-sm ww:text-muted-foreground ww:transition-colors ww:hover:text-foreground",
+				"ww:flex ww:min-h-5 ww:w-full ww:items-center ww:gap-1.5 ww:text-sm ww:text-muted-foreground ww:transition-colors ww:hover:text-foreground",
 				className,
 			)}
+			style={{ animation: "ww-fade-in 0.25s ease-out" }}
 			{...props}
 		>
-			<span className="ww:truncate">{content}</span>
+			<span className="ww:truncate">{children ?? label}</span>
 			<ChevronDownIcon
 				className={cn(
 					"ww:size-4 ww:shrink-0 ww:transition-transform ww:duration-200",

--- a/src/chat/web/components/message-list.tsx
+++ b/src/chat/web/components/message-list.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import type { ChatStatus, ReasoningUIPart, ToolUIPart, UIMessage } from "ai";
-import { GlobeIcon, type LucideIcon, WrenchIcon } from "lucide-react";
+import {
+	ClockIcon,
+	GlobeIcon,
+	type LucideIcon,
+	WrenchIcon,
+} from "lucide-react";
 import type { ModelContextUpdate } from "../../../shared/model-context";
 import type { ShowToolCalls, WelcomeConfig } from "../@types";
 import { Attachments } from "../ai-elements/attachments";
@@ -265,72 +270,92 @@ export function MessageList({
 						    reasoning trace folds in at the top, then each tool is a
 						    timeline step. `full` makes steps expand to their
 						    request/response JSON; `titles-only` shows label-only steps. */}
-						{showChain && (
-							<ChainOfThought
-								// Drive the header off the whole turn streaming (stable),
-								// not per-step running (which blips false between steps and
-								// makes the label flicker / settle early).
-								isWorking={
-									isLastAssistant &&
-									(status === "streaming" || status === "submitted")
-								}
-							>
-								<ChainOfThoughtHeader
-									workingLabel={t.chainOfThought.working}
-									label={t.chainOfThought.done}
-								/>
-								<ChainOfThoughtContent>
-									{activityParts.map((part, i) => {
-										const isLast = i === activityParts.length - 1;
-										if (part.type === "reasoning") {
-											return (
-												<ChainOfThoughtReasoning
-													key={`reasoning-${message.id}-${i}`}
-													isStreaming={part.state === "streaming"}
-													isLast={isLast}
-												>
-													{part.text}
-												</ChainOfThoughtReasoning>
-											);
+						{showChain &&
+							(() => {
+								// The active step drives the collapsed chain's single-line
+								// ticker: it's the last activity part (the one the model is
+								// on), mapped to a timeline icon + label. Reasoning reads as
+								// "Thinking…"; a tool reads as its humanized name.
+								const last = activityParts[activityParts.length - 1];
+								const activeStep =
+									last.type === "reasoning"
+										? { icon: ClockIcon, label: t.reasoning.thinking }
+										: {
+												icon: pickStepIcon(last.toolName),
+												label: last.title ?? formatToolName(last.toolName),
+											};
+								return (
+									<ChainOfThought
+										// Drive the header off the whole turn streaming (stable),
+										// not per-step running (which blips false between steps and
+										// makes the label flicker / settle early).
+										isWorking={
+											isLastAssistant &&
+											(status === "streaming" || status === "submitted")
 										}
-										const title = part.title ?? formatToolName(part.toolName);
-										const icon = pickStepIcon(part.toolName);
-										if (showToolCalls === "titles-only") {
-											return (
-												<ChainOfThoughtStep
-													key={part.toolCallId}
-													icon={icon}
-													title={title}
-													state={part.state}
-													isLast={isLast}
-												/>
-											);
-										}
-										const output = "output" in part ? part.output : undefined;
-										return (
-											<ChainOfThoughtStep
-												key={part.toolCallId}
-												icon={icon}
-												title={title}
-												state={part.state}
-												isLast={isLast}
-											>
-												<ToolInput input={part.input} debug={debug} />
-												{output !== undefined && (
-													<ToolOutput
-														output={output}
-														errorText={
-															"errorText" in part ? part.errorText : undefined
-														}
-														debug={debug}
-													/>
-												)}
-											</ChainOfThoughtStep>
-										);
-									})}
-								</ChainOfThoughtContent>
-							</ChainOfThought>
-						)}
+										activeStep={activeStep}
+									>
+										<ChainOfThoughtHeader
+											workingLabel={t.chainOfThought.working}
+											label={t.chainOfThought.done}
+										/>
+										<ChainOfThoughtContent>
+											{activityParts.map((part, i) => {
+												const isLast = i === activityParts.length - 1;
+												if (part.type === "reasoning") {
+													return (
+														<ChainOfThoughtReasoning
+															key={`reasoning-${message.id}-${i}`}
+															isStreaming={part.state === "streaming"}
+															isLast={isLast}
+														>
+															{part.text}
+														</ChainOfThoughtReasoning>
+													);
+												}
+												const title =
+													part.title ?? formatToolName(part.toolName);
+												const icon = pickStepIcon(part.toolName);
+												if (showToolCalls === "titles-only") {
+													return (
+														<ChainOfThoughtStep
+															key={part.toolCallId}
+															icon={icon}
+															title={title}
+															state={part.state}
+															isLast={isLast}
+														/>
+													);
+												}
+												const output =
+													"output" in part ? part.output : undefined;
+												return (
+													<ChainOfThoughtStep
+														key={part.toolCallId}
+														icon={icon}
+														title={title}
+														state={part.state}
+														isLast={isLast}
+													>
+														<ToolInput input={part.input} debug={debug} />
+														{output !== undefined && (
+															<ToolOutput
+																output={output}
+																errorText={
+																	"errorText" in part
+																		? part.errorText
+																		: undefined
+																}
+																debug={debug}
+															/>
+														)}
+													</ChainOfThoughtStep>
+												);
+											})}
+										</ChainOfThoughtContent>
+									</ChainOfThought>
+								);
+							})()}
 						{/* Lone tool with no reasoning → render it directly (no chain
 						    wrapper, which would just duplicate the one step under a
 						    header). With reasoning present, the chain above handles it. */}


### PR DESCRIPTION
## What

Reworks the chat embed's tool-chain display so it reads as one calm line while the agent works, then becomes a clickable accordion once finished.

- **While working:** the chain stays collapsed and shows a single line — the current action's icon + a shimmering label (🕐 Thinking… → 🔧 Getting you a quote → 🌐 Searching providers nearby). Each new step is keyed so it fades/slides in, giving a clean transition between tool calls. No chevron; nothing expands on its own.
- **When done:** the line settles into the `Thought process ⌄` accordion (closed). Clicking it reveals the full step timeline with per-step request/response JSON.

This replaces the old auto-expand-while-streaming / auto-collapse-after behavior, which was the noisy part.

## Changes

- `chain-of-thought.tsx` — removed the auto-open/close machinery; added a `settled` gate and an `activeStep` (`{ icon, label }`) prop/context. `ChainOfThoughtHeader` now renders in two modes: a live non-interactive ticker (unsettled) vs. the clickable accordion (settled).
- `message-list.tsx` — derives `activeStep` from the last activity part (reasoning → "Thinking…", tool → humanized name + globe/wrench icon) and passes it to `ChainOfThought`.
- `chain-of-thought.stories.tsx` — new Storybook story (`Chat/ChainOfThought`) driving a reasoning→3-tool lifecycle on a timer. Variants: Live, Dark, PlayOnce, Settled.

## Verified

Stepped through the story in a browser: the shimmering ticker transitioning between steps, the settle into the accordion, click-to-expand full timeline (globe icon picked for the search tool), and dark mode. `typecheck`, biome, and tests all pass (2 unrelated `useChatEngine` thread-history failures pre-exist on `main`).

Closes WAN-601

🤖 Generated with [Claude Code](https://claude.com/claude-code)