### PR TITLE
feat(chat): add onEvent host-page callback to embed.js

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -582,6 +582,47 @@ The event goes to the same canonical ingest every other event uses (`POST /api/m
 
 **Opting out.** On surfaces where a page view is meaningless — an already-authenticated app shell, an internal tool, a staging preview — suppress the event so it doesn't inflate the customer's funnel. Set `overrides={{ disablePageView: true }}` on `<WaniwaniChat>`, or `data-disable-page-view="true"` (a bare `data-disable-page-view` works too) on the `<script>` embed. The rest of the widget is unaffected; only the `page.viewed` event is skipped.
 
+### Mirroring events into your own analytics (`onEvent`)
+
+The `<script>` embed can report chat lifecycle events to the host page through an `onEvent` callback. The embed mounts directly in the page's DOM (the shadow root isolates styles only), so the callback runs in the page's own JS context: forwarding to `window.analytics.track(...)` (Segment), `gtag(...)`, or any other page-side SDK keeps that SDK's identity (for example Segment's `anonymousId`) attached automatically, with no server-side identity plumbing.
+
+| Event | Fired when | Notes |
+|-------|------------|-------|
+| `chat.opened` | The floating panel expands open | Floating mode only |
+| `chat.closed` | The floating panel collapses back to the dock | Floating mode only |
+| `message.sent` | The visitor submits a message | Never includes the message text |
+| `message.received` | The assistant response completes | Never includes the message text |
+
+Each event is `{ name, sessionId?, properties? }` (the `WidgetEvent` type, exported from `@waniwani/sdk/chat`). `properties.mode` carries the embed surface (`"inline"` or `"floating"`). `sessionId` is assigned by the server on the first exchange, so it is `undefined` on events that precede it.
+
+The event names are neutral and fixed. If your analytics schema uses different names or extra properties, map them in your callback:
+
+```html
+<script src="https://app.waniwani.ai/embed.js" defer></script>
+<script>
+  window.addEventListener('DOMContentLoaded', function () {
+    window.WaniWani.chat.init({
+      token: 'wwp_...',
+      mode: 'floating',
+      onEvent: function (event) {
+        var names = {
+          'chat.opened': 'chat_opened',
+          'chat.closed': 'chat_closed',
+          'message.sent': 'user_message',
+          'message.received': 'bot_message',
+        };
+        window.analytics.track(names[event.name] || event.name, {
+          page: window.location.pathname,
+          sessionId: event.sessionId,
+        });
+      },
+    });
+  });
+</script>
+```
+
+`onEvent` is programmatic-only (a function cannot be expressed as a `data-*` attribute), so it requires the `init()` call above rather than the bare auto-init script tag. Exceptions thrown by the callback are swallowed with a console warning; a broken callback never breaks the chat. Message content never passes through `onEvent`, only the fact that a message was exchanged.
+
 ## `ChatEmbed` (advanced)
 
 **Most apps should use `WaniwaniChat` or the `<script>` embed.** `ChatEmbed` is the bare-bones primitive underneath both of them: no token, no remote config, no defaults, no built-in MCP resource endpoint. You wire up `api`, `headers`, `body`, `theme`, and (optionally) `mcp` yourself.

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -157,6 +157,24 @@ describe("resolveConfig — render mode", () => {
 	});
 });
 
+describe("resolveConfig — onEvent", () => {
+	test("programmatic onEvent survives the layered merge", () => {
+		const onEvent = () => {};
+		const config = resolveConfig(
+			{ token: "tok", onEvent },
+			{ title: "Remote" },
+			{},
+		);
+		expect(config.onEvent).toBe(onEvent);
+		expect(config.title).toBe("Remote");
+	});
+
+	test("onEvent is undefined by default", () => {
+		const config = resolveConfig({ token: "tok" });
+		expect(config.onEvent).toBeUndefined();
+	});
+});
+
 async function parseWithAttrs(
 	attrs: Record<string, string>,
 ): Promise<Record<string, unknown>> {

--- a/src/chat/web/embed/__tests__/widget-events.test.ts
+++ b/src/chat/web/embed/__tests__/widget-events.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import type { WidgetEvent } from "../widget-events";
+import { emitWidgetEvent } from "../widget-events";
+
+describe("emitWidgetEvent", () => {
+	test("invokes the callback with the event", () => {
+		const received: WidgetEvent[] = [];
+		emitWidgetEvent((e) => received.push(e), {
+			name: "chat.opened",
+			sessionId: "sess_1",
+			properties: { mode: "floating" },
+		});
+
+		expect(received).toHaveLength(1);
+		expect(received[0]?.name).toBe("chat.opened");
+		expect(received[0]?.sessionId).toBe("sess_1");
+		expect(received[0]?.properties).toEqual({ mode: "floating" });
+	});
+
+	test("no-ops without a callback", () => {
+		expect(() =>
+			emitWidgetEvent(undefined, { name: "message.sent" }),
+		).not.toThrow();
+	});
+
+	test("swallows callback exceptions", () => {
+		expect(() =>
+			emitWidgetEvent(
+				() => {
+					throw new Error("host page bug");
+				},
+				{ name: "message.received" },
+			),
+		).not.toThrow();
+	});
+});

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -5,6 +5,7 @@
 import type { ChatTheme } from "../@types";
 import type { Locale } from "../i18n";
 import type { VisibilityRules } from "./visibility";
+import type { WidgetEvent } from "./widget-events";
 
 /**
  * Built-in theme presets. `auto` follows the host's `prefers-color-scheme`
@@ -174,6 +175,18 @@ export interface EmbedConfig {
 	 * `"floating"`.
 	 */
 	visibility?: VisibilityRules;
+	/**
+	 * Host-page callback fired on chat lifecycle events: `chat.opened`,
+	 * `chat.closed` (floating mode only), `message.sent`, `message.received`.
+	 * Message events never include the message text. The embed runs in the
+	 * host page's DOM, so the callback can forward events directly into the
+	 * page's analytics (e.g. `window.analytics.track(...)`).
+	 *
+	 * Programmatic-only: functions cannot be expressed as a `data-*`
+	 * attribute, so pass it to `WaniWani.chat.init()`. Exceptions thrown by
+	 * the callback are swallowed and never break the widget.
+	 */
+	onEvent?: (event: WidgetEvent) => void;
 }
 
 /** Fallback height applied to an inline embed container with no author sizing. */

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -40,6 +40,7 @@ import { useRemoteEmbedConfig } from "./remote-config";
 import { usePathname, useVisibilityGate } from "./use-pathname";
 import { useScrollAppearance } from "./use-scroll-appearance";
 import { appearTriggerForPath } from "./visibility";
+import { emitWidgetEvent } from "./widget-events";
 
 /** Default delay before the docked input animates into view on load. */
 const DEFAULT_APPEAR_DELAY_MS = 2000;
@@ -253,6 +254,26 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 			},
 			[openPanel],
 		);
+
+		// Report open/close transitions to the host page (`onEvent`). Watching
+		// `phase` covers every path that opens or closes the panel: dock focus,
+		// suggestion click, the imperative API, the header collapse button. The
+		// docked/expanded states both count as "closed"; only the full panel is
+		// "open". No event on mount (both start not-open).
+		const wasOpenRef = useRef(false);
+		const onEvent = config.onEvent;
+		useEffect(() => {
+			const isOpen = phase === "open";
+			if (isOpen === wasOpenRef.current) {
+				return;
+			}
+			wasOpenRef.current = isOpen;
+			emitWidgetEvent(onEvent, {
+				name: isOpen ? "chat.opened" : "chat.closed",
+				sessionId: chatRef.current?.sessionId,
+				properties: { mode: "floating" },
+			});
+		}, [phase, onEvent]);
 
 		useImperativeHandle(
 			ref,
@@ -500,6 +521,20 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 								headers={{ Authorization: `Bearer ${config.token}` }}
 								skipRemoteConfig
 								body={body}
+								onMessageSent={() =>
+									emitWidgetEvent(config.onEvent, {
+										name: "message.sent",
+										sessionId: chatRef.current?.sessionId,
+										properties: { mode: "floating" },
+									})
+								}
+								onResponseReceived={() =>
+									emitWidgetEvent(config.onEvent, {
+										name: "message.received",
+										sessionId: chatRef.current?.sessionId,
+										properties: { mode: "floating" },
+									})
+								}
 								appearance={config.appearance}
 								title={config.title}
 								headerActions={closeButton}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -12,6 +12,7 @@ import { ChatEmbed } from "../layouts/chat-embed";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
 import { useVisibilityGate } from "./use-pathname";
+import { emitWidgetEvent } from "./widget-events";
 
 export interface InlineChatProps {
 	config: EmbedConfig;
@@ -91,6 +92,20 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 				headers={{ Authorization: `Bearer ${config.token}` }}
 				skipRemoteConfig
 				body={body}
+				onMessageSent={() =>
+					emitWidgetEvent(config.onEvent, {
+						name: "message.sent",
+						sessionId: chatRef.current?.sessionId,
+						properties: { mode: "inline" },
+					})
+				}
+				onResponseReceived={() =>
+					emitWidgetEvent(config.onEvent, {
+						name: "message.received",
+						sessionId: chatRef.current?.sessionId,
+						properties: { mode: "inline" },
+					})
+				}
 				appearance={config.appearance}
 				title={config.title}
 				hideHeader={config.hideHeader}

--- a/src/chat/web/embed/widget-events.ts
+++ b/src/chat/web/embed/widget-events.ts
@@ -1,0 +1,52 @@
+// ============================================================================
+// Widget events: host-page callback for chat lifecycle events.
+//
+// The embed mounts in the host page's DOM (the shadow root isolates styles
+// only), so an `onEvent` callback runs in the page's own JS context. That is
+// the whole point: the host can forward events straight into its analytics
+// (`window.analytics.track(...)` for Segment, gtag, etc.) and the page's own
+// identity (e.g. Segment's anonymousId) is attached automatically, with no
+// server-side identity plumbing needed.
+//
+// Message events deliberately carry no message content: the host learns THAT
+// a message was exchanged, never what was said.
+// ============================================================================
+
+/** Names of the lifecycle events the widget reports to `onEvent`. */
+export type WidgetEventName =
+	| "chat.opened"
+	| "chat.closed"
+	| "message.sent"
+	| "message.received";
+
+/** Payload handed to the host page's `onEvent` callback. */
+export interface WidgetEvent {
+	name: WidgetEventName;
+	/**
+	 * Conversation session id, when one exists. Assigned by the server on the
+	 * first exchange, so it is `undefined` for events that precede it (e.g. the
+	 * first `message.sent` and any `chat.opened` before a conversation starts).
+	 */
+	sessionId?: string;
+	/** Extra event data (e.g. the embed `mode`). Never includes message text. */
+	properties?: Record<string, unknown>;
+}
+
+/**
+ * Invoke the host page's `onEvent` callback, if configured. Exceptions are
+ * swallowed (with a console warning): a broken host callback must never
+ * break the widget.
+ */
+export function emitWidgetEvent(
+	onEvent: ((event: WidgetEvent) => void) | undefined,
+	event: WidgetEvent,
+): void {
+	if (!onEvent) {
+		return;
+	}
+	try {
+		onEvent(event);
+	} catch (err) {
+		console.warn("[Waniwani] onEvent callback threw:", err);
+	}
+}

--- a/src/chat/web/index.ts
+++ b/src/chat/web/index.ts
@@ -25,6 +25,7 @@ export type {
 	McpAppFrameProps,
 } from "./components/mcp-app-frame";
 export { McpAppFrame } from "./components/mcp-app-frame";
+export type { WidgetEvent, WidgetEventName } from "./embed/widget-events";
 export { ChatEmbed } from "./layouts/chat-embed";
 export {
 	WaniwaniChat,


### PR DESCRIPTION
The script embed now accepts an `onEvent` callback via `WaniWani.chat.init()` that reports chat lifecycle events to the host page:

| Event | Fired when |
|---|---|
| `chat.opened` / `chat.closed` | Floating panel expands / collapses (floating mode only) |
| `message.sent` | Visitor submits a message (no message content) |
| `message.received` | Assistant response completes (no message content) |

Each event is `{ name, sessionId?, properties? }` with `properties.mode` carrying the embed surface. The embed mounts in the host page's DOM, so the callback runs in the page's own JS context: forwarding to `window.analytics.track(...)` keeps the page's identity (e.g. Segment's `anonymousId`) attached automatically, with no server-side identity plumbing.

Design notes:
- Event names are neutral and fixed. Hosts map them to their own analytics schema inside the callback (confirmed with tuio for their A/B test integration; we do not adopt customer-specific names).
- Message content never passes through `onEvent`.
- Callback exceptions are swallowed with a console warning so a broken host callback never breaks the widget.
- Programmatic-only: functions cannot ride a `data-*` attribute.

Includes tests (emit helper, config merge) and the `chat-widget.md` reference update. The 2 failing `use-chat-engine.test.tsx` thread-history tests are pre-existing on main.

Note: Linear ticket not created (Linear MCP unauthenticated in this session); please link one if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)