### PR TITLE
fix(mcp): type tool annotations as MCP's ToolAnnotations + document title

### DIFF
--- a/skills/waniwani-sdk/references/_legacy/tools-and-widgets.md
+++ b/skills/waniwani-sdk/references/_legacy/tools-and-widgets.md
@@ -61,7 +61,7 @@ Creates an MCP tool. When `resource` is provided, the tool returns `structuredCo
 | `inputSchema` | `ZodRawShape` | Yes | Input parameters using Zod |
 | `invoking` | `string` | No | Loading message (default: `"Loading..."`) |
 | `invoked` | `string` | No | Loaded message (default: `"Loaded"`) |
-| `annotations` | `object` | No | `readOnlyHint`, `idempotentHint`, `openWorldHint`, `destructiveHint` |
+| `annotations` | `object` | No | `title`, `readOnlyHint`, `idempotentHint`, `openWorldHint`, `destructiveHint`. Always set `title` (human-readable tool name) plus the applicable hint — Claude's Connectors Directory requires both and flags the server at submission without them. |
 
 **Handler signature:**
 
@@ -159,7 +159,7 @@ const pricingTool = createTool({
   inputSchema: {
     plan: z.enum(["starter", "pro", "enterprise"]).describe("Plan to display"),
   },
-  annotations: { readOnlyHint: true },
+  annotations: { title: "Show pricing", readOnlyHint: true },
 }, async ({ plan }, context) => {
   const pricing = await getPricing(plan);
   return {
@@ -176,7 +176,7 @@ const searchTool = createTool({
   inputSchema: {
     query: z.string().describe("Search query"),
   },
-  annotations: { readOnlyHint: true },
+  annotations: { title: "Search", readOnlyHint: true },
 }, async ({ query }) => {
   const results = await search(query);
   return { text: JSON.stringify(results) };

--- a/skills/waniwani-sdk/references/flows-api-reference.md
+++ b/skills/waniwani-sdk/references/flows-api-reference.md
@@ -12,7 +12,7 @@ Creates a new `StateGraph`. The state type is automatically inferred from the `s
 | `title` | `string` | yes | Display title |
 | `description` | `string` | yes | Tells the AI when to use this flow |
 | `state` | `Record<string, z.ZodType>` | yes | State schema. Values are Zod schemas with `.describe()`. Use `z.object()` for grouped nested fields (1 level max). |
-| `annotations` | `object` | no | MCP tool annotation hints: `readOnlyHint`, `idempotentHint`, `openWorldHint`, `destructiveHint` |
+| `annotations` | `object` | no | MCP tool annotations: `title`, `readOnlyHint`, `idempotentHint`, `openWorldHint`, `destructiveHint`. Always set `title` (human-readable tool name) plus the applicable hint — Claude's Connectors Directory requires both and flags the server at submission without them. |
 
 ```ts
 import { createFlow } from "@waniwani/sdk/mcp";

--- a/skills/waniwani-sdk/references/flows.md
+++ b/skills/waniwani-sdk/references/flows.md
@@ -370,11 +370,19 @@ const flow = createFlow({
   title: "Lookup",
   description: "Look up information",
   state: { query: z.string().describe("Search query") },
-  annotations: { readOnlyHint: true, idempotentHint: true },
+  annotations: { title: "Look up information", readOnlyHint: true, idempotentHint: true },
 })
 ```
 
-Supported annotations: `readOnlyHint`, `idempotentHint`, `openWorldHint`, `destructiveHint`.
+Supported annotations: `title`, `readOnlyHint`, `idempotentHint`, `openWorldHint`, `destructiveHint`.
+
+**Always set `annotations.title`** — a human-readable name for the tool. Claude's
+Connectors Directory requires it on every tool and flags the server at submission
+without it; the top-level `title` does not satisfy that. Pair it with the applicable
+hint (`readOnlyHint: true` for read-only tools, `destructiveHint: true` for tools that
+modify or delete data) — the directory requires one of those too, and they drive
+Claude's auto-permissions: read-only tools run without a per-call prompt, destructive
+tools always prompt.
 
 ## Common Mistakes
 

