### PR TITLE
feat(chat): full widget theming/customization surface (WAN-690)

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -525,15 +525,22 @@ Unset variables fall back to the preset's defaults, so you only override what yo
 | `--ww-muted` | Secondary text | `#6b7280` | `#8e8ea0` |
 | `--ww-border` | Border colour | `#e5e7eb` | `#444444` |
 | `--ww-assistant-bubble` | Assistant bubble bg | `#f3f4f6` | `#2f2f2f` |
+| `--ww-assistant-bubble-text` | Assistant bubble text | `#1f2937` | `#ececec` |
 | `--ww-user-bubble` | User bubble bg | `#f4f4f4` | `#303030` |
+| `--ww-user-bubble-text` | User bubble text | `#1f2937` | `#ffffff` |
 | `--ww-input-bg` | Input field bg | `#f9fafb` | `#2f2f2f` |
 | `--ww-header-bg` | Header background | `#ffffff` | `#1e1e1e` |
 | `--ww-header-text` | Header text | `#1f2937` | `#ececec` |
 | `--ww-status` | Status dot | `#22c55e` | `#22c55e` |
 | `--ww-tool-card` | Tool call card bg | `#f4f4f5` | `#262626` |
 | `--ww-radius` | Panel border-radius | `16px` | `16px` |
-| `--ww-msg-radius` | Message bubble radius | `12px` | `12px` |
+| `--ww-msg-radius` | Message bubble radius | `8px` | `8px` |
+| `--ww-msg-pad-x` | Message bubble padding X | `16px` | `16px` |
+| `--ww-msg-pad-y` | Message bubble padding Y | `12px` | `12px` |
+| `--ww-msg-max-width` | Message bubble max width | `80%` | `80%` |
 | `--ww-font` | Font family | system stack | system stack |
+| `--ww-font-size` | Base message font size | `16px` | `16px` |
+| `--ww-line-height` | Base message line height | `1.5` | `1.5` |
 
 #### 3. Programmatic `appearance`
 
