### PR TITLE
docs(flows): correct interrupt() to keyed-field syntax

### DIFF
--- a/.claude/skills/visualize-flow/SKILL.md
+++ b/.claude/skills/visualize-flow/SKILL.md
@@ -24,7 +24,7 @@ Parse the source code to identify:
 
 **Nodes** — Each `.addNode("name", ...)` call. Classify by what the handler returns:
 - **Widget node** — handler returns `showWidget({ tool, data })` (or the legacy positional form `showWidget(tool, { data })`). Look for `{ tool: ... }` (object form) or the second positional arg (legacy form).
-- **Interrupt node** — handler returns `interrupt({ field: { question } })`, one key per field asked (e.g. `interrupt({ email: { question: "What is your work email?" } })`). Each top-level key is a field name; `context` is the only reserved key.
+- **Interrupt node** — handler returns `interrupt({ field: { question } })`, one key per field asked (e.g. `interrupt({ email: { question: "What is your work email?" } })`).
 - **Action node** — handler returns a plain object like `{}` or `{ key: value }`. These run silently and auto-advance.
 
 **Direct edges** — Each `.addEdge(from, to)` call. `START` and `END` are sentinel constants (`"__start__"` and `"__end__"`).

--- a/.claude/skills/visualize-flow/SKILL.md
+++ b/.claude/skills/visualize-flow/SKILL.md
@@ -24,7 +24,7 @@ Parse the source code to identify:
 
 **Nodes** — Each `.addNode("name", ...)` call. Classify by what the handler returns:
 - **Widget node** — handler returns `showWidget({ tool, data })` (or the legacy positional form `showWidget(tool, { data })`). Look for `{ tool: ... }` (object form) or the second positional arg (legacy form).
-- **Interrupt node** — handler returns `interrupt({ question, field })`.
+- **Interrupt node** — handler returns `interrupt({ field: { question } })`, one key per field asked (e.g. `interrupt({ email: { question: "What is your work email?" } })`). Each top-level key is a field name; `context` is the only reserved key.
 - **Action node** — handler returns a plain object like `{}` or `{ key: value }`. These run silently and auto-advance.
 
 **Direct edges** — Each `.addEdge(from, to)` call. `START` and `END` are sentinel constants (`"__start__"` and `"__end__"`).