--- a/src/legacy/mcp/tools/types.ts
+++ b/src/legacy/mcp/tools/types.ts
@@ -6,6 +6,7 @@ import type {
 	ShapeOutput,
 	ZodRawShapeCompat,
 } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { ScopedWaniWaniClient } from "../../../mcp/server/scoped-client";
 import type { RegisteredResource } from "../resources/types";
 
@@ -44,13 +45,15 @@ export type ToolConfig<TInput extends ZodRawShapeCompat> = {
 	 * result is consumed programmatically by the widget.
 	 */
 	autoInjectResultText?: boolean;
-	/** Annotations describe the tool's potential impact. */
-	annotations?: {
-		readOnlyHint?: boolean;
-		idempotentHint?: boolean;
-		openWorldHint?: boolean;
-		destructiveHint?: boolean;
-	};
+	/**
+	 * Annotations describe the tool's potential impact. Passed through to
+	 * `registerTool` as-is.
+	 *
+	 * Includes MCP's `title` — a human-readable name for the tool. Claude's
+	 * Connectors Directory requires it on every tool and flags the server at
+	 * submission without it; the top-level `title` does not satisfy that.
+	 */
+	annotations?: ToolAnnotations;
 };
 
 export type ToolHandler<TInput extends ZodRawShapeCompat> = (

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -4,6 +4,7 @@ import type {
 	CallToolResult,
 	ServerNotification,
 	ServerRequest,
+	ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { z } from "zod";
 import type { RegisteredTool } from "../../../legacy/mcp/tools/types";
@@ -473,13 +474,14 @@ export type FlowConfig = {
 	 * guidance line to the tool description — does not redact server-side.
 	 */
 	omitIntentPII?: boolean;
-	/** Optional tool annotations */
-	annotations?: {
-		readOnlyHint?: boolean;
-		idempotentHint?: boolean;
-		openWorldHint?: boolean;
-		destructiveHint?: boolean;
-	};
+	/**
+	 * Optional tool annotations, passed through to `registerTool` as-is.
+	 *
+	 * Includes MCP's `title` — a human-readable name for the tool. Claude's
+	 * Connectors Directory requires it on every tool and flags the server at
+	 * submission without it; the top-level `title` does not satisfy that.
+	 */
+	annotations?: ToolAnnotations;
 };
 
 /**
@@ -530,12 +532,7 @@ export type RegisteredFlow = {
 		 * contract instead of an opaque JSON string.
 		 */
 		outputSchema: FlowOutputSchema;
-		annotations?: {
-			readOnlyHint?: boolean;
-			idempotentHint?: boolean;
-			openWorldHint?: boolean;
-			destructiveHint?: boolean;
-		};
+		annotations?: ToolAnnotations;
 	};
 	/** Tool callback — pass to `server.registerTool(flow.name, flow.config, flow.handler)`. */
 	handler: FlowToolHandler;

--- a/src/mcp/server/flows/__tests__/annotations.test.ts
+++ b/src/mcp/server/flows/__tests__/annotations.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tool annotations carry MCP's `title`.
+ *
+ * Claude's Connectors Directory requires a `title` *inside* `annotations` on
+ * every tool and flags the server at the submission portal's Tools step
+ * without it — the top-level `title` does not satisfy it. The annotation
+ * shapes used to be hand-copied here and omitted `title`, so a caller setting
+ * it hit "Object literal may only specify known properties" even though the
+ * value passes straight through to `registerTool`.
+ *
+ * The type is the fix, so these tests earn their keep mostly at `bun run
+ * typecheck`: the `title` in each literal below stops compiling if the
+ * annotations type ever narrows again. The runtime assertions guard the
+ * passthrough.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { createTool } from "../../../../legacy/mcp/tools/create-tool";
+import type { FlowTokenContent, McpServer } from "../@types";
+import { END, START } from "../@types";
+import { createFlow } from "../create-flow";
+
+class TestFlowStateStore {
+	private readonly map = new Map<string, FlowTokenContent>();
+	async get(key: string): Promise<FlowTokenContent | null> {
+		return this.map.get(key) ?? null;
+	}
+	async set(key: string, value: FlowTokenContent): Promise<void> {
+		this.map.set(key, value);
+	}
+	async delete(key: string): Promise<void> {
+		this.map.delete(key);
+	}
+}
+
+type RegisteredConfig = { annotations?: { title?: string } };
+
+function mockServer() {
+	const registered: RegisteredConfig[] = [];
+	const server = {
+		registerTool: (_name: string, config: RegisteredConfig) => {
+			registered.push(config);
+		},
+	};
+	return { server: server as unknown as McpServer, registered };
+}
+
+describe("annotations.title", () => {
+	test("createFlow passes annotations.title through to registerTool", async () => {
+		const flow = createFlow({
+			id: "titled_flow",
+			title: "Titled Flow",
+			description: "A flow whose annotations carry a title.",
+			state: { q: z.string().describe("A question.") },
+			annotations: {
+				title: "Create a titled thing",
+				readOnlyHint: false,
+				destructiveHint: false,
+			},
+		})
+			.addEdge(START, END)
+			.compile({ store: new TestFlowStateStore() });
+
+		const { server, registered } = mockServer();
+		await flow.register(server);
+
+		expect(registered).toHaveLength(1);
+		expect(registered[0]?.annotations?.title).toBe("Create a titled thing");
+	});
+
+	test("createTool passes annotations.title through to registerTool", async () => {
+		const tool = createTool(
+			{
+				id: "titled_tool",
+				title: "Titled Tool",
+				description: "A tool whose annotations carry a title.",
+				inputSchema: { a: z.string() },
+				annotations: {
+					title: "Show a titled thing",
+					readOnlyHint: true,
+				},
+			},
+			async () => ({ text: "ok" }),
+		);
+
+		const { server, registered } = mockServer();
+		await tool.register(server);
+
+		expect(registered).toHaveLength(1);
+		expect(registered[0]?.annotations?.title).toBe("Show a titled thing");
+	});
+
+	test("the other MCP hints still round-trip alongside title", async () => {
+		const tool = createTool(
+			{
+				id: "all_hints_tool",
+				title: "All Hints",
+				description: "Every annotation the MCP spec defines.",
+				inputSchema: { a: z.string() },
+				annotations: {
+					title: "Show everything",
+					readOnlyHint: true,
+					idempotentHint: true,
+					openWorldHint: false,
+					destructiveHint: false,
+				},
+			},
+			async () => ({ text: "ok" }),
+		);
+
+		const { server, registered } = mockServer();
+		await tool.register(server);
+
+		expect(registered[0]?.annotations).toEqual({
+			title: "Show everything",
+			readOnlyHint: true,
+			idempotentHint: true,
+			openWorldHint: false,
+			destructiveHint: false,
+		});
+	});
+});


### PR DESCRIPTION
## Problem

Two halves of one root cause. **No repo in the fleet sets `annotations.title` — 0 of 5.** That isn't five oversights; the SDK made it impossible and then told everyone it didn't exist.

**1. The type rejected it.** The `annotations` shape is hand-copied inline at three sites, listing only the four hints:

| file | |
|---|---|
| `src/legacy/mcp/tools/types.ts` | `createTool` |
| `src/mcp/server/flows/@types.ts` | flow config input |
| `src/mcp/server/flows/@types.ts` | flow's emitted `config` |

So setting `annotations.title` hits `TS2353: Object literal may only specify known properties` — even though the object passes straight through to `registerTool` untouched and works fine at runtime.

**2. The docs said it wasn't supported.** The skill references enumerate exactly those same four fields:

> `references/flows.md` — *"Supported annotations: `readOnlyHint`, `idempotentHint`, `openWorldHint`, `destructiveHint`."*
> `references/flows-api-reference.md` — *"MCP tool annotation hints: `readOnlyHint`, …"*

An agent scaffolding a tool from these would never write `title`. Fixing only the type leaves that hole open.

## Why it matters

Claude's Connectors Directory requires a `title` **inside** `annotations` on every tool:

> Every tool must include a `title` and the applicable hint—`readOnlyHint: true` for read-only tools, `destructiveHint: true` for tools that modify or delete data.
> — [review-criteria](https://claude.com/docs/connectors/building/review-criteria), "Provide tool annotations"

The submission portal "flags [tools] for missing titles or annotations" at its Tools step, and the **top-level `title` does not satisfy it**. Simplis hit this mid-submission and shipped a local workaround to unblock. The gap is unbroken across every shipped version — verified in the installed `dist/mcp/index.d.ts` of **0.11.1, 0.12.1, and 0.14.1**: identical narrow shape, zero `ToolAnnotations` references.

## Fix

- **Type**: import `ToolAnnotations` from `@modelcontextprotocol/sdk/types.js` at all three sites. Chosen over adding `title` to each copy: the MCP SDK is already a peer dep and both files already import types from it, so this drops three duplicated shapes *and* keeps annotations in step with the spec instead of drifting again. `title` comes free.
- **Docs**: add `title` to both flow references and the legacy `createTool` reference, with the directory requirement and the auto-permission consequence of the hints (read-only runs without a prompt, destructive always prompts) spelled out. Examples updated to model the right shape.

## Non-breaking — no migration

Widens an optional field's type; every existing call site keeps compiling. Per the [`release-migration` skill](.claude/skills/release-migration/SKILL.md): *"A new optional export is not [breaking]"*, and no migration is needed for non-breaking changes. **No version bump here** — rides the next release.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run build` clean.
- `bun test`: **362 pass / 2 fail** — the 2 are pre-existing `useChatEngine` `act()` failures on `main`, unrelated and unchanged (baseline 359/2, +3 new).
- Built `dist/mcp/index.d.ts` confirmed emitting `annotations?: ToolAnnotations`.
- New `src/mcp/server/flows/__tests__/annotations.test.ts` covers `createFlow` + `createTool` passthrough and all five annotations round-tripping. The type is the fix, so the test earns its keep at `typecheck`: **reverting the type makes it fail at all three call sites**, verified.

## Follow-up (not this PR)

Once released, each app sets `annotations.title` inline and `simplis` drops its local `annotationsWithTitle()` workaround.## Follow-up (not this PR)

Once released, each consumer bumps and sets `annotations.title` inline. Concretely, for whoever cuts the release:

- **`simplis`** ([Managed](https://github.com/WaniWani-Managed/simplis)) — delete `lib/simplis/tool-annotations.ts`, inline 3 titles. Live in prod today with the workaround; it stalled mid-submission, which is what surfaced this.
- **`fintonic`** ([Managed](https://github.com/WaniWani-Managed/fintonic)) — delete `lib/fintonic-mcp/tool-annotations.ts`, inline 5 titles. Same workaround, same reason.
- **`mcp-distribution-template`** — needs ~3 lines and has **no workaround**, so it needs this PR first. Its two Skybridge tools (`select-portfolio`, `faq`) can take `annotations.title` today (Skybridge already types annotations as MCP `ToolAnnotations` — same fix as this PR), but `investment_portfolio` goes through `createFlow` and currently declares **no annotations at all**. Worth doing with the bump: the template seeds every new project.
- **`cover-my-business-ai`** ([Managed](https://github.com/WaniWani-Managed/cover-my-business-ai)) — logged in its `BACKLOG.md`. Also has a separate, harder gap: `intake` declares only `openWorldHint`, so it has neither `readOnlyHint` nor `destructiveHint`.

Context: **0 of 5 repos set `annotations.title`** before this — the type forbade it and the docs said it was unsupported. That is the hole this PR closes.