@@ -565,6 +572,89 @@ window.WaniWani.chat.init({
 ```
 
 `variables` accepts the same keys as `ChatTheme`. The helpers `DEFAULT_THEME`, `DARK_THEME`, and `mergeTheme(base, overrides)` are exported from `@waniwani/sdk/chat` for assembling custom variable sets.
+
+#### 4. Assistant message bubble (opt-in)
+
+Assistant replies render as plain text by default. Turn them into filled bubbles — styled by `assistantBubbleColor` / `assistantBubbleTextColor`, sharing the user bubble's radius and padding — with `assistantBubble`:
+
+```js
+// embed.js
+window.WaniWani.chat.init({
+  token: "wwp_...",
+  appearance: {
+    assistantBubble: true,
+    variables: { assistantBubbleColor: "#e6f2f2", assistantBubbleTextColor: "#0b2b2e" },
+  },
+});
+```
+
+```html
+<!-- script tag -->
+<script src="…/embed.js" data-token="wwp_..." data-assistant-bubble="true"></script>
+```
+
+```tsx
+// React
+<WaniwaniChat token="wwp_..." channelId="..." overrides={{ assistantBubble: true }} />
+```
+
+Leave it unset (the default) and assistant messages stay bubble-less — existing widgets are unchanged.
+
+#### 5. Deep customization — per-slot classes
+
+Tokens cover colours, typography, and bubble shape. To restyle an element beyond what a token exposes, target it directly.
+
+**React** — pass `classNames` (type `ChatClassNames`). Each string is merged onto that slot:
+
+```tsx
+<WaniwaniChat
+  token="wwp_..."
+  channelId="..."
+  overrides={{
+    classNames: {
+      root: "my-chat",
+      header: "ww:uppercase ww:tracking-wide",
+      userBubble: "ww:shadow-md",
+      input: "ww:ring-2 ww:ring-[#0a6c74]",
+    },
+  }}
+/>
+```
+
+Slots: `root`, `header`, `message`, `userBubble`, `assistantBubble`, `input`.
+
+**Script embed** — the widget renders in a Shadow DOM, so your page's own selectors cannot reach inside. Two supported paths in:
+
+1. Set `--ww-*` variables (they inherit through the boundary) — see the table above.
+2. Inject a full stylesheet with `data-css` and target the stable semantic classes:
+
+```html
+<script
+  src="…/embed.js"
+  data-token="wwp_..."
+  data-css="https://your.site/widget.css"
+></script>
+```
+
+```css
+/* widget.css — loaded into the widget's Shadow DOM */
+.ww-header { letter-spacing: 0.02em; }
+.ww-input { box-shadow: 0 0 0 2px rgba(10, 108, 116, 0.25); }
+.ww-message-user .ww-bubble { box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
+.ww-message-assistant .ww-bubble { border: 1px solid #0a6c74; }
+```
+
+Stable hooks: `.ww-message`, `.ww-message-user`, `.ww-message-assistant`, `.ww-bubble`, `.ww-header`, `.ww-input`. These are guaranteed selectors — the internal `ww:`-prefixed Tailwind classes are not.
+
+#### What is not themeable
+
+To set expectations for a full rebrand, these are intentionally fixed today:
+
+- **Typographic scale beyond the base** — `fontSize` / `lineHeight` set the message base; per-heading sizes inside markdown and built-in label sizes/weights are not individually exposed.
+- **Floating launcher accent** — the dock's animated border-glow uses a fixed accent gradient.
+- **"Powered by" mark** — the footer logo is not removable via theming.
+
+For anything in this list, reach out — some are candidates for future tokens.
 
 ### Event tracking
 

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -250,6 +250,7 @@ The chat fits within whatever bound you set and scrolls internally — no need t
 | `data-show-tool-calls` | No | Tool-call activity rendering (grouped into one collapsible chain). `"true"` (default) — steps expandable to request/response JSON. `"titles-only"` — step labels only. `"false"` — hides the chain and the reasoning trace; only the "On it…" indicator shows |
 | `data-css` | No | URL to custom stylesheet (injected into Shadow DOM) |
 | `data-theme` | No | `"light"` (default), `"dark"`, or `"auto"` (follow `prefers-color-scheme`) |
+| `data-assistant-bubble` | No | `"true"`/`"false"` — render assistant replies in a filled, themeable bubble. Defaults to `"false"` (plain text). See [Assistant message bubble](#4-assistant-message-bubble-opt-in) |
 | `data-locale` | No | `"en"`, `"fr"`, or `"es"`. Auto-detects from `<html lang>` / `navigator.language` when omitted |
 | `data-mode` | No | `"inline"` (default) or `"floating"` — see [Floating mode](#floating-mode) |
 | `data-height` | No | Inline only. Default container height — any CSS length (`"500px"`, `"80vh"`) or a bare number (px). Defaults to `500px` |
@@ -539,7 +540,7 @@ Unset variables fall back to the preset's defaults, so you only override what yo
 | `--ww-msg-pad-y` | Message bubble padding Y | `12px` | `12px` |
 | `--ww-msg-max-width` | Message bubble max width | `80%` | `80%` |
 | `--ww-font` | Font family | system stack | system stack |
-| `--ww-font-size` | Base message font size | `16px` | `16px` |
+| `--ww-font-size` | Base message font size | `1rem` | `1rem` |
 | `--ww-line-height` | Base message line height | `1.5` | `1.5` |
 
 #### 3. Programmatic `appearance`
@@ -595,7 +596,11 @@ window.WaniWani.chat.init({
 
 ```tsx
 // React
-<WaniwaniChat token="wwp_..." channelId="..." overrides={{ assistantBubble: true }} />
+<WaniwaniChat
+  token="wwp_..."
+  channelId="..."
+  overrides={{ appearance: { assistantBubble: true } }}
+/>
 ```
 
 Leave it unset (the default) and assistant messages stay bubble-less — existing widgets are unchanged.
@@ -651,6 +656,7 @@ Stable hooks: `.ww-message`, `.ww-message-user`, `.ww-message-assistant`, `.ww-b
 To set expectations for a full rebrand, these are intentionally fixed today:
 
 - **Typographic scale beyond the base** — `fontSize` / `lineHeight` set the message base; per-heading sizes inside markdown and built-in label sizes/weights are not individually exposed.
+- **Chrome corner radii** — `messageBorderRadius` shapes message bubbles only; tool-call cards, the chain-of-thought accordion, menus, and welcome-screen buttons keep their fixed radii.
 - **Floating launcher accent** — the dock's animated border-glow uses a fixed accent gradient.
 - **"Powered by" mark** — the footer logo is not removable via theming.
 

--- a/skills/waniwani-sdk/references/upgrading.md
+++ b/skills/waniwani-sdk/references/upgrading.md
@@ -17,6 +17,16 @@ The SDK is `0.x`, so **minor bumps can contain breaking changes**. Whenever you 
 
 Deprecations (struck-through signatures, `@deprecated` JSDoc) are **not** breaking — the old shape keeps working until the removal version listed in the notice. Migrate them opportunistically, but a build does not require it.
 
+## Non-breaking additions (no migration required)
+
+These entries add capability without changing existing behavior — listed so the surface is discoverable, not because an upgrade needs action.
+
+### Chat widget customization tokens + escape hatch
+
+New `ChatTheme` tokens on `appearance.variables`: `userBubbleTextColor`, `assistantBubbleTextColor`, `messagePaddingX`, `messagePaddingY`, `messageMaxWidth`, `fontSize`, `lineHeight`. New `appearance.assistantBubble` flag (opt-in filled assistant bubble; default `false`). New React `classNames` prop (`ChatClassNames`: `root`, `header`, `message`, `userBubble`, `assistantBubble`, `input`) and stable Shadow-DOM-reachable classes for `data-css` (`.ww-message`, `.ww-message-user`, `.ww-message-assistant`, `.ww-bubble`, `.ww-header`, `.ww-input`). See `references/chat-widget.md`.
+
+One behavioral note (not a break): `messageBorderRadius` / `--ww-msg-radius` is now applied to message bubbles (it was previously inert). Its default is pinned to `8px`, which equals the value bubbles rendered before, so existing widgets are visually unchanged. Only a consumer who explicitly set `messageBorderRadius` will now see it take effect — the intended behavior.
+
 ## Currently auto-fixable breaking changes
 
 This list mirrors the changelog so you can apply migrations without a network fetch. Always cross-check against the live changelog for anything newer than this file.

--- a/src/chat/README.md
+++ b/src/chat/README.md
@@ -87,7 +87,7 @@ appearance: { theme: "dark", variables: { primaryColor: "#ff6b6b" } }
 | `messagePaddingY` | `--ww-msg-pad-y` | `12px` |
 | `messageMaxWidth` | `--ww-msg-max-width` | `80%` |
 | `fontFamily` | `--ww-font` | system stack |
-| `fontSize` | `--ww-font-size` | `16px` |
+| `fontSize` | `--ww-font-size` | `1rem` |
 | `lineHeight` | `--ww-line-height` | `1.5` |
 | `headerBackgroundColor` | `--ww-header-bg` | `#ffffff` |
 | `headerTextColor` | `--ww-header-text` | `#1f2937` |

--- a/src/chat/README.md
+++ b/src/chat/README.md
@@ -6,25 +6,42 @@ Embeddable chat widget built with Tailwind CSS, composable AI elements, and stre
 
 ```
 chat/
-├── index.ts                  # Public exports (ChatEmbed, ChatTheme, theme utils; ChatCard is @deprecated)
-├── @types.ts                 # ChatEmbedProps, ChatTheme interfaces (ChatCardProps is @deprecated)
-├── theme.ts                  # Default theme + CSS variable generation
+├── index.ts                  # Public exports (WaniwaniChat, ChatEmbed, ChatTheme, theme utils)
+├── @types.ts                 # ChatBaseProps, ChatEmbedProps, ChatTheme, ChatClassNames
+├── theme.ts                  # Default/dark themes + CSS variable generation
 ├── tailwind.css              # Tailwind theme mapping (--ww-* vars → Tailwind tokens)
+├── embed/                    # <script> IIFE embed (embed.js) + config resolution
 ├── lib/
-│   └── utils.ts              # cn() helper (clsx + tailwind-merge)
-├── ui/
-│   └── button.tsx            # Base Button component (default, outline, ghost variants)
+│   └── utils.ts              # cn() helper (clsx + tailwind-merge, ww prefix)
 ├── ai-elements/
 │   ├── conversation.tsx      # Scrollable message container (use-stick-to-bottom)
-│   ├── loader.tsx            # Bouncing dots typing indicator
-│   ├── message.tsx           # Message bubble (user/assistant) + Streamdown markdown renderer
-│   └── prompt-input.tsx      # Composable input (textarea, submit, attachments, drag & drop)
+│   ├── message.tsx           # Message wrapper + bubble content + Streamdown renderer
+│   └── prompt-input.tsx      # Composable input (textarea, submit, attachments)
 └── layouts/
-    ├── chat-card.tsx         # @deprecated — always-visible card with header
-    └── chat-embed.tsx        # Borderless, bring-your-own-backend chat (primary)
+    ├── waniwani-chat.tsx     # Hosted-tier chat (recommended)
+    └── chat-embed.tsx        # Borderless bring-your-own-backend primitive
 ```
 
+`ChatCard` is `@deprecated` and lives in `src/legacy/chat/web/chat-card.tsx`.
+
 ## Usage
+
+Hosted tier (recommended) — configure the agent in the dashboard, pass a token:
+
+```tsx
+import { WaniwaniChat } from "@waniwani/sdk/chat";
+import "@waniwani/sdk/chat/styles.css";
+
+<WaniwaniChat
+  token="wwp_..."
+  channelId="..."
+  overrides={{
+    appearance: { theme: "light", variables: { primaryColor: "#0a6c74" } },
+  }}
+/>;
+```
+
+Bring-your-own-backend primitive:
 
 ```tsx
 import { ChatEmbed } from "@waniwani/sdk/chat";
@@ -33,56 +50,68 @@ import { ChatEmbed } from "@waniwani/sdk/chat";
   api="/api/my-chat"
   title="Support"
   welcomeMessage="Hi! How can I help?"
-  theme={{ primaryColor: "#6366f1" }}
+  appearance={{ theme: "light", variables: { primaryColor: "#0a6c74" } }}
   allowAttachments
   onMessageSent={(msg) => console.log(msg)}
-/>
+/>;
 ```
-
-### Props
-
-| Prop                 | Type                          | Default                              |
-| -------------------- | ----------------------------- | ------------------------------------ |
-| `apiKey`             | `string`                      | —                                    |
-| `api`                | `string`                      | `https://app.waniwani.ai/api/chat`   |
-| `title`              | `string`                      | `"Chat"`                             |
-| `subtitle`           | `string`                      | —                                    |
-| `welcomeMessage`     | `string`                      | —                                    |
-| `theme`              | `ChatTheme`                   | see Theming                          |
-| `headers`            | `Record<string, string>`      | —                                    |
-| `body`               | `Record<string, unknown>`     | —                                    |
-| `width`              | `number`                      | `400`                                |
-| `height`             | `number`                      | `600`                                |
-| `allowAttachments`   | `boolean`                     | `false`                              |
-| `onMessageSent`      | `(message: string) => void`   | —                                    |
-| `onResponseReceived` | `() => void`                  | —                                    |
 
 ## Theming
 
-Pass a `theme` object to override any of the defaults:
+Styling is token-based. Pass `appearance` — a preset plus per-property `variables` — to the React components, `init({ appearance })` to the `<script>` embed, or set the `--ww-*` custom properties directly in your own CSS. The same shape works everywhere.
 
-| Property              | CSS Variable             | Default      |
-| --------------------- | ------------------------ | ------------ |
-| `primaryColor`        | `--ww-primary`           | `#6366f1`    |
-| `primaryForeground`   | `--ww-primary-fg`        | `#ffffff`    |
-| `backgroundColor`     | `--ww-bg`                | `#ffffff`    |
-| `textColor`           | `--ww-text`              | `#1f2937`    |
-| `mutedColor`          | `--ww-muted`             | `#6b7280`    |
-| `borderColor`         | `--ww-border`            | `#e5e7eb`    |
-| `assistantBubbleColor`| `--ww-assistant-bubble`  | `#f3f4f6`    |
-| `userBubbleColor`     | `--ww-user-bubble`       | `#6366f1`    |
-| `inputBackgroundColor`| `--ww-input-bg`          | `#f9fafb`    |
-| `borderRadius`        | `--ww-radius`            | `16px`       |
-| `messageBorderRadius` | `--ww-msg-radius`        | `12px`       |
-| `fontFamily`          | `--ww-font`              | system stack |
+```ts
+appearance: { theme: "dark", variables: { primaryColor: "#ff6b6b" } }
+```
 
-CSS variables are bridged to Tailwind tokens via `tailwind.css`, so all components use standard Tailwind classes (e.g. `bg-primary`, `text-foreground`) that resolve to the `--ww-*` values at runtime.
+### `appearance.variables` (`ChatTheme`)
+
+| Property | CSS variable | Default (light) |
+| --- | --- | --- |
+| `primaryColor` | `--ww-primary` | `#6366f1` |
+| `primaryForeground` | `--ww-primary-fg` | `#1f2937` |
+| `backgroundColor` | `--ww-bg` | `#ffffff` |
+| `textColor` | `--ww-text` | `#1f2937` |
+| `mutedColor` | `--ww-muted` | `#6b7280` |
+| `borderColor` | `--ww-border` | `#e5e7eb` |
+| `borderWidth` | `--ww-border-width` | `0` |
+| `boxShadow` | `--ww-shadow` | `none` |
+| `userBubbleColor` | `--ww-user-bubble` | `#f4f4f4` |
+| `userBubbleTextColor` | `--ww-user-bubble-text` | `#1f2937` |
+| `assistantBubbleColor` | `--ww-assistant-bubble` | `#f3f4f6` |
+| `assistantBubbleTextColor` | `--ww-assistant-bubble-text` | `#1f2937` |
+| `inputBackgroundColor` | `--ww-input-bg` | `#f9fafb` |
+| `borderRadius` | `--ww-radius` | `16px` |
+| `messageBorderRadius` | `--ww-msg-radius` | `8px` |
+| `messagePaddingX` | `--ww-msg-pad-x` | `16px` |
+| `messagePaddingY` | `--ww-msg-pad-y` | `12px` |
+| `messageMaxWidth` | `--ww-msg-max-width` | `80%` |
+| `fontFamily` | `--ww-font` | system stack |
+| `fontSize` | `--ww-font-size` | `16px` |
+| `lineHeight` | `--ww-line-height` | `1.5` |
+| `headerBackgroundColor` | `--ww-header-bg` | `#ffffff` |
+| `headerTextColor` | `--ww-header-text` | `#1f2937` |
+| `statusColor` | `--ww-status` | `#22c55e` |
+| `toolCardColor` | `--ww-tool-card` | `#f4f4f5` |
+
+CSS variables are bridged to Tailwind tokens in `tailwind.css`, so components use `ww:`-prefixed Tailwind classes that resolve to the `--ww-*` values at runtime.
+
+### `appearance.assistantBubble`
+
+Assistant messages render as plain text by default. Set `assistantBubble: true` to render them in a filled bubble styled by `assistantBubbleColor` / `assistantBubbleTextColor`, matching the user bubble's radius and padding.
+
+### Deep customization
+
+- **React** — pass `classNames` (`ChatClassNames`) to target individual slots: `root`, `header`, `message`, `userBubble`, `assistantBubble`, `input`.
+- **`<script>` embed** — the widget renders in a Shadow DOM, so host-page selectors can't reach internals. Set `--ww-*` variables (they inherit through the boundary), or inject a stylesheet with `data-css="https://.../sheet.css"` and target the stable semantic classes: `.ww-header`, `.ww-input`, `.ww-message-user .ww-bubble`, `.ww-message-assistant .ww-bubble`.
+
+See `skills/waniwani-sdk/references/chat-widget.md` for the full customization guide and script-tag options.
 
 ## Data flow
 
-1. `ChatEmbed` creates a `DefaultChatTransport` (from `ai` SDK) pointed at the chat API
-2. `useChat` (from `@ai-sdk/react`) manages message state and streaming
-3. User input → `sendMessage()` → API → streamed response → rendered via `Streamdown` markdown
-4. Tool invocations appear inline with status labels while running
-5. `Conversation` (powered by `use-stick-to-bottom`) auto-scrolls to new messages
-6. `PromptInput` supports file attachments via file picker, paste, and global drag & drop
+1. `ChatEmbed` creates a `DefaultChatTransport` (from the `ai` SDK) pointed at the chat API.
+2. `useChat` (from `@ai-sdk/react`) manages message state and streaming.
+3. User input → `sendMessage()` → API → streamed response → rendered via `Streamdown` markdown.
+4. Tool invocations group into a collapsible chain of thought; MCP App widgets render inline.
+5. The conversation auto-scrolls to new messages (`use-stick-to-bottom`).
+6. `PromptInput` supports file attachments via file picker, paste, and drag & drop.

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -50,6 +50,20 @@ export interface ChatTheme {
 	statusColor?: string;
 	/** Tool call JSON section background. Defaults to light gray / #262626 in dark. */
 	toolCardColor?: string;
+	/** Text color inside the user message bubble. Falls back to `primaryForeground`. */
+	userBubbleTextColor?: string;
+	/** Text color inside the assistant message bubble (only visible when `appearance.assistantBubble` is enabled). Falls back to `textColor`. */
+	assistantBubbleTextColor?: string;
+	/** Horizontal padding inside message bubbles (px). Defaults to 16. */
+	messagePaddingX?: number;
+	/** Vertical padding inside message bubbles (px). Defaults to 12. */
+	messagePaddingY?: number;
+	/** Max width of a message bubble as a CSS length/percentage. Defaults to `"80%"`. */
+	messageMaxWidth?: string;
+	/** Base font size for message text (px). Defaults to 16. */
+	fontSize?: number;
+	/** Base line height for message text (unitless string, e.g. `"1.5"`). Defaults to `"1.5"`. */
+	lineHeight?: string;
 }
 
 // ============================================================================
@@ -84,6 +98,28 @@ export interface SuggestionsConfig {
 	dynamic?: boolean;
 }
 
+/**
+ * Per-slot class name overrides for the chat widget. Each string is appended
+ * to the slot's own classes (merged with `tailwind-merge`, `ww` prefix). Use
+ * with your own (prefixed or plain) CSS to restyle any element. In the React
+ * path these reach into internals directly; in the `<script>` embed, prefer
+ * the stable `.ww-*` semantic classes with a `data-css` stylesheet.
+ */
+export interface ChatClassNames {
+	/** Root chat container. */
+	root?: string;
+	/** Sticky header bar. */
+	header?: string;
+	/** Every message wrapper (both roles). */
+	message?: string;
+	/** The user message bubble content. */
+	userBubble?: string;
+	/** The assistant message bubble content. */
+	assistantBubble?: string;
+	/** The input bar container. */
+	input?: string;
+}
+
 // ============================================================================
 // Shared Base Props
 // ============================================================================
@@ -110,6 +146,8 @@ export interface ChatBaseProps {
 	 * See `ChatAppearance` for the shape.
 	 */
 	appearance?: ChatAppearance;
+	/** Per-slot class name overrides. See {@link ChatClassNames}. */
+	classNames?: ChatClassNames;
 	/** Additional headers to send with chat API requests */
 	headers?: Record<string, string>;
 	/** Additional body fields to send with each chat request */

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -60,7 +60,7 @@ export interface ChatTheme {
 	messagePaddingY?: number;
 	/** Max width of a message bubble as a CSS length/percentage. Defaults to `"80%"`. */
 	messageMaxWidth?: string;
-	/** Base font size for message text (px). Defaults to 16. */
+	/** Base font size for message text (px). When unset, messages use the CSS default of `1rem` (16px at the standard root font size). */
 	fontSize?: number;
 	/** Base line height for message text (unitless string, e.g. `"1.5"`). Defaults to `"1.5"`. */
 	lineHeight?: string;

--- a/src/chat/web/__tests__/theme.test.ts
+++ b/src/chat/web/__tests__/theme.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_THEME, mergeTheme, themeToCSSProperties } from "../theme";
+
+describe("theme defaults preserve current rendering", () => {
+	test("messageBorderRadius default is 8 (matches hardcoded rounded-lg)", () => {
+		expect(DEFAULT_THEME.messageBorderRadius).toBe(8);
+	});
+});
+
+describe("themeToCSSProperties", () => {
+	test("emits --ww-msg-radius in px when set", () => {
+		const vars = themeToCSSProperties({ messageBorderRadius: 20 });
+		expect(vars["--ww-msg-radius"]).toBe("20px");
+	});
+
+	test("omits keys the user did not set", () => {
+		const vars = themeToCSSProperties({ primaryColor: "#000" });
+		expect(vars["--ww-msg-radius"]).toBeUndefined();
+		expect(vars["--ww-primary"]).toBe("#000");
+	});
+
+	test("mergeTheme fills unset keys from defaults", () => {
+		const merged = mergeTheme({ primaryColor: "#f00" });
+		expect(merged.primaryColor).toBe("#f00");
+		expect(merged.messageBorderRadius).toBe(8);
+	});
+
+	test("emits new bubble + typography vars", () => {
+		const vars = themeToCSSProperties({
+			userBubbleTextColor: "#fff",
+			assistantBubbleTextColor: "#eee",
+			messagePaddingX: 20,
+			messagePaddingY: 14,
+			messageMaxWidth: "70%",
+			fontSize: 15,
+			lineHeight: "1.6",
+		});
+		expect(vars["--ww-user-bubble-text"]).toBe("#fff");
+		expect(vars["--ww-assistant-bubble-text"]).toBe("#eee");
+		expect(vars["--ww-msg-pad-x"]).toBe("20px");
+		expect(vars["--ww-msg-pad-y"]).toBe("14px");
+		expect(vars["--ww-msg-max-width"]).toBe("70%");
+		expect(vars["--ww-font-size"]).toBe("15px");
+		expect(vars["--ww-line-height"]).toBe("1.6");
+	});
+});

--- a/src/chat/web/ai-elements/message.tsx
+++ b/src/chat/web/ai-elements/message.tsx
@@ -46,9 +46,9 @@ export const MessageContent = ({
 	<div
 		className={cn(
 			"ww-bubble ww:flex ww:w-fit ww:min-w-0 ww:max-w-full ww:flex-col ww:gap-2 ww:overflow-hidden",
-			"ww:[font-size:var(--ww-font-size,16px)] ww:[line-height:var(--ww-line-height,1.5)]",
+			"ww:[font-size:var(--ww-font-size,1rem)] ww:[line-height:var(--ww-line-height,1.5)]",
 			"ww:group-[.is-user]:ml-auto ww:group-[.is-user]:bg-user-bubble ww:group-[.is-user]:[color:var(--ww-color-user-bubble-text)] ww:group-[.is-user]:[border-radius:var(--ww-msg-radius,8px)] ww:group-[.is-user]:[padding:var(--ww-msg-pad-y,12px)_var(--ww-msg-pad-x,16px)]",
-			"ww:group-[.is-assistant]:[color:var(--ww-color-assistant-bubble-text)]",
+			"ww:group-[.is-assistant]:text-foreground",
 			className,
 		)}
 		{...props}

--- a/src/chat/web/ai-elements/message.tsx
+++ b/src/chat/web/ai-elements/message.tsx
@@ -22,10 +22,10 @@ export const Message = ({
 }: MessageProps) => (
 	<div
 		className={cn(
-			"ww:group ww:flex ww:w-full",
+			"ww-message ww:group ww:flex ww:w-full",
 			from === "user"
-				? "is-user ww:ml-auto ww:max-w-[80%] ww:flex-col ww:items-end"
-				: "is-assistant ww:flex-col",
+				? "ww-message-user is-user ww:ml-auto ww:flex-col ww:items-end ww:[max-width:var(--ww-msg-max-width,80%)]"
+				: "ww-message-assistant is-assistant ww:flex-col",
 			className,
 		)}
 		{...props}
@@ -45,9 +45,10 @@ export const MessageContent = ({
 }: MessageContentProps) => (
 	<div
 		className={cn(
-			"ww:flex ww:w-fit ww:min-w-0 ww:max-w-full ww:flex-col ww:gap-2 ww:overflow-hidden ww:text-base",
-			"ww:group-[.is-user]:ml-auto ww:group-[.is-user]:rounded-lg ww:group-[.is-user]:bg-user-bubble ww:group-[.is-user]:px-4 ww:group-[.is-user]:py-3 ww:group-[.is-user]:text-primary-foreground",
-			"ww:group-[.is-assistant]:text-foreground",
+			"ww-bubble ww:flex ww:w-fit ww:min-w-0 ww:max-w-full ww:flex-col ww:gap-2 ww:overflow-hidden",
+			"ww:[font-size:var(--ww-font-size,16px)] ww:[line-height:var(--ww-line-height,1.5)]",
+			"ww:group-[.is-user]:ml-auto ww:group-[.is-user]:bg-user-bubble ww:group-[.is-user]:[color:var(--ww-color-user-bubble-text)] ww:group-[.is-user]:[border-radius:var(--ww-msg-radius,8px)] ww:group-[.is-user]:[padding:var(--ww-msg-pad-y,12px)_var(--ww-msg-pad-x,16px)]",
+			"ww:group-[.is-assistant]:[color:var(--ww-color-assistant-bubble-text)]",
 			className,
 		)}
 		{...props}

--- a/src/chat/web/components/message-list.tsx
+++ b/src/chat/web/components/message-list.tsx
@@ -44,6 +44,7 @@ import {
 	WorkingIndicator,
 } from "../ai-elements/working-indicator";
 import { useTranslation } from "../i18n";
+import { cn } from "../lib/utils";
 import type { McpAppDisplayMode } from "./mcp-app-frame";
 import { McpAppFrame } from "./mcp-app-frame";
 import { WelcomeScreen } from "./welcome-screen";
@@ -128,6 +129,12 @@ interface MessageListProps {
 	 * `GET /api/waniwani/tools`.
 	 */
 	toolDefinitions?: ToolDefinitionsMap;
+	/** Per-slot class overrides forwarded to Message/MessageContent. */
+	messageClassNames?: {
+		message?: string;
+		userBubble?: string;
+		assistantBubble?: string;
+	};
 }
 
 export function MessageList({
@@ -146,6 +153,7 @@ export function MessageList({
 	debug,
 	showToolCalls = true,
 	toolDefinitions,
+	messageClassNames,
 }: MessageListProps) {
 	const { t } = useTranslation();
 	const lastMessage = messages[messages.length - 1];
@@ -250,7 +258,11 @@ export function MessageList({
 				}
 
 				return (
-					<Message from={message.role} key={message.id}>
+					<Message
+						from={message.role}
+						key={message.id}
+						className={messageClassNames?.message}
+					>
 						{/* Reasoning trace. Folded into the chain when one is shown
 						    (2+ tools); rendered on its own otherwise. Suppressed
 						    entirely in `hidden` mode (only "On it…" shows). */}
@@ -501,7 +513,13 @@ export function MessageList({
 						})}
 						{!containsFullscreenTool && (
 							<div>
-								<MessageContent>
+								<MessageContent
+									className={cn(
+										message.role === "user"
+											? messageClassNames?.userBubble
+											: messageClassNames?.assistantBubble,
+									)}
+								>
 									{fileParts.length > 0 && <Attachments files={fileParts} />}
 									{hasTextContent
 										? textParts.map((part, i) => {

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -385,3 +385,13 @@ describe("resolveConfig — validation", () => {
 		);
 	});
 });
+
+describe("resolveConfig — assistantBubble", () => {
+	test("carries appearance.assistantBubble through", () => {
+		const config = resolveConfig({
+			token: "tok",
+			appearance: { theme: "light", assistantBubble: true },
+		});
+		expect(config.appearance?.assistantBubble).toBe(true);
+	});
+});

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -395,3 +395,51 @@ describe("resolveConfig — assistantBubble", () => {
 		expect(config.appearance?.assistantBubble).toBe(true);
 	});
 });
+
+describe("parseConfigFromScript — data-assistant-bubble", () => {
+	test("'true' opts in", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-assistant-bubble": "true",
+		});
+		expect(cfg.appearance).toEqual({ assistantBubble: true });
+	});
+
+	test("'1' and bare attribute opt in like sibling boolean attrs", async () => {
+		const one = await parseWithAttrs({
+			"data-token": "tok",
+			"data-assistant-bubble": "1",
+		});
+		expect(one.appearance).toEqual({ assistantBubble: true });
+
+		const bare = await parseWithAttrs({
+			"data-token": "tok",
+			"data-assistant-bubble": "",
+		});
+		expect(bare.appearance).toEqual({ assistantBubble: true });
+	});
+
+	test("'false' parses to an explicit false", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-assistant-bubble": "false",
+		});
+		expect(cfg.appearance).toEqual({ assistantBubble: false });
+	});
+
+	test("unspecified leaves appearance untouched", async () => {
+		const cfg = await parseWithAttrs({ "data-token": "tok" });
+		expect(cfg.appearance).toBeUndefined();
+	});
+});
+
+describe("resolveConfig — assistantBubble precedence", () => {
+	test("script-tag false overrides remote true", () => {
+		const config = resolveConfig(
+			{ token: "tok" },
+			{ appearance: { assistantBubble: true } },
+			{ appearance: { assistantBubble: false } },
+		);
+		expect(config.appearance?.assistantBubble).toBe(false);
+	});
+});

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -339,9 +339,9 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 		config.appearance = { ...config.appearance, theme: themeRaw };
 	}
 
-	const assistantBubbleRaw = str("data-assistant-bubble");
-	if (assistantBubbleRaw === "true") {
-		config.appearance = { ...config.appearance, assistantBubble: true };
+	const assistantBubble = bool("data-assistant-bubble");
+	if (assistantBubble !== undefined) {
+		config.appearance = { ...config.appearance, assistantBubble };
 	}
 
 	const localeRaw = str("data-locale");

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -28,6 +28,13 @@ export interface ChatAppearance {
 	theme?: ThemePreset;
 	/** Per-property overrides applied on top of the preset. */
 	variables?: ChatTheme;
+	/**
+	 * Render assistant messages inside a filled bubble (background + padding +
+	 * radius), styled by `variables.assistantBubbleColor` /
+	 * `assistantBubbleTextColor`. Defaults to `false` — assistant messages
+	 * render as plain text. Opt in for a "both sides bubbled" chat style.
+	 */
+	assistantBubble?: boolean;
 }
 
 /**
@@ -329,7 +336,12 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 
 	const themeRaw = str("data-theme");
 	if (themeRaw === "light" || themeRaw === "dark" || themeRaw === "auto") {
-		config.appearance = { theme: themeRaw };
+		config.appearance = { ...config.appearance, theme: themeRaw };
+	}
+
+	const assistantBubbleRaw = str("data-assistant-bubble");
+	if (assistantBubbleRaw === "true") {
+		config.appearance = { ...config.appearance, assistantBubble: true };
 	}
 
 	const localeRaw = str("data-locale");
@@ -447,7 +459,11 @@ function mergeAppearance(
 		...(programmatic?.appearance?.variables ?? {}),
 	};
 	const hasVars = Object.keys(variables).length > 0;
-	if (!theme && !hasVars) {
+	const assistantBubble =
+		programmatic?.appearance?.assistantBubble ??
+		fromScript.appearance?.assistantBubble ??
+		remote?.appearance?.assistantBubble;
+	if (!theme && !hasVars && assistantBubble === undefined) {
 		return undefined;
 	}
 	const out: ChatAppearance = {};
@@ -456,6 +472,9 @@ function mergeAppearance(
 	}
 	if (hasVars) {
 		out.variables = variables;
+	}
+	if (assistantBubble !== undefined) {
+		out.assistantBubble = assistantBubble;
 	}
 	return out;
 }

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -66,6 +66,7 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 		const {
 			appearance,
 			className,
+			classNames,
 			allowAttachments = false,
 			welcomeMessage,
 			welcome,
@@ -91,6 +92,7 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 		// and a `prefers-color-scheme` media query in tailwind.css.
 		const preset = appearance?.theme;
 		const userVars = appearance?.variables;
+		const assistantBubble = appearance?.assistantBubble ?? false;
 
 		// `preset: dark` doesn't need its full DARK_THEME table emitted as
 		// inline vars — the `.dark [data-waniwani-chat]` rule handles the
@@ -379,6 +381,7 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 				}}
 				data-waniwani-chat=""
 				data-waniwani-layout="embed"
+				data-assistant-bubble={assistantBubble ? "true" : undefined}
 				data-color-scheme={preset === "auto" ? "auto" : undefined}
 				{...(masked ? { "data-waniwani-initializing": "" } : {})}
 				{...(isDark ? { "data-waniwani-dark": "" } : {})}
@@ -386,11 +389,15 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 					"ww:relative ww:w-full ww:h-full ww:flex ww:flex-col ww:bg-background ww:text-foreground ww:font-[family-name:var(--ww-font)] ww:overflow-hidden",
 					preset === "dark" && "dark",
 					className,
+					classNames?.root,
 				)}
 			>
 				{showHeader && (
 					<div
-						className="ww:shrink-0 ww:flex ww:items-center ww:gap-2 ww:pl-4 ww:pr-3 ww:py-3 ww:border-b ww:border-border"
+						className={cn(
+							"ww-header ww:shrink-0 ww:flex ww:items-center ww:gap-2 ww:pl-4 ww:pr-3 ww:py-3 ww:border-b ww:border-border",
+							classNames?.header,
+						)}
 						style={{
 							backgroundColor: "var(--ww-color-card-header)",
 							color: "var(--ww-color-card-header-foreground)",
@@ -450,6 +457,11 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 							debug={debug}
 							showToolCalls={showToolCalls}
 							toolDefinitions={engine.toolDefinitions}
+							messageClassNames={{
+								message: classNames?.message,
+								userBubble: classNames?.userBubble,
+								assistantBubble: classNames?.assistantBubble,
+							}}
 							onWidgetDisplayModeChange={(mode, widget) => {
 								if (mode === "fullscreen") {
 									// Read the height while the embed is still laid out inline
@@ -502,7 +514,10 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 									onSubmit={engine.handleSubmit}
 									globalDrop={allowAttachments}
 									multiple={allowAttachments}
-									className="ww:rounded-2xl ww:border-border ww:bg-input"
+									className={cn(
+										"ww-input ww:rounded-2xl ww:border-border ww:bg-input",
+										classNames?.input,
+									)}
 								>
 									<div className="ww:flex ww:items-center ww:gap-1 ww:pl-4 ww:pr-3 ww:py-2.5">
 										{allowAttachments && <PromptInputAddAttachments />}

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -3,6 +3,7 @@
 import { forwardRef, useEffect, useMemo, useState } from "react";
 import type {
 	ChatAppearance,
+	ChatClassNames,
 	ChatHandle,
 	ShowToolCalls,
 	WelcomeConfig,
@@ -68,6 +69,10 @@ export interface WaniwaniChatOverrides {
 	 * ```
 	 */
 	appearance?: ChatAppearance;
+	/** Per-slot class name overrides. See `ChatClassNames`. */
+	classNames?: ChatClassNames;
+	/** Render assistant messages in a filled bubble. Defaults to false. */
+	assistantBubble?: boolean;
 	/** Chat API URL. Defaults to `https://app.waniwani.ai/api/mcp/chat`. */
 	api?: string;
 	/** Override the MCP server URL (rarely needed). */
@@ -294,7 +299,12 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 				headers={{ Authorization: `Bearer ${config.token}` }}
 				skipRemoteConfig
 				body={body}
-				appearance={config.appearance}
+				appearance={{
+					...config.appearance,
+					assistantBubble:
+						overrides?.assistantBubble ?? config.appearance?.assistantBubble,
+				}}
+				classNames={overrides?.classNames}
 				title={config.title}
 				hideHeader={config.hideHeader}
 				welcomeMessage={config.welcomeMessage}

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -71,8 +71,6 @@ export interface WaniwaniChatOverrides {
 	appearance?: ChatAppearance;
 	/** Per-slot class name overrides. See `ChatClassNames`. */
 	classNames?: ChatClassNames;
-	/** Render assistant messages in a filled bubble. Defaults to false. */
-	assistantBubble?: boolean;
 	/** Chat API URL. Defaults to `https://app.waniwani.ai/api/mcp/chat`. */
 	api?: string;
 	/** Override the MCP server URL (rarely needed). */
@@ -299,11 +297,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 				headers={{ Authorization: `Bearer ${config.token}` }}
 				skipRemoteConfig
 				body={body}
-				appearance={{
-					...config.appearance,
-					assistantBubble:
-						overrides?.assistantBubble ?? config.appearance?.assistantBubble,
-				}}
+				appearance={config.appearance}
 				classNames={overrides?.classNames}
 				title={config.title}
 				hideHeader={config.hideHeader}

--- a/src/chat/web/stories/brand-custom.stories.tsx
+++ b/src/chat/web/stories/brand-custom.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { UIMessage } from "ai";
+import type { ChatAppearance, ChatClassNames } from "../@types";
+import { ChatEmbed } from "../layouts/chat-embed";
+
+// ============================================================================
+// Custom-brand theming stories — exercise every customization knob at once:
+// colors, typography (family + size + line height), message-bubble
+// radius/padding/max-width/text-color, the opt-in assistant bubble, and the
+// per-slot `classNames` escape hatch.
+//
+// Messages are seeded via `initialMessages` so both a user and an assistant
+// bubble render on mount — no backend round-trip needed to eyeball the theme.
+// `api` points at an unreachable mock host with `skipRemoteConfig`, so nothing
+// is fetched; the seeded conversation is all we render.
+// ============================================================================
+
+const MOCK_API = "https://brand.mock/api/chat";
+
+const SEEDED_MESSAGES: UIMessage[] = [
+	{
+		id: "u1",
+		role: "user",
+		parts: [{ type: "text", text: "Can you help me get started?" }],
+	},
+	{
+		id: "a1",
+		role: "assistant",
+		parts: [
+			{
+				type: "text",
+				text: "Absolutely — tell me what you're looking for and I'll walk you through it step by step.",
+			},
+		],
+	},
+];
+
+const BRAND_APPEARANCE: ChatAppearance = {
+	theme: "light",
+	assistantBubble: true,
+	variables: {
+		primaryColor: "#0a6c74",
+		backgroundColor: "#f7fbfb",
+		userBubbleColor: "#0a6c74",
+		userBubbleTextColor: "#ffffff",
+		assistantBubbleColor: "#e6f2f2",
+		assistantBubbleTextColor: "#0b2b2e",
+		messageBorderRadius: 20,
+		messagePaddingX: 18,
+		messagePaddingY: 12,
+		messageMaxWidth: "75%",
+		fontFamily: "Georgia, serif",
+		fontSize: 15,
+		lineHeight: "1.6",
+		headerBackgroundColor: "#0a6c74",
+		headerTextColor: "#ffffff",
+	},
+};
+
+const BRAND_CLASSNAMES: ChatClassNames = {
+	input: "ww:ring-2 ww:ring-[#0a6c74]",
+	header: "ww:uppercase ww:tracking-wide",
+};
+
+interface BrandArgs {
+	appearance?: ChatAppearance;
+	classNames?: ChatClassNames;
+}
+
+function Embed(args: BrandArgs) {
+	return (
+		<ChatEmbed
+			api={MOCK_API}
+			skipRemoteConfig
+			title="Assistant"
+			initialMessages={SEEDED_MESSAGES}
+			appearance={args.appearance}
+			classNames={args.classNames}
+		/>
+	);
+}
+
+const meta: Meta<BrandArgs> = {
+	title: "Chat/Theming — Custom Brand",
+	render: (args) => (
+		<div style={{ height: "100dvh", width: "100%" }}>
+			<Embed {...args} />
+		</div>
+	),
+	parameters: { bare: true },
+};
+
+export default meta;
+
+type Story = StoryObj<BrandArgs>;
+
+/**
+ * A full custom-brand rebrand. Verify every knob at once:
+ * - user bubble: brand fill, white text, 20px radius, 18/12 padding, ≤75% width
+ * - assistant bubble: tinted fill (opt-in ON), dark text, same shape
+ * - header: brand bg, white uppercase text (via `classNames.header`)
+ * - font: Georgia serif at 15px / 1.6 line-height
+ * - input: brand ring (via `classNames.input`)
+ */
+export const CustomBrand: Story = {
+	args: {
+		appearance: BRAND_APPEARANCE,
+		classNames: BRAND_CLASSNAMES,
+	},
+};
+
+/**
+ * Back-compat regression guard: no `appearance`, no `classNames`. The assistant
+ * message must render as plain text (NO bubble), and the user bubble must look
+ * exactly like production — grey `userBubble`, 8px radius, 12/16 padding. If an
+ * assistant background appears here, the opt-in default has regressed.
+ */
+export const DefaultLook: Story = {
+	args: {},
+};

--- a/src/chat/web/tailwind.css
+++ b/src/chat/web/tailwind.css
@@ -68,6 +68,8 @@
 	--color-card-header-foreground: #1f2937;
 	--color-status: #22c55e;
 	--color-tool-card: #f4f4f5;
+	--color-user-bubble-text: #1f2937;
+	--color-assistant-bubble-text: #1f2937;
 	--radius: 16px;
 	--font-sans: system-ui, -apple-system, "Segoe UI", sans-serif;
 }
@@ -194,6 +196,17 @@
 	--ww-color-tool-card: var(--ww-tool-card, #f4f4f5);
 	--ww-radius: var(--ww-radius, 16px);
 	--ww-font-sans: var(--ww-font, system-ui, -apple-system, "Segoe UI", sans-serif);
+	--ww-color-user-bubble-text: var(--ww-user-bubble-text, var(--ww-color-primary-foreground));
+	--ww-color-assistant-bubble-text: var(--ww-assistant-bubble-text, var(--ww-color-foreground));
+	--ww-msg-radius: var(--ww-msg-radius, 8px);
+	--ww-msg-pad-x: var(--ww-msg-pad-x, 16px);
+	--ww-msg-pad-y: var(--ww-msg-pad-y, 12px);
+	--ww-msg-max-width: var(--ww-msg-max-width, 80%);
+	--ww-font-size: var(--ww-font-size, 16px);
+	--ww-line-height: var(--ww-line-height, 1.5);
+	font-family: var(--ww-font-sans);
+	font-size: var(--ww-font-size);
+	line-height: var(--ww-line-height);
 
 	/* Frosted-glass tint for the floating bar's suggestion card. Neutral by
 	   default — not white, a soft translucent surface that reads over any
@@ -209,6 +222,19 @@
 	border-width: var(--ww-border-width, 0);
 	border-color: var(--ww-color-border);
 	box-shadow: var(--ww-shadow, none);
+}
+
+/* Opt-in assistant bubble. Off by default (assistant messages are plain
+   text). When `appearance.assistantBubble` is true the host stamps
+   `data-assistant-bubble="true"` and assistant bubbles get a filled surface
+   styled by --ww-assistant-bubble / --ww-assistant-bubble-text. */
+[data-waniwani-chat][data-assistant-bubble="true"] .ww-message-assistant .ww-bubble {
+	background: var(--ww-color-accent);
+	color: var(--ww-color-assistant-bubble-text);
+	border-radius: var(--ww-msg-radius, 8px);
+	padding: var(--ww-msg-pad-y, 12px) var(--ww-msg-pad-x, 16px);
+	width: fit-content;
+	max-width: var(--ww-msg-max-width, 80%);
 }
 
 .dark [data-waniwani-chat],
@@ -229,6 +255,8 @@
 	--ww-color-card-header-foreground: var(--ww-header-text, #ececec);
 	--ww-color-status: var(--ww-status, #22c55e);
 	--ww-color-tool-card: var(--ww-tool-card, #262626);
+	--ww-color-user-bubble-text: var(--ww-user-bubble-text, #ffffff);
+	--ww-color-assistant-bubble-text: var(--ww-assistant-bubble-text, var(--ww-color-foreground));
 	--ww-glass: rgba(40, 42, 52, 0.5);
 	--ww-glass-border: rgba(255, 255, 255, 0.12);
 }
@@ -254,6 +282,8 @@
 		--ww-color-card-header-foreground: var(--ww-header-text, #ececec);
 		--ww-color-status: var(--ww-status, #22c55e);
 		--ww-color-tool-card: var(--ww-tool-card, #262626);
+		--ww-color-user-bubble-text: var(--ww-user-bubble-text, #ffffff);
+		--ww-color-assistant-bubble-text: var(--ww-assistant-bubble-text, var(--ww-color-foreground));
 		--ww-glass: rgba(40, 42, 52, 0.5);
 		--ww-glass-border: rgba(255, 255, 255, 0.12);
 	}

--- a/src/chat/web/tailwind.css
+++ b/src/chat/web/tailwind.css
@@ -198,15 +198,6 @@
 	--ww-font-sans: var(--ww-font, system-ui, -apple-system, "Segoe UI", sans-serif);
 	--ww-color-user-bubble-text: var(--ww-user-bubble-text, var(--ww-color-primary-foreground));
 	--ww-color-assistant-bubble-text: var(--ww-assistant-bubble-text, var(--ww-color-foreground));
-	--ww-msg-radius: var(--ww-msg-radius, 8px);
-	--ww-msg-pad-x: var(--ww-msg-pad-x, 16px);
-	--ww-msg-pad-y: var(--ww-msg-pad-y, 12px);
-	--ww-msg-max-width: var(--ww-msg-max-width, 80%);
-	--ww-font-size: var(--ww-font-size, 16px);
-	--ww-line-height: var(--ww-line-height, 1.5);
-	font-family: var(--ww-font-sans);
-	font-size: var(--ww-font-size);
-	line-height: var(--ww-line-height);
 
 	/* Frosted-glass tint for the floating bar's suggestion card. Neutral by
 	   default — not white, a soft translucent surface that reads over any

--- a/src/chat/web/theme.ts
+++ b/src/chat/web/theme.ts
@@ -13,12 +13,19 @@ export const DEFAULT_THEME: Required<ChatTheme> = {
 	userBubbleColor: "#f4f4f4",
 	inputBackgroundColor: "#f9fafb",
 	borderRadius: 16,
-	messageBorderRadius: 12,
+	messageBorderRadius: 8,
 	fontFamily: "system-ui, -apple-system, 'Segoe UI', sans-serif",
 	headerBackgroundColor: "#ffffff",
 	headerTextColor: "#1f2937",
 	statusColor: "#22c55e",
 	toolCardColor: "#f4f4f5",
+	userBubbleTextColor: "#1f2937",
+	assistantBubbleTextColor: "#1f2937",
+	messagePaddingX: 16,
+	messagePaddingY: 12,
+	messageMaxWidth: "80%",
+	fontSize: 16,
+	lineHeight: "1.5",
 };
 
 export const DARK_THEME: ChatTheme = {
@@ -35,6 +42,8 @@ export const DARK_THEME: ChatTheme = {
 	primaryColor: "#6366f1",
 	statusColor: "#22c55e",
 	toolCardColor: "#262626",
+	userBubbleTextColor: "#ffffff",
+	assistantBubbleTextColor: "#ececec",
 };
 
 const CSS_VAR_MAP: Record<keyof ChatTheme, string[]> = {
@@ -60,6 +69,13 @@ const CSS_VAR_MAP: Record<keyof ChatTheme, string[]> = {
 	headerTextColor: ["--ww-header-text"],
 	statusColor: ["--ww-status"],
 	toolCardColor: ["--ww-tool-card", "--ww-color-tool-card"],
+	userBubbleTextColor: ["--ww-user-bubble-text"],
+	assistantBubbleTextColor: ["--ww-assistant-bubble-text"],
+	messagePaddingX: ["--ww-msg-pad-x"],
+	messagePaddingY: ["--ww-msg-pad-y"],
+	messageMaxWidth: ["--ww-msg-max-width"],
+	fontSize: ["--ww-font-size"],
+	lineHeight: ["--ww-line-height"],
 };
 
 export function mergeTheme(userTheme?: ChatTheme): Required<ChatTheme> {

--- a/src/legacy/chat/web/chat-card.tsx
+++ b/src/legacy/chat/web/chat-card.tsx
@@ -92,7 +92,9 @@ export const ChatCard = forwardRef<ChatHandle, ChatCardProps>(
 		);
 
 		const resolvedTheme = mergeTheme(userTheme);
-		const cssVars = themeToCSSProperties(resolvedTheme);
+		// Emit only user-set keys so the stylesheet fallback chains stay live
+		// (e.g. bubble text ← primaryForeground); defaults come from tailwind.css.
+		const cssVars = themeToCSSProperties(userTheme ?? {});
 		// Legacy heuristic: dark when the background's perceived luminance is low.
 		// New code uses the explicit `appearance.theme` preset instead.
 		const hex = resolvedTheme.backgroundColor.replace("#", "");


### PR DESCRIPTION
Adds a full theming/customization layer to the chat widget across **both embed paths** (script + React), with defaults pinned so existing widgets are visually unchanged.

## What's added
- **Message-bubble theming** — `messageBorderRadius` / `--ww-msg-radius` now actually applies to bubbles (it was declared but inert; default pinned to `8px` = the prior hardcoded `rounded-lg`). New tokens: `userBubbleTextColor`, `assistantBubbleTextColor`, `messagePaddingX/Y`, `messageMaxWidth`.
- **Typography** — new `fontSize` and `lineHeight` tokens on top of the existing `fontFamily`, wired to a base size/line-height on the root.
- **Opt-in assistant bubble** — `appearance.assistantBubble` (script `data-assistant-bubble` / React override) renders assistant messages in a filled, themeable bubble. Off by default.
- **Deep customization** — React per-slot `classNames` prop (`ChatClassNames`: root/header/message/userBubble/assistantBubble/input) and stable, un-prefixed `.ww-*` semantic classes (`.ww-message*`, `.ww-bubble`, `.ww-header`, `.ww-input`) that are reachable through the Shadow DOM via a `data-css` stylesheet.
- **Hosted component** — `classNames` + `assistantBubble` surfaced on `WaniwaniChat` overrides.

## Changes
- `theme.ts` / `@types.ts` — new `ChatTheme` tokens + `ChatClassNames`.
- `tailwind.css` — resolve the new `--ww-*` vars; base font-size/line-height on the root; opt-in assistant-bubble rule keyed on `[data-assistant-bubble="true"]`.
- `message.tsx` — var-driven bubble radius/padding/max-width/text-color; plain-literal `.ww-message*` / `.ww-bubble` hooks.
- `config.ts` / `chat-embed.tsx` / `waniwani-chat.tsx` / `message-list.tsx` — `appearance.assistantBubble` plumbing, per-slot `classNames`, `.ww-header` / `.ww-input` hooks.
- **Docs** — rewrote the stale `src/chat/README.md`; expanded `references/chat-widget.md` (recipes for all embed paths, opt-in bubble, deep customization, and an explicit list of what remains non-themeable); non-breaking note in `upgrading.md`.
- **Tests** — theme serializer + config resolution coverage; Storybook rebrand and default-look regression stories.

## Back-compat
Fully additive/opt-in. The assistant bubble is off by default and every new default byte-matches the value bubbles rendered before, so there is no visual regression.

## Verification
- Test suite passes including the new cases. (Two pre-existing `useChatEngine` thread-history failures also fail on `main` — unrelated.)
- Typecheck clean apart from the pre-existing missing-`@storybook/react-vite` dev-dep errors in `*.stories.tsx`.
- CSS builds; semantic hooks confirmed present in the compiled JS.