--- a/src/mcp/server/flows/README.md
+++ b/src/mcp/server/flows/README.md
@@ -64,16 +64,17 @@ const flow = createFlow({
   },
 })
   .addNode("ask_email", () =>
-    interrupt({ question: "What is your work email?", field: "email" }),
+    interrupt({ email: { question: "What is your work email?" } }),
   )
   .addNode("ask_role", () =>
-    interrupt({ question: "What is your role?", field: "role" }),
+    interrupt({ role: { question: "What is your role?" } }),
   )
   .addNode("ask_use_case", () =>
     interrupt({
-      question: "What's your primary use case?",
-      field: "useCase",
-      suggestions: ["Analytics", "Lead gen", "Support"],
+      useCase: {
+        question: "What's your primary use case?",
+        suggestions: ["Analytics", "Lead gen", "Support"],
+      },
     }),
   )
   .addNode("complete", (state) => ({
@@ -138,10 +139,10 @@ const flow = createFlow({
   },
 })
   .addNode("ask_postal", () =>
-    interrupt({ question: "What's your postal code?", field: "postalCode" }),
+    interrupt({ postalCode: { question: "What's your postal code?" } }),
   )
   .addNode("ask_sqm", () =>
-    interrupt({ question: "How many m² is your home?", field: "sqm" }),
+    interrupt({ sqm: { question: "How many m² is your home?" } }),
   )
   .addNode("show_pricing", (state) =>
     showWidget({
@@ -176,7 +177,7 @@ const flow = createFlow({
   },
 })
   .addNode("ask_email", () =>
-    interrupt({ question: "What's your email?", field: "email" }),
+    interrupt({ email: { question: "What's your email?" } }),
   )
   .addNode("analyze_email", (state) => {
     const domain = state.email?.split("@")[1] ?? "";
@@ -184,7 +185,7 @@ const flow = createFlow({
     return { isCompanyEmail: !generic.has(domain) };
   })
   .addNode("ask_company", () =>
-    interrupt({ question: "What company are you with?", field: "companyName" }),
+    interrupt({ companyName: { question: "What company are you with?" } }),
   )
   .addNode("done", () => ({ ready: true }))
   .addEdge(START, "ask_email")
@@ -208,8 +209,8 @@ undeclared, and graph introspection (funnel analytics, Mermaid diagrams) reads
 
 | Return value | Behavior |
 |---|---|
-| `interrupt({ question, field })` | Pause -> ask user -> resume with answer stored at `field` |
-| `interrupt({ question, field, context })` | Same, plus hidden guidance for the assistant |
+| `interrupt({ field: { question } })` | Pause -> ask user -> resume with answer stored at `field` |
+| `interrupt({ field: { question, context } })` | Same, plus hidden guidance for the assistant |
 | `showWidget({ tool: displayTool, data?, field?, interactive? })` | Pause -> instruct AI to call display tool -> resume on continue |
 | `{ key: value, ... }` | Action node -> merge into state -> auto-advance |
 

--- a/src/mcp/server/flows/create-flow.ts
+++ b/src/mcp/server/flows/create-flow.ts
@@ -24,11 +24,11 @@ import { StateGraph } from "./state-graph";
  * })
  *   .addNode({
  *     id: "ask_name",
- *     run: () => interrupt({ question: "What's your name?", field: "name" }),
+ *     run: () => interrupt({ name: { question: "What's your name?" } }),
  *   })
  *   .addNode({
  *     id: "ask_email",
- *     run: () => interrupt({ question: "What's your email?", field: "email" }),
+ *     run: () => interrupt({ email: { question: "What's your email?" } }),
  *   })
  *   .addEdge(START, "ask_name")
  *   .addEdge("ask_name", "ask_email")

--- a/src/mcp/server/flows/state-graph.ts
+++ b/src/mcp/server/flows/state-graph.ts
@@ -45,7 +45,7 @@ function buildMermaidGraph(
  * })
  *   .addNode({
  *     id: "ask_name",
- *     run: ({ interrupt }) => interrupt({ question: "What's your name?", field: "name" }),
+ *     run: ({ interrupt }) => interrupt({ name: { question: "What's your name?" } }),
  *   })
  *   .addNode({
  *     id: "greet",
@@ -80,7 +80,7 @@ export class StateGraph<
 	 * .addNode({
 	 *   id: "ask_name",
 	 *   label: "Ask for name",
-	 *   run: ({ interrupt }) => interrupt({ question: "What's your name?", field: "name" }),
+	 *   run: ({ interrupt }) => interrupt({ name: { question: "What's your name?" } }),
 	 * })
 	 * ```
 	 */


### PR DESCRIPTION
## Problem

The flow-authoring docs show `interrupt({ question, field })`, but `interrupt()` (in `@types.ts`) iterates `Object.entries(fields)` and only records a question when the **value** is an object containing `question`:

```ts
for (const [key, value] of Object.entries(fields)) {
  if (typeof value === "object" && value !== null && "question" in value) {
    questions.push({ question: value.question, field: key, ... });
  }
}
```

The documented form passes **string** values (`question: "..."`, `field: "..."`), so nothing matches and the interrupt is produced with an **empty `questions` array** — copy-pasting the examples silently asks the user nothing.

## Fix

Correct every example to the keyed form `interrupt({ field: { question } })`, which matches the implementation and every case in `compile.test.ts` (e.g. `interrupt({ useCase: { question: "What's your primary use case?" } })`). Updated:

- `src/mcp/server/flows/README.md` — 6 flow examples + the node-types reference table
- `src/mcp/server/flows/create-flow.ts` and `state-graph.ts` — JSDoc `@example` blocks

Docs/JSDoc only — no code or type changes.