### PR TITLE
feat: fold kb.search retrieval traces onto tool.called

### DIFF
--- a/skills/waniwani-sdk/references/events.md
+++ b/skills/waniwani-sdk/references/events.md
@@ -156,6 +156,11 @@ await client.track({ event: "quote.succeeded", properties: { amount: 120, curren
   server is safe without an API key (its auto-capture is internally guarded and
   session metadata still bridges) — but your own `track.*` calls still throw keyless;
   see the tier note above.
+- **KB retrieval trace:** when a wrapped tool handler calls `client.kb.search()`, the
+  `tool.called` event for that tool carries `properties.kbSearch`: an array of
+  `{ query, resultCount, results: [{ source, heading, score }] }`, one entry per
+  search. It is metadata only — chunk bodies stay in the tool's own output. This makes
+  retrieval a deterministic, first-class signal without a separate event.
 - **Identify:** `client.identify(userId, properties?)` attaches a stable external
   identity to the session — useful right before an off-platform conversion so the later
   `converted` can be joined by `externalUserId`.

--- a/skills/waniwani-sdk/references/knowledge-base.md
+++ b/skills/waniwani-sdk/references/knowledge-base.md
@@ -28,6 +28,10 @@ const results = await client.kb.search("pricing", { metadata: { category: "prici
 | `minScore` | `number` | `0.3` | Minimum similarity score (0-1) |
 | `metadata` | `Record<string, string>` | -- | Filter by exact metadata key-value match |
 
+When `search()` runs inside a tool wrapped by `withWaniwani`, its query and retrieved
+sources are automatically recorded onto that tool's `tool.called` event as
+`properties.kbSearch` (metadata only). See the `events.md` reference for the shape.
+
 ## `client.kb.ingest(files)`
 
 Ingest markdown files into the knowledge base. **Destructive** -- deletes all existing chunks for the environment before ingesting.

--- a/src/kb/client.test.ts
+++ b/src/kb/client.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { InternalConfig } from "../types.js";
+import { createKbClient } from "./client.js";
+import { retrievalCollectorStore } from "./retrieval-context.js";
+import type { KbSearchTrace } from "./types.js";
+
+const config: InternalConfig = {
+	apiUrl: "https://example.test",
+	apiKey: "wwk_test",
+	tracking: {
+		endpointPath: "/api/mcp/events/v2/batch",
+		flushIntervalMs: 1000,
+		maxBatchSize: 20,
+		maxBufferSize: 1000,
+		maxRetries: 3,
+		retryBaseDelayMs: 200,
+		retryMaxDelayMs: 2000,
+		shutdownTimeoutMs: 2000,
+	},
+};
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+function stubFetch(data: unknown) {
+	globalThis.fetch = Object.assign(
+		async () => new Response(JSON.stringify({ data }), { status: 200 }),
+		{ preconnect: () => {} },
+	);
+}
+
+describe("kb.search retrieval trace", () => {
+	test("records a metadata-only trace into the active collector", async () => {
+		stubFetch([{ source: "a.md", heading: "A", content: "body", score: 0.9 }]);
+		const kb = createKbClient(config);
+		const collector: { searches: KbSearchTrace[] } = { searches: [] };
+		await retrievalCollectorStore.run(collector, () => kb.search("hello"));
+		expect(collector.searches).toEqual([
+			{
+				query: "hello",
+				resultCount: 1,
+				results: [{ source: "a.md", heading: "A", score: 0.9 }],
+			},
+		]);
+	});
+
+	test("records resultCount 0 for an empty search", async () => {
+		stubFetch([]);
+		const kb = createKbClient(config);
+		const collector: { searches: KbSearchTrace[] } = { searches: [] };
+		await retrievalCollectorStore.run(collector, () => kb.search("miss"));
+		expect(collector.searches).toEqual([
+			{ query: "miss", resultCount: 0, results: [] },
+		]);
+	});
+});

--- a/src/kb/client.ts
+++ b/src/kb/client.ts
@@ -2,6 +2,7 @@
 
 import { WaniWaniError } from "../error.js";
 import type { InternalConfig } from "../types.js";
+import { recordKbSearch } from "./retrieval-context.js";
 import type {
 	KbClient,
 	KbIngestFile,
@@ -68,10 +69,24 @@ export function createKbClient(config: InternalConfig): KbClient {
 			query: string,
 			options?: KbSearchOptions,
 		): Promise<SearchResult[]> {
-			return request<SearchResult[]>("POST", "/api/mcp/kb/search", {
+			const results = await request<SearchResult[]>(
+				"POST",
+				"/api/mcp/kb/search",
+				{
+					query,
+					...options,
+				},
+			);
+			recordKbSearch({
 				query,
-				...options,
+				resultCount: results.length,
+				results: results.map((r) => ({
+					source: r.source,
+					heading: r.heading,
+					score: r.score,
+				})),
 			});
+			return results;
 		},
 
 		async sources(): Promise<KbSource[]> {

--- a/src/kb/retrieval-context.test.ts
+++ b/src/kb/retrieval-context.test.ts
@@ -16,11 +16,31 @@ describe("retrieval collector", () => {
 	test("is a no-op with no active collector", () => {
 		expect(() => recordKbSearch(makeTrace())).not.toThrow();
 	});
+
+	// The serverless safety property: one isolate serves many concurrent
+	// requests, but AsyncLocalStorage scopes each collector to its own async
+	// context, so interleaved searches never cross-contaminate.
+	test("concurrent contexts stay isolated", async () => {
+		const a = { searches: [] as ReturnType<typeof makeTrace>[] };
+		const b = { searches: [] as ReturnType<typeof makeTrace>[] };
+		await Promise.all([
+			retrievalCollectorStore.run(a, async () => {
+				await Promise.resolve();
+				recordKbSearch(makeTrace("a"));
+			}),
+			retrievalCollectorStore.run(b, async () => {
+				await Promise.resolve();
+				recordKbSearch(makeTrace("b"));
+			}),
+		]);
+		expect(a.searches.map((s) => s.query)).toEqual(["a"]);
+		expect(b.searches.map((s) => s.query)).toEqual(["b"]);
+	});
 });
 
-function makeTrace() {
+function makeTrace(query = "q") {
 	return {
-		query: "q",
+		query,
 		resultCount: 1,
 		results: [{ source: "a.md", heading: "A", score: 0.9 }],
 	};

--- a/src/kb/retrieval-context.test.ts
+++ b/src/kb/retrieval-context.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import {
+	recordKbSearch,
+	retrievalCollectorStore,
+} from "./retrieval-context.js";
+
+describe("retrieval collector", () => {
+	test("records into the active collector", () => {
+		const collector = { searches: [] as ReturnType<typeof makeTrace>[] };
+		retrievalCollectorStore.run(collector, () => {
+			recordKbSearch(makeTrace());
+		});
+		expect(collector.searches).toHaveLength(1);
+	});
+
+	test("is a no-op with no active collector", () => {
+		expect(() => recordKbSearch(makeTrace())).not.toThrow();
+	});
+});
+
+function makeTrace() {
+	return {
+		query: "q",
+		resultCount: 1,
+		results: [{ source: "a.md", heading: "A", score: 0.9 }],
+	};
+}

--- a/src/kb/retrieval-context.test.ts
+++ b/src/kb/retrieval-context.test.ts
@@ -1,28 +1,55 @@
 import { describe, expect, test } from "bun:test";
 import {
+	type RetrievalCollector,
 	recordKbSearch,
 	retrievalCollectorStore,
 } from "./retrieval-context.js";
 
-describe("retrieval collector", () => {
+function makeTrace(query = "q") {
+	return {
+		query,
+		resultCount: 1,
+		results: [{ source: "a.md", heading: "A", score: 0.9 }],
+	};
+}
+
+function collector() {
+	return { searches: [] as ReturnType<typeof makeTrace>[] };
+}
+
+describe("retrieval collector — basics", () => {
 	test("records into the active collector", () => {
-		const collector = { searches: [] as ReturnType<typeof makeTrace>[] };
-		retrievalCollectorStore.run(collector, () => {
-			recordKbSearch(makeTrace());
+		const c = collector();
+		retrievalCollectorStore.run(c, () => recordKbSearch(makeTrace()));
+		expect(c.searches).toHaveLength(1);
+	});
+
+	test("accumulates searches in call order", () => {
+		const c = collector();
+		retrievalCollectorStore.run(c, () => {
+			recordKbSearch(makeTrace("a"));
+			recordKbSearch(makeTrace("b"));
+			recordKbSearch(makeTrace("c"));
 		});
-		expect(collector.searches).toHaveLength(1);
+		expect(c.searches.map((s) => s.query)).toEqual(["a", "b", "c"]);
 	});
 
 	test("is a no-op with no active collector", () => {
 		expect(() => recordKbSearch(makeTrace())).not.toThrow();
 	});
 
+	test("getStore is undefined outside any run()", () => {
+		expect(retrievalCollectorStore.getStore()).toBeUndefined();
+	});
+});
+
+describe("retrieval collector — context isolation", () => {
 	// The serverless safety property: one isolate serves many concurrent
 	// requests, but AsyncLocalStorage scopes each collector to its own async
 	// context, so interleaved searches never cross-contaminate.
 	test("concurrent contexts stay isolated", async () => {
-		const a = { searches: [] as ReturnType<typeof makeTrace>[] };
-		const b = { searches: [] as ReturnType<typeof makeTrace>[] };
+		const a = collector();
+		const b = collector();
 		await Promise.all([
 			retrievalCollectorStore.run(a, async () => {
 				await Promise.resolve();
@@ -36,12 +63,97 @@ describe("retrieval collector", () => {
 		expect(a.searches.map((s) => s.query)).toEqual(["a"]);
 		expect(b.searches.map((s) => s.query)).toEqual(["b"]);
 	});
+
+	test("nested contexts: inner shadows outer, outer resumes after", () => {
+		const outer = collector();
+		const inner = collector();
+		retrievalCollectorStore.run(outer, () => {
+			recordKbSearch(makeTrace("outer1"));
+			retrievalCollectorStore.run(inner, () =>
+				recordKbSearch(makeTrace("inner")),
+			);
+			recordKbSearch(makeTrace("outer2"));
+		});
+		expect(outer.searches.map((s) => s.query)).toEqual(["outer1", "outer2"]);
+		expect(inner.searches.map((s) => s.query)).toEqual(["inner"]);
+	});
+
+	test("the context does not leak after run() returns", () => {
+		retrievalCollectorStore.run(collector(), () => {});
+		expect(retrievalCollectorStore.getStore()).toBeUndefined();
+		expect(() => recordKbSearch(makeTrace())).not.toThrow();
+	});
 });
 
-function makeTrace(query = "q") {
-	return {
-		query,
-		resultCount: 1,
-		results: [{ source: "a.md", heading: "A", score: 0.9 }],
-	};
-}
+describe("retrieval collector — context propagation", () => {
+	test("survives multiple awaits inside run()", async () => {
+		const c = collector();
+		await retrievalCollectorStore.run(c, async () => {
+			await Promise.resolve();
+			await new Promise((r) => setTimeout(r, 0));
+			recordKbSearch(makeTrace("late"));
+		});
+		expect(c.searches.map((s) => s.query)).toEqual(["late"]);
+	});
+
+	test("survives a setTimeout scheduled inside run()", async () => {
+		const c = collector();
+		await retrievalCollectorStore.run(
+			c,
+			() =>
+				new Promise<void>((resolve) => {
+					setTimeout(() => {
+						recordKbSearch(makeTrace("timer"));
+						resolve();
+					}, 0);
+				}),
+		);
+		expect(c.searches.map((s) => s.query)).toEqual(["timer"]);
+	});
+
+	test("parallel awaited work records into the same context", async () => {
+		const c = collector();
+		await retrievalCollectorStore.run(c, async () => {
+			await Promise.all([
+				(async () => {
+					await Promise.resolve();
+					recordKbSearch(makeTrace("p1"));
+				})(),
+				(async () => {
+					await new Promise((r) => setTimeout(r, 0));
+					recordKbSearch(makeTrace("p2"));
+				})(),
+			]);
+		});
+		expect(c.searches.map((s) => s.query).sort()).toEqual(["p1", "p2"]);
+	});
+});
+
+describe("retrieval collector — robustness", () => {
+	// recordKbSearch runs inside kb.search(); a throw would break a user's
+	// search. A corrupted collector (e.g. a mixed SDK version) must not escape.
+	test("never throws on a corrupted collector shape", () => {
+		const corrupted = { searches: undefined } as unknown as RetrievalCollector;
+		retrievalCollectorStore.run(corrupted, () => {
+			expect(() => recordKbSearch(makeTrace())).not.toThrow();
+		});
+	});
+
+	test("records only metadata, never chunk bodies", () => {
+		const c = collector();
+		retrievalCollectorStore.run(c, () => recordKbSearch(makeTrace()));
+		expect(Object.keys(c.searches[0].results[0]).sort()).toEqual([
+			"heading",
+			"score",
+			"source",
+		]);
+	});
+
+	// This is what makes the two separate tsup bundles (core + mcp) share one
+	// store: the export IS the globalThis slot.
+	test("the exported store is the single shared global instance", () => {
+		const slot = (globalThis as { __waniwaniKbRetrievalStore?: unknown })
+			.__waniwaniKbRetrievalStore;
+		expect(retrievalCollectorStore).toBe(slot);
+	});
+});

--- a/src/kb/retrieval-context.ts
+++ b/src/kb/retrieval-context.ts
@@ -1,0 +1,26 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { KbSearchTrace } from "./types.js";
+
+// Per-request bucket the tool wrapper opens; kb.search records into it.
+export interface RetrievalCollector {
+	searches: KbSearchTrace[];
+}
+
+// Global slot, not a module-level instance: core (kb.search) and mcp
+// (withWaniwani) ship as separate bundles, so only globalThis keeps a single
+// shared AsyncLocalStorage per process. Two SDK copies in one process share
+// this slot, so RetrievalCollector's shape must stay backward-compatible.
+const globalWithStore = globalThis as typeof globalThis & {
+	__waniwaniKbRetrievalStore?: AsyncLocalStorage<RetrievalCollector>;
+};
+
+let store = globalWithStore.__waniwaniKbRetrievalStore;
+if (!store) {
+	store = new AsyncLocalStorage<RetrievalCollector>();
+	globalWithStore.__waniwaniKbRetrievalStore = store;
+}
+export const retrievalCollectorStore = store;
+
+export function recordKbSearch(trace: KbSearchTrace): void {
+	retrievalCollectorStore.getStore()?.searches.push(trace);
+}

--- a/src/kb/retrieval-context.ts
+++ b/src/kb/retrieval-context.ts
@@ -21,6 +21,10 @@ if (!store) {
 }
 export const retrievalCollectorStore = store;
 
+// Best-effort: recording runs inside kb.search(), so it must never throw back
+// into a user's search (e.g. a corrupted collector from a mixed SDK version).
 export function recordKbSearch(trace: KbSearchTrace): void {
-	retrievalCollectorStore.getStore()?.searches.push(trace);
+	try {
+		retrievalCollectorStore.getStore()?.searches.push(trace);
+	} catch {}
 }

--- a/src/kb/types.ts
+++ b/src/kb/types.ts
@@ -6,6 +6,14 @@ export interface SearchResult {
 	metadata?: Record<string, string>;
 }
 
+// One kb.search() call, folded onto the tool.called event as
+// properties.kbSearch. Metadata only — chunk bodies stay in the tool output.
+export interface KbSearchTrace {
+	query: string;
+	resultCount: number;
+	results: Array<Pick<SearchResult, "source" | "heading" | "score">>;
+}
+
 /** A file to ingest into the knowledge base */
 export interface KbIngestFile {
 	/** Filename (used as chunk source identifier) */

--- a/src/mcp/server/with-waniwani/helpers.test.ts
+++ b/src/mcp/server/with-waniwani/helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import type { KbSearchTrace } from "../../../kb/types.js";
+import { buildTrackInput } from "./helpers.js";
+
+const trace: KbSearchTrace[] = [
+	{
+		query: "q",
+		resultCount: 1,
+		results: [{ source: "a.md", heading: "A", score: 0.5 }],
+	},
+];
+
+describe("buildTrackInput kbSearch fold-in", () => {
+	test("folds kbSearch onto tool.called properties", () => {
+		const input = buildTrackInput(
+			"ask",
+			{},
+			{},
+			undefined,
+			undefined,
+			{ input: {}, output: {} },
+			trace,
+		);
+		expect("event" in input && input.event).toBe("tool.called");
+		expect(input.properties?.kbSearch).toEqual(trace);
+	});
+
+	test("omits kbSearch when no searches ran", () => {
+		const input = buildTrackInput(
+			"ask",
+			{},
+			{},
+			undefined,
+			undefined,
+			{ input: {}, output: {} },
+			[],
+		);
+		expect(input.properties && "kbSearch" in input.properties).toBe(false);
+	});
+});

--- a/src/mcp/server/with-waniwani/helpers.ts
+++ b/src/mcp/server/with-waniwani/helpers.ts
@@ -1,3 +1,4 @@
+import type { KbSearchTrace } from "../../../kb/types.js";
 import type {
 	CallableTrack,
 	ToolCalledProperties,
@@ -117,6 +118,7 @@ export function buildTrackInput(
 	timing?: { durationMs: number; status: string; errorMessage?: string },
 	clientInfo?: { name: string; version: string },
 	io?: { input?: unknown; output?: unknown },
+	kbSearch?: KbSearchTrace[],
 ): TrackInput {
 	const toolType = resolveToolType(toolName, options.toolType);
 
@@ -183,6 +185,7 @@ export function buildTrackInput(
 			...(timing ?? {}),
 			...(input !== undefined && { input }),
 			...(output !== undefined && { output }),
+			...(kbSearch && kbSearch.length > 0 && { kbSearch }),
 		},
 		meta: mergedMeta,
 		source: extractSource(mergedMeta ?? meta, clientInfo),

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -1,3 +1,7 @@
+import {
+	type RetrievalCollector,
+	retrievalCollectorStore,
+} from "../../../kb/retrieval-context.js";
 import type { ToolCalledProperties } from "../../../tracking/index.js";
 import { createLogger } from "../../../utils/logger.js";
 import { waniwani } from "../../../waniwani.js";
@@ -236,9 +240,12 @@ function createWrappedHandler(
 			extra[SCOPED_CLIENT_KEY] = scopedClient;
 		}
 
+		const retrievalCollector: RetrievalCollector = { searches: [] };
 		const startTime = performance.now();
 		try {
-			const result = await originalHandler(input, extra);
+			const result = await retrievalCollectorStore.run(retrievalCollector, () =>
+				originalHandler(input, extra),
+			);
 			const durationMs = Math.round(performance.now() - startTime);
 
 			log(
@@ -270,6 +277,7 @@ function createWrappedHandler(
 					},
 					clientInfo,
 					{ input, output: result },
+					retrievalCollector.searches,
 				),
 				opts.onError,
 			);
@@ -315,6 +323,7 @@ function createWrappedHandler(
 					},
 					clientInfo,
 					{ input },
+					retrievalCollector.searches,
 				),
 				opts.onError,
 			);

--- a/src/tracking/@types.ts
+++ b/src/tracking/@types.ts
@@ -1,5 +1,7 @@
 // Tracking Module Types
 
+import type { KbSearchTrace } from "../kb/types.js";
+
 // ============================================
 // Event Types
 // ============================================
@@ -58,6 +60,8 @@ export interface PageViewedProperties {
 export interface ToolCalledProperties {
 	name?: string;
 	type?: "pricing" | "product_info" | "availability" | "support" | "other";
+	/** Retrieval traces for kb.search() calls made inside this tool handler. */
+	kbSearch?: KbSearchTrace[];
 }
 
 export interface QuoteSucceededProperties {


### PR DESCRIPTION
WAN-659 — SDK side of the KB retrieval signal.

## Summary

`wani.kb.search()` records a metadata-only trace (`query`, `resultCount`, `results[{source, heading, score}]`) into an AsyncLocalStorage collector that `withWaniwani` opens around each tool handler. The wrapper folds it onto the `tool.called` event as `properties.kbSearch`, giving a deterministic knowledge-base retrieval signal without a separate event.

The collector store lives on a `globalThis` slot so the core (`kb.search`) and mcp (`withWaniwani`) entries — separate tsup bundles — share one instance per process. Additive and non-breaking: consumers see `kbSearch` only when a wrapped tool searches the KB.

## How to see it working

A tool wrapped by `withWaniwani` that calls `wani.kb.search()` emits a `tool.called` event carrying `properties.kbSearch`. Verified with a runtime harness importing the built core + mcp bundles: a wrapped handler's `kb.search("prêt flash")` produced `kbSearch: [{ query, resultCount: 2, results: [{source, heading, score}] }]` on the event — metadata only, chunk bodies stay in the tool output.

## Follow-up (not in this PR)

Version bump + changelog entry + `bun run release`; managed MCPs then pick it up by bumping the SDK and redeploying.
