### PR TITLE
feat(chat): host-page widget event subscription via onEvent

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -749,6 +749,61 @@ const chat = useRef<ChatHandle>(null);
 
 `track` is the same `TrackFn` as everywhere else: callable with a typed event (`track({ event: "link.clicked", properties: { url } })`) plus the flat revenue helpers. `track` and `identify` are **absent on the bare `ChatEmbed`** primitive, which holds no Waniwani credential. See [events.md](./events.md) for the taxonomy.
 
+### Mirroring events into your own analytics (`onEvent`)
+
+Both hosted surfaces accept an `onEvent` callback — `WaniWani.chat.init({ onEvent })` on the `<script>` embed and `<WaniwaniChat onEvent={...} />` in React — fired on every chat lifecycle event. The embed mounts in the host page's DOM (the shadow root isolates styles only), so the callback runs in the page's own JS context: forward events straight into `window.amplitude`, `window.analytics`, or `gtag` and the page-side SDK's identity is attached automatically, with no server-side identity plumbing.
+
+| Event | Fired when | Extra `properties` |
+|-------|-----------|--------------------|
+| `chat.ready` | Widget mounted and config resolved, or the readiness timeout elapses (all modes; fires even on pages where visibility rules hide the floating bar) | — |
+| `chat.opened` | Full chat panel opened (floating mode only; the collapsed dock does not count) | — |
+| `chat.closed` | Full chat panel closed (floating mode only; a page-gate hiding an open panel also emits this) | — |
+| `message.sent` | The visitor (or the imperative API, e.g. `sendMessage`) submits a message (never includes the message text) | — |
+| `message.received` | Assistant reply finished (never includes the message text) | — |
+| `session.started` | Server assigned the session id on the first exchange (restored threads don't re-fire) | `{ sessionId }` |
+| `thread.changed` | Thread created or switched (requires thread history) | `{ threadId }` |
+| `chat.error` | Chat request failed | `{ message }` (truncated to 200 chars) |
+| `suggestion.clicked` | Suggestion pill or welcome card clicked (dock pills, in-chat pills, welcome cards) | `{ text, index }` (`index` is `-1` when the origin is unknown) |
+| `link.clicked` | Anchor clicked inside the conversation | `{ url }` (absolute URL) |
+
+Do not assume `chat.opened` precedes the first `message.sent`: a send from the docked bar opens the panel and sends in one action, and the open transition is reported after the send.
+
+Every callback receives a `WidgetEvent` (exported from `@waniwani/sdk/chat`, alongside `WidgetEventName` and `WidgetMode`) — a discriminated union on `name` with a top-level `mode` (`"inline" | "floating"`), an optional `sessionId` (`undefined` until the server assigns one on the first exchange), a `timestamp` in epoch milliseconds, and the per-event `properties` from the table above. `<WaniwaniChat>` reports `"inline"` — it is an in-page mount, and this is the same `mode` tag its server-side events (chat requests, `page.viewed`) carry, so both streams correlate.
+
+Event names are neutral and fixed; map them to your own schema inside the callback:
+
+```html
+<script src="https://app.waniwani.ai/embed.js" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const names = {
+      "chat.opened": "chat_opened",
+      "chat.closed": "chat_closed",
+      "message.sent": "user_message",
+      "message.received": "bot_message",
+    };
+    WaniWani.chat.init({
+      token: "wwp_...",
+      mode: "floating",
+      onEvent: (event) => {
+        window.amplitude.track(names[event.name] || event.name, {
+          page: window.location.pathname,
+          sessionId: event.sessionId,
+        });
+      },
+    });
+  });
+</script>
+```
+
+Notes:
+
+- **Programmatic-only on the script embed.** A function cannot be expressed as a `data-*` attribute, so `onEvent` has no declarative equivalent — pass it to `WaniWani.chat.init()`.
+- **Exceptions are swallowed.** An error thrown by your callback is caught and logged as a console warning; it never breaks the widget.
+- **Privacy.** Message content never passes through this channel — the host learns *that* a message was exchanged, never what was said. Suggestion text is operator-authored config, so `suggestion.clicked` may carry it.
+- **Separate from the `track()` taxonomy.** Some `onEvent` names (`session.started`, `link.clicked`) also exist as event names in the hosted `track()` funnel taxonomy ([events.md](./events.md)) — same concepts, but a separate client-side channel with different payload shapes. `onEvent` events are not `client.track()` events, do not feed the platform funnel dashboard, and should not be forwarded into `client.track()` as-is even where names coincide.
+- **`ChatEmbed` does not expose `onEvent`** — like `track`/`identify`, it is a hosted-surface feature.
+
 ## `ChatEmbed` (advanced)
 
 **Most apps should use `WaniwaniChat` or the `<script>` embed.** `ChatEmbed` is the bare-bones primitive underneath both of them: no token, no remote config, no defaults, no built-in MCP resource endpoint. You wire up `api`, `headers`, `body`, `theme`, and (optionally) `mcp` yourself.

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -761,7 +761,7 @@ Both hosted surfaces accept an `onEvent` callback — `WaniWani.chat.init({ onEv
 | `message.sent` | The visitor (or the imperative API, e.g. `sendMessage`) submits a message (never includes the message text) | — |
 | `message.received` | Assistant reply finished (never includes the message text) | — |
 | `session.started` | Server assigned the session id on the first exchange (restored threads don't re-fire) | `{ sessionId }` |
-| `thread.changed` | Thread created or switched (requires thread history) | `{ threadId }` |
+| `thread.changed` | Thread created or switched (requires thread history; the top-level `sessionId` is the target thread's session, `undefined` for a fresh thread) | `{ threadId }` |
 | `chat.error` | Chat request failed | `{ message }` (truncated to 200 chars) |
 | `suggestion.clicked` | Suggestion pill or welcome card clicked (dock pills, in-chat pills, welcome cards) | `{ text, index }` (`index` is `-1` when the origin is unknown) |
 | `link.clicked` | Anchor clicked inside the conversation | `{ url }` (absolute URL) |

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -157,6 +157,24 @@ describe("resolveConfig — render mode", () => {
 	});
 });
 
+describe("resolveConfig — onEvent", () => {
+	test("programmatic onEvent survives the layered merge", () => {
+		const onEvent = () => {};
+		const config = resolveConfig(
+			{ token: "tok", onEvent },
+			{ title: "Remote" },
+			{},
+		);
+		expect(config.onEvent).toBe(onEvent);
+		expect(config.title).toBe("Remote");
+	});
+
+	test("onEvent is undefined by default", () => {
+		const config = resolveConfig({ token: "tok" });
+		expect(config.onEvent).toBeUndefined();
+	});
+});
+
 async function parseWithAttrs(
 	attrs: Record<string, string>,
 ): Promise<Record<string, unknown>> {

--- a/src/chat/web/embed/__tests__/widget-events.test.ts
+++ b/src/chat/web/embed/__tests__/widget-events.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+
+import type { WidgetEvent } from "../widget-events";
+import {
+	createNoopWidgetEventEmitter,
+	createWidgetEventEmitter,
+} from "../widget-events";
+
+describe("createWidgetEventEmitter", () => {
+	test("enriches events with mode, timestamp and live sessionId", () => {
+		let sessionId: string | undefined;
+		const emitter = createWidgetEventEmitter({
+			mode: "floating",
+			getSessionId: () => sessionId,
+		});
+		const received: WidgetEvent[] = [];
+		emitter.subscribe((e) => received.push(e));
+
+		emitter.emit({ name: "chat.opened" });
+		sessionId = "sess_1";
+		emitter.emit({ name: "message.received" });
+
+		expect(received).toHaveLength(2);
+		expect(received[0]?.name).toBe("chat.opened");
+		expect(received[0]?.mode).toBe("floating");
+		expect(received[0]?.sessionId).toBeUndefined();
+		expect(typeof received[0]?.timestamp).toBe("number");
+		expect(received[1]?.sessionId).toBe("sess_1");
+	});
+
+	test("explicit sessionId on emit wins over the getter", () => {
+		const emitter = createWidgetEventEmitter({
+			mode: "inline",
+			getSessionId: () => "sess_old",
+		});
+		const received: WidgetEvent[] = [];
+		emitter.subscribe((e) => received.push(e));
+
+		emitter.emit({
+			name: "session.started",
+			sessionId: "sess_new",
+			properties: { sessionId: "sess_new" },
+		});
+
+		expect(received[0]?.sessionId).toBe("sess_new");
+		expect(received[0]?.name).toBe("session.started");
+		if (received[0]?.name === "session.started") {
+			expect(received[0].properties.sessionId).toBe("sess_new");
+		}
+	});
+
+	test("supports multiple subscribers and unsubscribe", () => {
+		const emitter = createWidgetEventEmitter({ mode: "floating" });
+		const a: string[] = [];
+		const b: string[] = [];
+		const unsubA = emitter.subscribe((e) => a.push(e.name));
+		emitter.subscribe((e) => b.push(e.name));
+
+		emitter.emit({ name: "chat.ready" });
+		unsubA();
+		emitter.emit({ name: "message.sent" });
+
+		expect(a).toEqual(["chat.ready"]);
+		expect(b).toEqual(["chat.ready", "message.sent"]);
+	});
+
+	test("unsubscribing a peer during emit keeps the in-flight snapshot intact", () => {
+		const emitter = createWidgetEventEmitter({ mode: "inline" });
+		const received: string[] = [];
+		let unsubPeer = () => {};
+		emitter.subscribe(() => {
+			unsubPeer();
+		});
+		unsubPeer = emitter.subscribe((e) => received.push(e.name));
+
+		emitter.emit({ name: "chat.ready" });
+		emitter.emit({ name: "message.sent" });
+
+		expect(received).toEqual(["chat.ready"]);
+	});
+
+	test("subscribing during emit defers the new listener to the next emit", () => {
+		const emitter = createWidgetEventEmitter({ mode: "inline" });
+		const received: string[] = [];
+		let lateAttached = false;
+		emitter.subscribe(() => {
+			if (!lateAttached) {
+				lateAttached = true;
+				emitter.subscribe((e) => received.push(e.name));
+			}
+		});
+
+		emitter.emit({ name: "chat.ready" });
+		emitter.emit({ name: "message.sent" });
+
+		expect(received).toEqual(["message.sent"]);
+	});
+
+	test("double-calling an unsubscribe function is a safe no-op", () => {
+		const emitter = createWidgetEventEmitter({ mode: "inline" });
+		const received: string[] = [];
+		const unsub = emitter.subscribe(() => {});
+		emitter.subscribe((e) => received.push(e.name));
+
+		unsub();
+		expect(() => unsub()).not.toThrow();
+		emitter.emit({ name: "chat.ready" });
+
+		expect(received).toEqual(["chat.ready"]);
+	});
+
+	test("session.started derives its top-level id from properties", () => {
+		const emitter = createWidgetEventEmitter({
+			mode: "inline",
+			getSessionId: () => "sess_stale",
+		});
+		const received: WidgetEvent[] = [];
+		emitter.subscribe((e) => received.push(e));
+
+		emitter.emit({
+			name: "session.started",
+			properties: { sessionId: "sess_fresh" },
+		});
+
+		expect(received[0]?.sessionId).toBe("sess_fresh");
+	});
+
+	test("a throwing subscriber never breaks the emit nor other subscribers", () => {
+		const emitter = createWidgetEventEmitter({ mode: "inline" });
+		const received: string[] = [];
+		emitter.subscribe(() => {
+			throw new Error("host page bug");
+		});
+		emitter.subscribe((e) => received.push(e.name));
+
+		expect(() => emitter.emit({ name: "message.received" })).not.toThrow();
+		expect(received).toEqual(["message.received"]);
+	});
+
+	test("detail events carry their typed properties", () => {
+		const emitter = createWidgetEventEmitter({ mode: "inline" });
+		const received: WidgetEvent[] = [];
+		emitter.subscribe((e) => received.push(e));
+
+		emitter.emit({
+			name: "suggestion.clicked",
+			properties: { text: "What are your prices?", index: 2 },
+		});
+		emitter.emit({
+			name: "link.clicked",
+			properties: { url: "https://x.dev" },
+		});
+		emitter.emit({ name: "chat.error", properties: { message: "boom" } });
+		emitter.emit({ name: "thread.changed", properties: { threadId: "t1" } });
+
+		expect(received.map((e) => e.name)).toEqual([
+			"suggestion.clicked",
+			"link.clicked",
+			"chat.error",
+			"thread.changed",
+		]);
+		if (received[0]?.name === "suggestion.clicked") {
+			expect(received[0].properties).toEqual({
+				text: "What are your prices?",
+				index: 2,
+			});
+		}
+	});
+});
+
+describe("createNoopWidgetEventEmitter", () => {
+	test("emit and subscribe are inert and safe", () => {
+		const emitter = createNoopWidgetEventEmitter();
+		const unsub = emitter.subscribe(() => {
+			throw new Error("never called");
+		});
+		expect(() => emitter.emit({ name: "chat.ready" })).not.toThrow();
+		expect(() => unsub()).not.toThrow();
+	});
+});

--- a/src/chat/web/embed/__tests__/widget-events.test.ts
+++ b/src/chat/web/embed/__tests__/widget-events.test.ts
@@ -109,6 +109,24 @@ describe("createWidgetEventEmitter", () => {
 		expect(received).toEqual(["chat.ready"]);
 	});
 
+	test("an explicit undefined sessionId suppresses the live getter", () => {
+		const emitter = createWidgetEventEmitter({
+			mode: "inline",
+			getSessionId: () => "sess_stale",
+		});
+		const received: WidgetEvent[] = [];
+		emitter.subscribe((e) => received.push(e));
+
+		emitter.emit({
+			name: "thread.changed",
+			sessionId: undefined,
+			properties: { threadId: "t1" },
+		});
+
+		expect(received).toHaveLength(1);
+		expect(received[0]?.sessionId).toBeUndefined();
+	});
+
 	test("session.started derives its top-level id from properties", () => {
 		const emitter = createWidgetEventEmitter({
 			mode: "inline",

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -6,6 +6,7 @@ import type { ChatTheme } from "../@types";
 import type { Locale } from "../i18n";
 import type { VisitorIdInput } from "../lib/visitor-context";
 import type { VisibilityRules } from "./visibility";
+import type { WidgetEvent } from "./widget-events";
 
 /**
  * Built-in theme presets. `auto` follows the host's `prefers-color-scheme`
@@ -197,6 +198,19 @@ export interface EmbedConfig {
 	 * `"floating"`.
 	 */
 	visibility?: VisibilityRules;
+	/**
+	 * Host-page callback fired on chat lifecycle events (`chat.ready`,
+	 * `chat.opened`/`chat.closed` in floating mode, `message.sent`,
+	 * `message.received`, `session.started`, `thread.changed`, `chat.error`,
+	 * `suggestion.clicked`, `link.clicked`). Message events never include the
+	 * message text. The embed runs in the host page's DOM, so the callback can
+	 * forward events directly into the page's analytics.
+	 *
+	 * Programmatic-only: a function cannot be expressed as a `data-*`
+	 * attribute, so pass it to `WaniWani.chat.init()`. Exceptions thrown by
+	 * the callback are swallowed and never break the widget.
+	 */
+	onEvent?: (event: WidgetEvent) => void;
 }
 
 /** Fallback height applied to an inline embed container with no author sizing. */

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -40,6 +40,8 @@ import { useRemoteEmbedConfig } from "./remote-config";
 import { usePathname, useVisibilityGate } from "./use-pathname";
 import { useScrollAppearance } from "./use-scroll-appearance";
 import { appearTriggerForPath } from "./visibility";
+import { createWidgetEventEmitter } from "./widget-events";
+import { WidgetEventsProvider } from "./widget-events-context";
 
 /** Default delay before the docked input animates into view on load. */
 const DEFAULT_APPEAR_DELAY_MS = 2000;
@@ -119,6 +121,23 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 		const scrolledPast = useScrollAppearance(appearAfter);
 
 		const chatRef = useRef<ChatHandle>(null);
+		// One emitter per mount. The session id getter reads through the chat
+		// handle so events pick up the server-assigned id as soon as it exists.
+		const widgetEvents = useMemo(
+			() =>
+				createWidgetEventEmitter({
+					mode: "floating",
+					getSessionId: () => chatRef.current?.sessionId,
+				}),
+			[],
+		);
+		const onEvent = config.onEvent;
+		useEffect(() => {
+			if (!onEvent) {
+				return;
+			}
+			return widgetEvents.subscribe(onEvent);
+		}, [onEvent, widgetEvents]);
 		const composerInputRef = useRef<HTMLInputElement>(null);
 		const dockRef = useRef<HTMLDivElement>(null);
 		// Set when the visitor manually collapses the expanded card (close button)
@@ -217,6 +236,31 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 				chatRef.current?.focus();
 			}
 		}, [focusNonce, phase]);
+
+		// `chat.ready` once the remote config has resolved.
+		const readyEmittedRef = useRef(false);
+		useEffect(() => {
+			if (ready && !readyEmittedRef.current) {
+				readyEmittedRef.current = true;
+				widgetEvents.emit({ name: "chat.ready" });
+			}
+		}, [ready, widgetEvents]);
+
+		// Open/close transitions. Watching `phase` covers every path that opens
+		// or closes the panel: dock focus, suggestion click, the imperative API,
+		// the header collapse button. The docked and expanded-dock states both
+		// count as "closed"; only the full panel is "open". `visible` folds the
+		// per-URL gate in, so a panel hidden by an SPA route change reports
+		// `chat.closed` — events reflect what is on screen. No event on mount.
+		const wasOpenRef = useRef(false);
+		useEffect(() => {
+			const isOpen = visible && phase === "open";
+			if (isOpen === wasOpenRef.current) {
+				return;
+			}
+			wasOpenRef.current = isOpen;
+			widgetEvents.emit({ name: isOpen ? "chat.opened" : "chat.closed" });
+		}, [visible, phase, widgetEvents]);
 
 		const openPanel = useCallback(() => {
 			setPhase("open");
@@ -338,192 +382,203 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 		return (
 			// `display: contents` wrapper carries the theme vars (via
 			// `data-waniwani-chat`) and dark class to the dock + panel.
-			<div
-				data-waniwani-chat=""
-				data-color-scheme={preset === "auto" ? "auto" : undefined}
-				className={cn(
-					"ww:contents ww:font-[family-name:var(--ww-font-sans)]",
-					preset === "dark" && "dark",
-				)}
-				style={cssVars}
-			>
-				{visible && (
-					<>
-						{/* Docked composer — animates in after the appear delay. Narrow
+			<WidgetEventsProvider value={widgetEvents}>
+				<div
+					data-waniwani-chat=""
+					data-color-scheme={preset === "auto" ? "auto" : undefined}
+					className={cn(
+						"ww:contents ww:font-[family-name:var(--ww-font-sans)]",
+						preset === "dark" && "dark",
+					)}
+					style={cssVars}
+				>
+					{visible && (
+						<>
+							{/* Docked composer — animates in after the appear delay. Narrow
 						    at rest; widens (and reveals the CTAs) once clicked. */}
-						<div
-							ref={dockRef}
-							data-waniwani-floating="dock"
-							data-state={phase === "open" ? "hidden" : "shown"}
-							data-appeared={appeared ? "true" : "false"}
-							className={cn(
-								"ww:fixed ww:bottom-3 ww:sm:bottom-4 ww:left-0 ww:right-0 ww:mx-auto ww:z-[2147483002] ww:flex ww:flex-col",
-								"ww:w-[calc(100vw-2rem)] ww:transition-[max-width] ww:duration-300 ww:ease-out",
-								showCard ? "ww:max-w-[720px]" : "ww:max-w-[440px]",
-							)}
-						>
-							{/* Frosted-glass card around the input. It only materializes
+							<div
+								ref={dockRef}
+								data-waniwani-floating="dock"
+								data-state={phase === "open" ? "hidden" : "shown"}
+								data-appeared={appeared ? "true" : "false"}
+								className={cn(
+									"ww:fixed ww:bottom-3 ww:sm:bottom-4 ww:left-0 ww:right-0 ww:mx-auto ww:z-[2147483002] ww:flex ww:flex-col",
+									"ww:w-[calc(100vw-2rem)] ww:transition-[max-width] ww:duration-300 ww:ease-out",
+									showCard ? "ww:max-w-[720px]" : "ww:max-w-[440px]",
+								)}
+							>
+								{/* Frosted-glass card around the input. It only materializes
 							    once the dock is expanded/open (the visitor clicked the bar);
 							    at rest the wrapper is invisible (no fill/border/padding) so
 							    the input looks exactly like the standalone bar. The tint is
 							    the theme's brand color at low alpha — not white — so it reads
 							    as intentional glass and the host page shows through it. */}
-							<div
-								className={cn(
-									"ww:relative ww:flex ww:flex-col ww:rounded-[20px] ww:border ww:transition-all ww:duration-300 ww:ease-out",
-									showCard
-										? "ww:p-2 ww:backdrop-blur-xl ww:backdrop-saturate-150"
-										: "ww:border-transparent ww:p-0",
-								)}
-								style={
-									showCard
-										? {
-												boxShadow: cardShadow,
-												backgroundColor: "var(--ww-glass)",
-												borderColor: "var(--ww-glass-border)",
-											}
-										: undefined
-								}
-							>
-								{/* Close (X) in the card's top-right — collapses the expanded
+								<div
+									className={cn(
+										"ww:relative ww:flex ww:flex-col ww:rounded-[20px] ww:border ww:transition-all ww:duration-300 ww:ease-out",
+										showCard
+											? "ww:p-2 ww:backdrop-blur-xl ww:backdrop-saturate-150"
+											: "ww:border-transparent ww:p-0",
+									)}
+									style={
+										showCard
+											? {
+													boxShadow: cardShadow,
+													backgroundColor: "var(--ww-glass)",
+													borderColor: "var(--ww-glass-border)",
+												}
+											: undefined
+									}
+								>
+									{/* Close (X) in the card's top-right — collapses the expanded
 								    card back to just the docked input, so the visitor can read
 								    only their own text. Clicking the bar again brings the CTAs
 								    back. Only while expanded; the open panel has its own header
 								    collapse control (`closeButton` via `headerActions`). */}
-								{showCard && phase !== "open" && (
-									<button
-										type="button"
-										onClick={collapse}
-										aria-label={t.launcher.close}
-										className="ww:absolute ww:right-2 ww:top-2 ww:z-10 ww:flex ww:size-7 ww:items-center ww:justify-center ww:rounded-md ww:text-muted-foreground ww:transition-colors hover:ww:bg-accent hover:ww:text-foreground ww:cursor-pointer"
-									>
-										<XIcon className="ww:size-4" />
-									</button>
-								)}
+									{showCard && phase !== "open" && (
+										<button
+											type="button"
+											onClick={collapse}
+											aria-label={t.launcher.close}
+											className="ww:absolute ww:right-2 ww:top-2 ww:z-10 ww:flex ww:size-7 ww:items-center ww:justify-center ww:rounded-md ww:text-muted-foreground ww:transition-colors hover:ww:bg-accent hover:ww:text-foreground ww:cursor-pointer"
+										>
+											<XIcon className="ww:size-4" />
+										</button>
+									)}
 
-								{suggestions.length > 0 && (
-									// The card grows straight up to reveal the pills: a
-									// `grid-rows` 0fr → 1fr height animation (eases to the pills'
-									// real height — no `max-h` guessing, no scale, so it rises
-									// vertically rather than diagonally) plus a fade. Anchored at
-									// the bottom of the screen, so the growth pushes upward.
-									<div
-										className={cn(
-											"ww:grid ww:transition-all ww:duration-300 ww:ease-out",
-											suggestionsVisible
-												? "ww:grid-rows-[1fr] ww:opacity-100"
-												: "ww:pointer-events-none ww:grid-rows-[0fr] ww:opacity-0",
-										)}
-									>
-										<div className="ww:overflow-hidden">
-											<Suggestions
-												suggestions={suggestions}
-												onSelect={openWith}
-												// Right padding keeps the top row of pills clear of the
-												// absolutely-positioned close button in the corner.
-												className="ww:pl-1 ww:pr-9 ww:pt-1 ww:pb-2.5"
-											/>
+									{suggestions.length > 0 && (
+										// The card grows straight up to reveal the pills: a
+										// `grid-rows` 0fr → 1fr height animation (eases to the pills'
+										// real height — no `max-h` guessing, no scale, so it rises
+										// vertically rather than diagonally) plus a fade. Anchored at
+										// the bottom of the screen, so the growth pushes upward.
+										<div
+											className={cn(
+												"ww:grid ww:transition-all ww:duration-300 ww:ease-out",
+												suggestionsVisible
+													? "ww:grid-rows-[1fr] ww:opacity-100"
+													: "ww:pointer-events-none ww:grid-rows-[0fr] ww:opacity-0",
+											)}
+										>
+											<div className="ww:overflow-hidden">
+												<Suggestions
+													suggestions={suggestions}
+													onSelect={(text) => {
+														widgetEvents.emit({
+															name: "suggestion.clicked",
+															properties: {
+																text,
+																index: suggestions.indexOf(text),
+															},
+														});
+														openWith(text);
+													}}
+													// Right padding keeps the top row of pills clear of the
+													// absolutely-positioned close button in the corner.
+													className="ww:pl-1 ww:pr-9 ww:pt-1 ww:pb-2.5"
+												/>
+											</div>
 										</div>
-									</div>
-								)}
+									)}
 
-								{/* Composer wrapped in the ReactBits border glow. Background +
+									{/* Composer wrapped in the ReactBits border glow. Background +
 								    radius are themed to match the input surface; the glow plays
 								    a one-off sweep on appear. */}
-								<BorderGlow
-									animated={appeared}
-									backgroundColor="var(--ww-color-input)"
-									borderRadius={16}
-									edgeSensitivity={30}
-									coneSpread={25}
-									colors={["#c084fc", "#f472b6", "#38bdf8"]}
-									className="ww:border-border"
-									style={{ boxShadow: cardShadow }}
-								>
-									<div className="ww:flex ww:items-center ww:gap-1 ww:pl-3.5 ww:pr-1.5 ww:py-1.5 ww:sm:pl-4 ww:sm:pr-2 ww:sm:py-2">
-										{/* `text-base` (16px) on mobile is load-bearing: iOS Safari
+									<BorderGlow
+										animated={appeared}
+										backgroundColor="var(--ww-color-input)"
+										borderRadius={16}
+										edgeSensitivity={30}
+										coneSpread={25}
+										colors={["#c084fc", "#f472b6", "#38bdf8"]}
+										className="ww:border-border"
+										style={{ boxShadow: cardShadow }}
+									>
+										<div className="ww:flex ww:items-center ww:gap-1 ww:pl-3.5 ww:pr-1.5 ww:py-1.5 ww:sm:pl-4 ww:sm:pr-2 ww:sm:py-2">
+											{/* `text-base` (16px) on mobile is load-bearing: iOS Safari
 										    auto-zooms a focused input under 16px. `sm:text-sm`
 										    restores the smaller text where the zoom rule doesn't
 										    apply. Do not drop the 16px mobile size. */}
-										<input
-											ref={composerInputRef}
-											type="text"
-											value={composerText}
-											placeholder={animatedDockPlaceholder}
-											onChange={(e) => setComposerText(e.target.value)}
-											onFocus={onComposerFocus}
-											onKeyDown={(e) => {
-												if (e.key === "Enter" && !e.shiftKey) {
-													e.preventDefault();
-													submitComposer();
-												}
-											}}
-											className="ww:min-w-0 ww:flex-1 ww:bg-transparent ww:py-1 ww:text-base ww:sm:text-sm ww:text-foreground ww:outline-none ww:placeholder:text-muted-foreground"
-										/>
-										<button
-											type="button"
-											onClick={submitComposer}
-											disabled={!composerText.trim()}
-											aria-label={t.promptInput.submit}
-											className="ww:relative ww:flex ww:size-8 ww:shrink-0 ww:items-center ww:justify-center ww:rounded-full ww:bg-foreground ww:text-background ww:transition-opacity hover:ww:opacity-90 disabled:ww:opacity-40"
-										>
-											<ArrowUp className="ww:size-4" />
-										</button>
-									</div>
-								</BorderGlow>
+											<input
+												ref={composerInputRef}
+												type="text"
+												value={composerText}
+												placeholder={animatedDockPlaceholder}
+												onChange={(e) => setComposerText(e.target.value)}
+												onFocus={onComposerFocus}
+												onKeyDown={(e) => {
+													if (e.key === "Enter" && !e.shiftKey) {
+														e.preventDefault();
+														submitComposer();
+													}
+												}}
+												className="ww:min-w-0 ww:flex-1 ww:bg-transparent ww:py-1 ww:text-base ww:sm:text-sm ww:text-foreground ww:outline-none ww:placeholder:text-muted-foreground"
+											/>
+											<button
+												type="button"
+												onClick={submitComposer}
+												disabled={!composerText.trim()}
+												aria-label={t.promptInput.submit}
+												className="ww:relative ww:flex ww:size-8 ww:shrink-0 ww:items-center ww:justify-center ww:rounded-full ww:bg-foreground ww:text-background ww:transition-opacity hover:ww:opacity-90 disabled:ww:opacity-40"
+											>
+												<ArrowUp className="ww:size-4" />
+											</button>
+										</div>
+									</BorderGlow>
+								</div>
 							</div>
-						</div>
 
-						{/* Full chat panel — expands open from the docked input's
+							{/* Full chat panel — expands open from the docked input's
 				    position (clip-path, see tailwind.css). Same desktop width
 				    as the expanded dock so the growth reads as one motion. */}
-						<div
-							role="dialog"
-							aria-label={config.title ?? dockPlaceholder}
-							data-waniwani-floating="panel"
-							data-state={phase === "open" ? "shown" : "hidden"}
-							style={{ boxShadow: cardShadow }}
-							className={cn(
-								"ww:fixed ww:z-[2147483002] ww:flex ww:flex-col ww:overflow-hidden ww:bg-background",
-								// Mobile: full-screen sheet.
-								"ww:inset-0 ww:w-full ww:rounded-none",
-								// Desktop: wide ChatGPT-style card. Message content + input both
-								// stay capped at max-w-3xl and centered, so they share one
-								// column (good input/text ratio) and the extra panel width
-								// reads as balanced side padding — not a narrow Intercom panel.
-								"ww:sm:inset-auto ww:sm:bottom-4 ww:sm:left-0 ww:sm:right-0 ww:sm:mx-auto ww:sm:h-[720px] ww:sm:max-h-[calc(100dvh-2rem)] ww:sm:w-[calc(100vw-2rem)] ww:sm:max-w-[1000px] ww:sm:rounded-2xl ww:sm:border ww:sm:border-border",
-							)}
-						>
-							<ChatEmbed
-								ref={chatRef}
-								api={config.api ?? ""}
-								headers={{ Authorization: `Bearer ${config.token}` }}
-								skipRemoteConfig
-								body={body}
-								appearance={config.appearance}
-								title={config.title}
-								headerActions={closeButton}
-								// Force the header on in floating mode: the minimize control
-								// lives in `headerActions`, so honoring `hideHeader` here would
-								// leave an opened (full-screen on mobile) panel with no in-UI
-								// way back to the dock. The panel is its own chrome anyway.
-								hideHeader={false}
-								welcomeMessage={config.welcomeMessage}
-								placeholder={config.placeholder}
-								suggestions={
-									config.suggestions
-										? { initial: config.suggestions }
-										: undefined
-								}
-								enableThreadHistory={config.enableThreadHistory}
-								showToolCalls={config.showToolCalls}
-								locale={config.locale}
-								initializing={!ready}
-							/>
-						</div>
-					</>
-				)}
-			</div>
+							<div
+								role="dialog"
+								aria-label={config.title ?? dockPlaceholder}
+								data-waniwani-floating="panel"
+								data-state={phase === "open" ? "shown" : "hidden"}
+								style={{ boxShadow: cardShadow }}
+								className={cn(
+									"ww:fixed ww:z-[2147483002] ww:flex ww:flex-col ww:overflow-hidden ww:bg-background",
+									// Mobile: full-screen sheet.
+									"ww:inset-0 ww:w-full ww:rounded-none",
+									// Desktop: wide ChatGPT-style card. Message content + input both
+									// stay capped at max-w-3xl and centered, so they share one
+									// column (good input/text ratio) and the extra panel width
+									// reads as balanced side padding — not a narrow Intercom panel.
+									"ww:sm:inset-auto ww:sm:bottom-4 ww:sm:left-0 ww:sm:right-0 ww:sm:mx-auto ww:sm:h-[720px] ww:sm:max-h-[calc(100dvh-2rem)] ww:sm:w-[calc(100vw-2rem)] ww:sm:max-w-[1000px] ww:sm:rounded-2xl ww:sm:border ww:sm:border-border",
+								)}
+							>
+								<ChatEmbed
+									ref={chatRef}
+									api={config.api ?? ""}
+									headers={{ Authorization: `Bearer ${config.token}` }}
+									skipRemoteConfig
+									body={body}
+									appearance={config.appearance}
+									title={config.title}
+									headerActions={closeButton}
+									// Force the header on in floating mode: the minimize control
+									// lives in `headerActions`, so honoring `hideHeader` here would
+									// leave an opened (full-screen on mobile) panel with no in-UI
+									// way back to the dock. The panel is its own chrome anyway.
+									hideHeader={false}
+									welcomeMessage={config.welcomeMessage}
+									placeholder={config.placeholder}
+									suggestions={
+										config.suggestions
+											? { initial: config.suggestions }
+											: undefined
+									}
+									enableThreadHistory={config.enableThreadHistory}
+									showToolCalls={config.showToolCalls}
+									locale={config.locale}
+									initializing={!ready}
+								/>
+							</div>
+						</>
+					)}
+				</div>
+			</WidgetEventsProvider>
 		);
 	},
 );

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -122,7 +122,7 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 
 		const chatRef = useRef<ChatHandle>(null);
 		// One emitter per mount. The session id getter reads through the chat
-		// handle so events pick up the server-assigned id as soon as it exists.
+		// handle so events pick up the session id as soon as it exists.
 		const widgetEvents = useMemo(
 			() =>
 				createWidgetEventEmitter({

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -6,12 +6,20 @@
 // useEffect to drive the fetch.
 // ============================================================================
 
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import {
+	forwardRef,
+	useEffect,
+	useImperativeHandle,
+	useMemo,
+	useRef,
+} from "react";
 import type { ChatHandle } from "../@types";
 import { ChatEmbed } from "../layouts/chat-embed";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
 import { useVisibilityGate } from "./use-pathname";
+import { createWidgetEventEmitter } from "./widget-events";
+import { WidgetEventsProvider } from "./widget-events-context";
 
 export interface InlineChatProps {
 	config: EmbedConfig;
@@ -51,6 +59,33 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 
 		const chatRef = useRef<ChatHandle>(null);
 
+		// One emitter per mount. The session id getter reads through the chat
+		// handle so events pick up the server-assigned id as soon as it exists.
+		const widgetEvents = useMemo(
+			() =>
+				createWidgetEventEmitter({
+					mode: "inline",
+					getSessionId: () => chatRef.current?.sessionId,
+				}),
+			[],
+		);
+		const onEvent = config.onEvent;
+		useEffect(() => {
+			if (!onEvent) {
+				return;
+			}
+			return widgetEvents.subscribe(onEvent);
+		}, [onEvent, widgetEvents]);
+
+		// `chat.ready` once the remote config has resolved.
+		const readyEmittedRef = useRef(false);
+		useEffect(() => {
+			if (ready && !readyEmittedRef.current) {
+				readyEmittedRef.current = true;
+				widgetEvents.emit({ name: "chat.ready" });
+			}
+		}, [ready, widgetEvents]);
+
 		// biome-ignore lint/correctness/useExhaustiveDependencies: fire once on mount
 		useEffect(() => {
 			onReady?.();
@@ -85,25 +120,27 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 		}
 
 		return (
-			<ChatEmbed
-				ref={chatRef}
-				api={config.api ?? ""}
-				headers={{ Authorization: `Bearer ${config.token}` }}
-				skipRemoteConfig
-				body={body}
-				appearance={config.appearance}
-				title={config.title}
-				hideHeader={config.hideHeader}
-				welcomeMessage={config.welcomeMessage}
-				placeholder={config.placeholder}
-				suggestions={
-					config.suggestions ? { initial: config.suggestions } : undefined
-				}
-				enableThreadHistory={config.enableThreadHistory}
-				showToolCalls={config.showToolCalls}
-				locale={config.locale}
-				initializing={!ready}
-			/>
+			<WidgetEventsProvider value={widgetEvents}>
+				<ChatEmbed
+					ref={chatRef}
+					api={config.api ?? ""}
+					headers={{ Authorization: `Bearer ${config.token}` }}
+					skipRemoteConfig
+					body={body}
+					appearance={config.appearance}
+					title={config.title}
+					hideHeader={config.hideHeader}
+					welcomeMessage={config.welcomeMessage}
+					placeholder={config.placeholder}
+					suggestions={
+						config.suggestions ? { initial: config.suggestions } : undefined
+					}
+					enableThreadHistory={config.enableThreadHistory}
+					showToolCalls={config.showToolCalls}
+					locale={config.locale}
+					initializing={!ready}
+				/>
+			</WidgetEventsProvider>
 		);
 	},
 );

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -60,7 +60,7 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 		const chatRef = useRef<ChatHandle>(null);
 
 		// One emitter per mount. The session id getter reads through the chat
-		// handle so events pick up the server-assigned id as soon as it exists.
+		// handle so events pick up the session id as soon as it exists.
 		const widgetEvents = useMemo(
 			() =>
 				createWidgetEventEmitter({

--- a/src/chat/web/embed/widget-events-context.tsx
+++ b/src/chat/web/embed/widget-events-context.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { WidgetEventEmitter } from "./widget-events";
+import { createNoopWidgetEventEmitter } from "./widget-events";
+
+// Default is an inert emitter, so components emit unconditionally and a bare
+// `ChatEmbed` mounted without a provider (the BYO-backend path) stays silent.
+const WidgetEventsContext = createContext<WidgetEventEmitter>(
+	createNoopWidgetEventEmitter(),
+);
+
+/** Event emitter for the enclosing widget mount; inert without a provider. */
+export function useWidgetEvents(): WidgetEventEmitter {
+	return useContext(WidgetEventsContext);
+}
+
+export const WidgetEventsProvider = WidgetEventsContext.Provider;

--- a/src/chat/web/embed/widget-events.ts
+++ b/src/chat/web/embed/widget-events.ts
@@ -1,0 +1,127 @@
+// ============================================================================
+// Widget events: host-page subscription channel for chat lifecycle events.
+//
+// The embed mounts in the host page's DOM (the shadow root isolates styles
+// only), so subscribers run in the page's own JS context. The host forwards
+// events straight into its analytics (window.amplitude, window.analytics,
+// gtag, ...) and the page's own identity is attached automatically, with no
+// server-side identity plumbing. Event names are fixed and neutral; hosts
+// map them to their own schema inside the callback.
+//
+// Message events deliberately carry no message content: the host learns THAT
+// a message was exchanged, never what was said.
+// ============================================================================
+
+/** Surface the widget is mounted on. */
+export type WidgetMode = "inline" | "floating";
+
+interface WidgetEventBase {
+	/** Surface the widget is mounted on. */
+	mode: WidgetMode;
+	/**
+	 * Conversation session id, when one exists. Assigned by the server on the
+	 * first exchange, so it is `undefined` for events that precede it.
+	 */
+	sessionId?: string;
+	/** Epoch milliseconds at emit time. */
+	timestamp: number;
+}
+
+/**
+ * Per-event discriminant and extra properties. Events in the first branch
+ * carry no `properties` object.
+ */
+export type WidgetEventDetail =
+	| {
+			name:
+				| "chat.ready"
+				| "chat.opened"
+				| "chat.closed"
+				| "message.sent"
+				| "message.received";
+	  }
+	| { name: "session.started"; properties: { sessionId: string } }
+	| { name: "thread.changed"; properties: { threadId: string } }
+	| { name: "chat.error"; properties: { message: string } }
+	| { name: "suggestion.clicked"; properties: { text: string; index: number } }
+	| { name: "link.clicked"; properties: { url: string } };
+
+/** Payload handed to `onEvent` subscribers. Discriminated on `name`. */
+export type WidgetEvent = WidgetEventBase & WidgetEventDetail;
+
+export type WidgetEventName = WidgetEventDetail["name"];
+
+/**
+ * `emit()` input: the event detail, plus an optional explicit session id for
+ * call sites that hold a fresher value than the live getter (e.g. the engine
+ * emitting `session.started` in the same tick the id is assigned).
+ * `session.started` derives its top-level `sessionId` from
+ * `properties.sessionId` when no explicit override is given.
+ */
+export type WidgetEventInput = WidgetEventDetail & { sessionId?: string };
+
+export interface WidgetEventEmitter {
+	/** Register a listener. Returns its unsubscribe function. */
+	subscribe: (listener: (event: WidgetEvent) => void) => () => void;
+	/** Build the full event (mode, timestamp, session id) and fan it out. */
+	emit: (input: WidgetEventInput) => void;
+}
+
+export interface CreateWidgetEventEmitterOptions {
+	mode: WidgetMode;
+	/** Live session id, read at emit time. */
+	getSessionId?: () => string | undefined;
+}
+
+/**
+ * Per-mount emitter. Every listener is isolated: an exception in one
+ * subscriber is swallowed with a console warning and never breaks the widget
+ * nor the other subscribers.
+ */
+export function createWidgetEventEmitter(
+	options: CreateWidgetEventEmitterOptions,
+): WidgetEventEmitter {
+	const listeners = new Set<(event: WidgetEvent) => void>();
+	return {
+		subscribe(listener) {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		emit(input) {
+			const { sessionId: explicitSessionId, ...detail } = input;
+			const derivedSessionId =
+				input.name === "session.started"
+					? input.properties.sessionId
+					: undefined;
+			const event: WidgetEvent = {
+				...detail,
+				mode: options.mode,
+				sessionId:
+					explicitSessionId ?? derivedSessionId ?? options.getSessionId?.(),
+				timestamp: Date.now(),
+			};
+			// Snapshot so listener-triggered subscribe/unsubscribe during emit
+			// cannot skip peers or receive the in-flight event; mutations apply
+			// from the next emit.
+			for (const listener of [...listeners]) {
+				try {
+					listener(event);
+				} catch (err) {
+					console.warn("[Waniwani] onEvent subscriber threw:", err);
+				}
+			}
+		},
+	};
+}
+
+/** Inert emitter — the context default when no provider is mounted. */
+export function createNoopWidgetEventEmitter(): WidgetEventEmitter {
+	return {
+		subscribe() {
+			return () => {};
+		},
+		emit() {},
+	};
+}

--- a/src/chat/web/embed/widget-events.ts
+++ b/src/chat/web/embed/widget-events.ts
@@ -19,8 +19,8 @@ interface WidgetEventBase {
 	/** Surface the widget is mounted on. */
 	mode: WidgetMode;
 	/**
-	 * Conversation session id, when one exists. Assigned by the server on the
-	 * first exchange, so it is `undefined` for events that precede it.
+	 * Conversation session id, when one exists. Assigned on the first
+	 * exchange, so it is `undefined` for events that precede it.
 	 */
 	sessionId?: string;
 	/** Epoch milliseconds at emit time. */
@@ -54,8 +54,10 @@ export type WidgetEventName = WidgetEventDetail["name"];
 /**
  * `emit()` input: the event detail, plus an optional explicit session id for
  * call sites that hold a fresher value than the live getter (e.g. the engine
- * emitting `session.started` in the same tick the id is assigned).
- * `session.started` derives its top-level `sessionId` from
+ * emitting in the same tick a session id is assigned, restored, or cleared).
+ * A present `sessionId` key is authoritative even when its value is
+ * `undefined` — the live getter reads React state and lags same-tick
+ * mutations. `session.started` derives its top-level `sessionId` from
  * `properties.sessionId` when no explicit override is given.
  */
 export type WidgetEventInput = WidgetEventDetail & { sessionId?: string };
@@ -98,8 +100,9 @@ export function createWidgetEventEmitter(
 			const event: WidgetEvent = {
 				...detail,
 				mode: options.mode,
-				sessionId:
-					explicitSessionId ?? derivedSessionId ?? options.getSessionId?.(),
+				sessionId: Object.hasOwn(input, "sessionId")
+					? explicitSessionId
+					: (derivedSessionId ?? options.getSessionId?.()),
 				timestamp: Date.now(),
 			};
 			// Snapshot so listener-triggered subscribe/unsubscribe during emit

--- a/src/chat/web/hooks/use-chat-engine.test.tsx
+++ b/src/chat/web/hooks/use-chat-engine.test.tsx
@@ -57,7 +57,14 @@ type Root = ReturnType<typeof createRoot>;
  * "submitted → streaming → ready" lifecycle.
  */
 let useChatStatus = "ready";
-let capturedOnFinish: ((payload: { message: unknown }) => void) | undefined;
+let capturedOnFinish:
+	| ((payload: {
+			message: unknown;
+			isAbort?: boolean;
+			isDisconnect?: boolean;
+			isError?: boolean;
+	  }) => void)
+	| undefined;
 let capturedOnError: ((error: Error) => void) | undefined;
 const mockSendMessage = mock(() => {});
 const mockSetMessages = mock(() => {});
@@ -104,6 +111,9 @@ afterEach(() => {
 
 // Now import the hook under test (after mocks are registered)
 const { useChatEngine } = await import("./use-chat-engine");
+const { WidgetEventsProvider } = await import("../embed/widget-events-context");
+const { createWidgetEventEmitter } = await import("../embed/widget-events");
+type WidgetEventType = import("../embed/widget-events").WidgetEvent;
 
 // ---------------------------------------------------------------------------
 // Test harness — a thin component that exposes the hook's return value via ref
@@ -111,8 +121,14 @@ const { useChatEngine } = await import("./use-chat-engine");
 
 type HookReturn = ReturnType<typeof useChatEngine>;
 
-function Harness({ resultRef }: { resultRef: { current: HookReturn | null } }) {
-	const engine = useChatEngine({ api: "/api/waniwani" });
+function Harness({
+	resultRef,
+	body,
+}: {
+	resultRef: { current: HookReturn | null };
+	body?: Record<string, unknown>;
+}) {
+	const engine = useChatEngine({ api: "/api/waniwani", body });
 	resultRef.current = engine;
 	return null;
 }
@@ -299,5 +315,172 @@ describe("useChatEngine – thread history", () => {
 		// Body builder now uses the new threadId
 		const secondBody = capturedTransportBody?.();
 		expect(secondBody?.threadId).toBe(nextId);
+	});
+});
+
+// Re-renders the shared root with Harness wrapped in a WidgetEventsProvider,
+// so the captured useChat/transport mocks belong to the provider-wrapped
+// engine (a second concurrent mount would race over them). Returns a
+// `rerender` bound to the same emitter for prop/status changes, and awaits
+// the mount-effect continuations so they settle inside act.
+async function mountWithEvents(options?: { body?: Record<string, unknown> }) {
+	const events: WidgetEventType[] = [];
+	const emitter = createWidgetEventEmitter({ mode: "inline" });
+	emitter.subscribe((event) => {
+		events.push(event);
+	});
+	const rerender = (next?: { body?: Record<string, unknown> }) => {
+		act(() => {
+			root.render(
+				createElement(
+					WidgetEventsProvider,
+					{ value: emitter },
+					createElement(Harness, {
+						resultRef: hookRef,
+						body: next?.body ?? options?.body,
+					}),
+				),
+			);
+		});
+	};
+	rerender();
+	await flushAsync();
+	return { events, rerender };
+}
+
+describe("useChatEngine – widget events", () => {
+	test("message.sent fires on submit and never carries the text", async () => {
+		const { events } = await mountWithEvents();
+		const engine = hookRef.current;
+		if (!engine) {
+			throw new Error("Engine not mounted");
+		}
+
+		act(() => {
+			engine.handleSubmit({ text: "my secret question", files: [] });
+		});
+
+		const sent = events.filter((e) => e.name === "message.sent");
+		expect(sent.length).toBe(1);
+		expect(JSON.stringify(events)).not.toContain("my secret question");
+	});
+
+	test("message.sent fires exactly once for a queued message", async () => {
+		const { events, rerender } = await mountWithEvents();
+		useChatStatus = "streaming";
+		rerender();
+		const engine = hookRef.current;
+		if (!engine) {
+			throw new Error("Engine not mounted");
+		}
+
+		act(() => {
+			engine.handleSubmit({ text: "queued while streaming", files: [] });
+		});
+		expect(events.filter((e) => e.name === "message.sent").length).toBe(0);
+
+		useChatStatus = "ready";
+		rerender();
+
+		expect(events.filter((e) => e.name === "message.sent").length).toBe(1);
+	});
+
+	test("message.received fires on finish", async () => {
+		const { events } = await mountWithEvents();
+
+		act(() => {
+			capturedOnFinish?.({ message: { role: "assistant" } });
+		});
+
+		expect(events.some((e) => e.name === "message.received")).toBe(true);
+	});
+
+	test("message.received does not fire when the request errored", async () => {
+		const { events } = await mountWithEvents();
+
+		act(() => {
+			capturedOnError?.(new Error("boom"));
+			capturedOnFinish?.({ message: { role: "assistant" }, isError: true });
+		});
+
+		expect(events.filter((e) => e.name === "chat.error").length).toBe(1);
+		expect(events.filter((e) => e.name === "message.received").length).toBe(0);
+
+		act(() => {
+			capturedOnFinish?.({ message: { role: "assistant" } });
+		});
+		expect(events.filter((e) => e.name === "message.received").length).toBe(1);
+	});
+
+	test("chat.error fires with a truncated technical message", async () => {
+		const { events } = await mountWithEvents();
+
+		act(() => {
+			capturedOnError?.(new Error("x".repeat(500)));
+		});
+
+		const errors = events.filter((e) => e.name === "chat.error");
+		expect(errors.length).toBe(1);
+		for (const e of errors) {
+			if (e.name === "chat.error") {
+				expect(e.properties.message.length).toBe(200);
+			}
+		}
+	});
+
+	test("session.started fires once when the id is first assigned", async () => {
+		const { events, rerender } = await mountWithEvents({
+			body: { sessionId: "sess_1" },
+		});
+
+		act(() => {
+			capturedTransportBody?.();
+			capturedTransportBody?.();
+		});
+
+		// A rotated session id must not re-fire session.started.
+		rerender({ body: { sessionId: "sess_2" } });
+		act(() => {
+			capturedTransportBody?.();
+		});
+
+		const started = events.filter((e) => e.name === "session.started");
+		expect(started.length).toBe(1);
+		expect(started[0]?.sessionId).toBe("sess_1");
+	});
+
+	test("thread.changed fires when a thread becomes active", async () => {
+		const { events } = await mountWithEvents();
+		const engine = hookRef.current;
+		if (!engine) {
+			throw new Error("Engine not mounted");
+		}
+
+		let nextId = "";
+		act(() => {
+			nextId = engine.startNewThread();
+		});
+		expect(nextId.length).toBeGreaterThan(5);
+
+		const changed = events.filter((e) => e.name === "thread.changed");
+		expect(changed.length).toBe(1);
+		for (const e of changed) {
+			if (e.name === "thread.changed") {
+				expect(e.properties.threadId).toBe(nextId);
+			}
+		}
+	});
+
+	test("emits are inert without a provider", () => {
+		const engine = hookRef.current;
+		if (!engine) {
+			throw new Error("Engine not mounted");
+		}
+
+		expect(() => {
+			act(() => {
+				engine.handleSubmit({ text: "hello", files: [] });
+			});
+		}).not.toThrow();
 	});
 });

--- a/src/chat/web/hooks/use-chat-engine.test.tsx
+++ b/src/chat/web/hooks/use-chat-engine.test.tsx
@@ -323,9 +323,15 @@ describe("useChatEngine – thread history", () => {
 // engine (a second concurrent mount would race over them). Returns a
 // `rerender` bound to the same emitter for prop/status changes, and awaits
 // the mount-effect continuations so they settle inside act.
-async function mountWithEvents(options?: { body?: Record<string, unknown> }) {
+async function mountWithEvents(options?: {
+	body?: Record<string, unknown>;
+	getSessionId?: () => string | undefined;
+}) {
 	const events: WidgetEventType[] = [];
-	const emitter = createWidgetEventEmitter({ mode: "inline" });
+	const emitter = createWidgetEventEmitter({
+		mode: "inline",
+		getSessionId: options?.getSessionId,
+	});
 	emitter.subscribe((event) => {
 		events.push(event);
 	});
@@ -469,6 +475,61 @@ describe("useChatEngine – widget events", () => {
 				expect(e.properties.threadId).toBe(nextId);
 			}
 		}
+	});
+
+	test("thread.changed on switchThread carries the target thread's session id", async () => {
+		const { upsertThread } = await import("../lib/thread-store");
+		const now = new Date().toISOString();
+		await upsertThread({
+			threadId: "thread_stored",
+			memoryUserId: "user_test",
+			title: "Stored thread",
+			messages: [],
+			sessionId: "sess_stored",
+			createdAt: now,
+			updatedAt: now,
+		});
+
+		const { events } = await mountWithEvents({
+			getSessionId: () => "sess_outgoing",
+		});
+		const engine = hookRef.current;
+		if (!engine) {
+			throw new Error("Engine not mounted");
+		}
+
+		await act(async () => {
+			await engine.switchThread("thread_stored");
+		});
+
+		const changed = events.filter(
+			(e) =>
+				e.name === "thread.changed" &&
+				e.properties.threadId === "thread_stored",
+		);
+		expect(changed).toHaveLength(1);
+		expect(changed[0]?.sessionId).toBe("sess_stored");
+	});
+
+	test("thread.changed on startNewThread does not report the outgoing session", async () => {
+		const { events } = await mountWithEvents({
+			getSessionId: () => "sess_stale",
+		});
+		const engine = hookRef.current;
+		if (!engine) {
+			throw new Error("Engine not mounted");
+		}
+
+		let nextId = "";
+		act(() => {
+			nextId = engine.startNewThread();
+		});
+
+		const changed = events.filter(
+			(e) => e.name === "thread.changed" && e.properties.threadId === nextId,
+		);
+		expect(changed).toHaveLength(1);
+		expect(changed[0]?.sessionId).toBeUndefined();
 	});
 
 	test("emits are inert without a provider", () => {

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -8,6 +8,7 @@ import type { ModelContextUpdate } from "../../../shared/model-context";
 import { hasModelContext } from "../../../shared/model-context";
 import type { ChatBaseProps } from "../@types";
 import type { PromptInputMessage } from "../ai-elements/prompt-input";
+import { useWidgetEvents } from "../embed/widget-events-context";
 import { buildApiUrl } from "../lib/api-url";
 import { LenientChatTransport } from "../lib/lenient-chat-transport";
 import {
@@ -28,6 +29,7 @@ import {
 
 const SESSION_HEADER_NAME = "x-session-id";
 const THREAD_PERSIST_DEBOUNCE_MS = 250;
+const ERROR_MESSAGE_MAX_LENGTH = 200;
 
 function generateThreadId(): string {
 	if (
@@ -138,6 +140,10 @@ export function useChatEngine(props: ChatBaseProps) {
 	const propVisitorId = props.visitorId;
 	useEffect(() => applyVisitorId(propVisitorId), [propVisitorId]);
 
+	// The transport is constructed once at first render and captures that
+	// render's callbacks, so the provider must supply a per-mount-stable emitter.
+	const widgetEvents = useWidgetEvents();
+
 	const headersRef = useRef(userHeaders);
 	const bodyRef = useRef(body);
 	const enableThreadHistoryRef = useRef(enableThreadHistory);
@@ -180,13 +186,20 @@ export function useChatEngine(props: ChatBaseProps) {
 		onThreadChangeRef.current = onThreadChange;
 	}, [onThreadChange]);
 
-	const setActiveThreadId = useCallback((next: string | undefined) => {
-		activeThreadIdRef.current = next;
-		setActiveThreadIdState(next);
-		if (next) {
-			onThreadChangeRef.current?.(next);
-		}
-	}, []);
+	const setActiveThreadId = useCallback(
+		(next: string | undefined) => {
+			activeThreadIdRef.current = next;
+			setActiveThreadIdState(next);
+			if (next) {
+				onThreadChangeRef.current?.(next);
+				widgetEvents.emit({
+					name: "thread.changed",
+					properties: { threadId: next },
+				});
+			}
+		},
+		[widgetEvents],
+	);
 
 	const refreshThreads = useCallback(async () => {
 		if (!enableThreadHistory) {
@@ -204,18 +217,28 @@ export function useChatEngine(props: ChatBaseProps) {
 		return sessionIdRef.current;
 	}, []);
 
-	const setSessionId = useCallback((value: unknown) => {
-		const sessionId = normalizeSessionId(value);
-		if (!sessionId) {
-			return;
-		}
-		if (sessionIdRef.current === sessionId) {
-			return;
-		}
+	const setSessionId = useCallback(
+		(value: unknown) => {
+			const sessionId = normalizeSessionId(value);
+			if (!sessionId) {
+				return;
+			}
+			if (sessionIdRef.current === sessionId) {
+				return;
+			}
 
-		sessionIdRef.current = sessionId;
-		setSessionIdState(sessionId);
-	}, []);
+			const isFirstAssignment = sessionIdRef.current === undefined;
+			sessionIdRef.current = sessionId;
+			setSessionIdState(sessionId);
+			if (isFirstAssignment) {
+				widgetEvents.emit({
+					name: "session.started",
+					properties: { sessionId },
+				});
+			}
+		},
+		[widgetEvents],
+	);
 
 	const clearSessionId = useCallback(() => {
 		sessionIdRef.current = undefined;
@@ -452,8 +475,14 @@ export function useChatEngine(props: ChatBaseProps) {
 	const { messages, sendMessage, setMessages, status } = useChat({
 		messages: props.initialMessages,
 		transport: transportRef.current,
-		onFinish({ message }) {
+		onFinish({ message, isAbort, isDisconnect, isError }) {
+			// `onFinish` also runs for aborted/disconnected/errored requests.
+			// `onResponseReceived` fires for all of them; the widget event is
+			// emitted only for a successful assistant reply.
 			onResponseReceived?.();
+			if (!isAbort && !isDisconnect && !isError) {
+				widgetEvents.emit({ name: "message.received" });
+			}
 			if (pendingWaitRef.current) {
 				// Stash the message — resolve only after React commits the
 				// messages state update (see useEffect on `status` below).
@@ -462,6 +491,12 @@ export function useChatEngine(props: ChatBaseProps) {
 		},
 		onError(error) {
 			console.warn("[Waniwani] Chat error:", error.message);
+			widgetEvents.emit({
+				name: "chat.error",
+				properties: {
+					message: error.message.slice(0, ERROR_MESSAGE_MAX_LENGTH),
+				},
+			});
 			if (pendingWaitRef.current) {
 				pendingWaitRef.current.reject(error);
 				pendingWaitRef.current = null;
@@ -611,9 +646,16 @@ export function useChatEngine(props: ChatBaseProps) {
 			});
 
 			onMessageSent?.(message.text || "");
+			widgetEvents.emit({ name: "message.sent" });
 			setText("");
 		},
-		[sendMessage, onMessageSent, isLoading, queuedMessages.length],
+		[
+			sendMessage,
+			onMessageSent,
+			isLoading,
+			queuedMessages.length,
+			widgetEvents,
+		],
 	);
 
 	const sendMessageAndWait = useCallback(
@@ -622,9 +664,10 @@ export function useChatEngine(props: ChatBaseProps) {
 				pendingWaitRef.current = { resolve, reject };
 				sendMessage({ text });
 				onMessageSent?.(text);
+				widgetEvents.emit({ name: "message.sent" });
 			});
 		},
-		[sendMessage, onMessageSent],
+		[sendMessage, onMessageSent, widgetEvents],
 	);
 
 	// Flush first queued message once the current response finishes
@@ -645,7 +688,8 @@ export function useChatEngine(props: ChatBaseProps) {
 			files: first.files.length > 0 ? first.files : undefined,
 		});
 		onMessageSent?.(first.text);
-	}, [status, sendMessage, onMessageSent, queuedMessages]);
+		widgetEvents.emit({ name: "message.sent" });
+	}, [status, sendMessage, onMessageSent, queuedMessages, widgetEvents]);
 
 	const reset = useCallback(() => {
 		setMessages([]);

--- a/src/chat/web/hooks/use-chat-engine.ts
+++ b/src/chat/web/hooks/use-chat-engine.ts
@@ -194,6 +194,11 @@ export function useChatEngine(props: ChatBaseProps) {
 				onThreadChangeRef.current?.(next);
 				widgetEvents.emit({
 					name: "thread.changed",
+					// Explicit: the ref is mutated synchronously, while the live
+					// getter reads React state and would report the outgoing
+					// session after a same-tick restore (switchThread) or clear
+					// (startNewThread).
+					sessionId: sessionIdRef.current,
 					properties: { threadId: next },
 				});
 			}
@@ -852,15 +857,17 @@ export function useChatEngine(props: ChatBaseProps) {
 			if (!stored) {
 				return;
 			}
-			setActiveThreadId(stored.threadId);
-			threadCreatedAtRef.current = stored.createdAt;
-			threadTitleRef.current = stored.title;
+			// Restore the session before announcing the switch, so the
+			// `thread.changed` event carries the target thread's session id.
 			if (stored.sessionId) {
 				sessionIdRef.current = stored.sessionId;
 				setSessionIdState(stored.sessionId);
 			} else {
 				clearSessionId();
 			}
+			setActiveThreadId(stored.threadId);
+			threadCreatedAtRef.current = stored.createdAt;
+			threadTitleRef.current = stored.title;
 			setMessages(stored.messages);
 			setQueuedMessages([]);
 			setText("");

--- a/src/chat/web/index.ts
+++ b/src/chat/web/index.ts
@@ -25,6 +25,11 @@ export type {
 	McpAppFrameProps,
 } from "./components/mcp-app-frame";
 export { McpAppFrame } from "./components/mcp-app-frame";
+export type {
+	WidgetEvent,
+	WidgetEventName,
+	WidgetMode,
+} from "./embed/widget-events";
 export { ChatEmbed } from "./layouts/chat-embed";
 export {
 	WaniwaniChat,

--- a/src/chat/web/layouts/__tests__/chat-embed-widget-events.test.tsx
+++ b/src/chat/web/layouts/__tests__/chat-embed-widget-events.test.tsx
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { IDBFactory, IDBKeyRange } from "fake-indexeddb";
+import { Window } from "happy-dom";
+
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).indexedDB = new IDBFactory();
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).IDBKeyRange = IDBKeyRange;
+
+// ---------------------------------------------------------------------------
+// Set up DOM globals before importing React
+// ---------------------------------------------------------------------------
+
+const win = new Window({ url: "https://localhost" });
+for (const key of [
+	"document",
+	"navigator",
+	"HTMLElement",
+	"HTMLDivElement",
+	"HTMLAnchorElement",
+	"HTMLButtonElement",
+	"HTMLTextAreaElement",
+	"MutationObserver",
+	"IntersectionObserver",
+	"customElements",
+	"Element",
+	"Node",
+	"Text",
+	"Comment",
+	"DocumentFragment",
+	"Event",
+	"CustomEvent",
+	"MouseEvent",
+	"KeyboardEvent",
+	"requestAnimationFrame",
+	"cancelAnimationFrame",
+	"getComputedStyle",
+] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any)[key] = (win as any)[key];
+}
+// React checks for `window` specifically
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).window = win;
+// happy-dom's selector parser instantiates `window.SyntaxError`, which is
+// uninitialized when running under Bun — wire it to the global constructor.
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(win as any).SyntaxError = SyntaxError;
+// Tell React this is a test environment so act() works without warnings
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Now safe to import React
+const { act, createElement } = await import("react");
+const { createRoot } = await import("react-dom/client");
+type Root = ReturnType<typeof createRoot>;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSendMessage = mock(() => {});
+
+// @ts-expect-error -- bun:test `mock.module` exists at runtime but has no TS type
+mock.module("@ai-sdk/react", () => ({
+	useChat() {
+		return {
+			messages: [],
+			sendMessage: mockSendMessage,
+			setMessages: mock(() => {}),
+			status: "ready",
+		};
+	},
+}));
+
+// @ts-expect-error -- bun:test `mock.module` exists at runtime but has no TS type
+mock.module("../../lib/lenient-chat-transport", () => ({
+	LenientChatTransport: class {},
+}));
+
+const originalFetch = globalThis.fetch;
+beforeEach(() => {
+	globalThis.fetch = mock(async () =>
+		Response.json({ tools: [] }),
+	) as unknown as typeof fetch;
+});
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+// Now import the components under test (after mocks are registered)
+const { ChatEmbed } = await import("../chat-embed");
+const { WidgetEventsProvider } = await import(
+	"../../embed/widget-events-context"
+);
+const { createWidgetEventEmitter } = await import("../../embed/widget-events");
+type WidgetEventType = import("../../embed/widget-events").WidgetEvent;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+afterEach(() => {
+	if (root) {
+		act(() => {
+			root?.unmount();
+		});
+		root = null;
+	}
+	container?.remove();
+	container = null;
+});
+
+async function renderEmbed() {
+	const emitter = createWidgetEventEmitter({ mode: "inline" });
+	const events: WidgetEventType[] = [];
+	emitter.subscribe((event) => events.push(event));
+
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+
+	await act(async () => {
+		root?.render(
+			createElement(
+				WidgetEventsProvider,
+				{ value: emitter },
+				createElement(ChatEmbed, {
+					api: "https://example.com/api/chat",
+					suggestions: { initial: ["First suggestion", "Second suggestion"] },
+				}),
+			),
+		);
+	});
+
+	return { events };
+}
+
+function clickElement(el: Element) {
+	el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChatEmbed widget events", () => {
+	test("clicking a suggestion pill emits suggestion.clicked with its index", async () => {
+		const { events } = await renderEmbed();
+
+		const pill = [...document.querySelectorAll("button")].find(
+			(button) => button.textContent === "Second suggestion",
+		);
+		expect(pill).toBeDefined();
+
+		await act(async () => {
+			if (pill) {
+				clickElement(pill);
+			}
+		});
+
+		const clicks = events.filter((e) => e.name === "suggestion.clicked");
+		expect(clicks).toHaveLength(1);
+		expect(clicks[0]).toMatchObject({
+			name: "suggestion.clicked",
+			mode: "inline",
+			properties: { text: "Second suggestion", index: 1 },
+		});
+	});
+
+	test("clicking an anchor inside the messages scroller emits link.clicked", async () => {
+		const { events } = await renderEmbed();
+
+		const scroller = document.querySelector('div[class*="ww:overflow-y-auto"]');
+		expect(scroller).not.toBeNull();
+
+		const anchor = document.createElement("a");
+		anchor.setAttribute("href", "https://example.com/docs");
+		anchor.textContent = "docs";
+		anchor.addEventListener("click", (e) => e.preventDefault());
+		scroller?.appendChild(anchor);
+
+		await act(async () => {
+			clickElement(anchor);
+		});
+
+		const clicks = events.filter((e) => e.name === "link.clicked");
+		expect(clicks).toHaveLength(1);
+		expect(clicks[0]).toMatchObject({
+			name: "link.clicked",
+			mode: "inline",
+			properties: { url: "https://example.com/docs" },
+		});
+	});
+});

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -23,6 +23,7 @@ import { MessageList } from "../components/message-list";
 import { PoweredBy } from "../components/powered-by";
 import { Suggestions } from "../components/suggestions";
 import { ThreadMenu } from "../components/thread-menu";
+import { useWidgetEvents } from "../embed/widget-events-context";
 import { useCallTool } from "../hooks/use-call-tool";
 import { useChatEngine } from "../hooks/use-chat-engine";
 import { useSuggestions } from "../hooks/use-suggestions";
@@ -124,6 +125,7 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 		const isDark = preset === "dark" || (preset === "auto" && autoIsDark);
 
 		const engine = useChatEngine({ ...props, api });
+		const widgetEvents = useWidgetEvents();
 		const handleCallTool = useCallTool({
 			...props,
 			api,
@@ -201,6 +203,28 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 			observer.observe(el);
 			return () => observer.disconnect();
 		}, []);
+
+		// Delegated click listener on the messages scroller: reports every anchor click
+		// inside the conversation (markdown-rendered links) to the widget event
+		// emitter without customizing the markdown pipeline.
+		useEffect(() => {
+			const scroller = scrollRef.current;
+			if (!scroller) {
+				return;
+			}
+			const onClick = (e: MouseEvent) => {
+				const target = e.target instanceof Element ? e.target : null;
+				const anchor = target?.closest("a");
+				if (anchor?.href) {
+					widgetEvents.emit({
+						name: "link.clicked",
+						properties: { url: anchor.href },
+					});
+				}
+			};
+			scroller.addEventListener("click", onClick);
+			return () => scroller.removeEventListener("click", onClick);
+		}, [widgetEvents]);
 
 		// Auto-scroll on new messages / streaming tokens. When the user
 		// just sent a message we always jump to the bottom — they expect
@@ -305,10 +329,25 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 
 		const handleSuggestionSelect = useCallback(
 			(suggestion: string) => {
+				const dynamicIndex = suggestionsState.suggestions.indexOf(suggestion);
+				const index =
+					dynamicIndex >= 0
+						? dynamicIndex
+						: (welcome?.suggestions?.indexOf(suggestion) ?? -1);
+				widgetEvents.emit({
+					name: "suggestion.clicked",
+					properties: { text: suggestion, index },
+				});
 				suggestionsState.clear();
 				engine.handleSubmit({ text: suggestion, files: [] });
 			},
-			[suggestionsState.clear, engine.handleSubmit],
+			[
+				suggestionsState.suggestions,
+				suggestionsState.clear,
+				engine.handleSubmit,
+				welcome,
+				widgetEvents,
+			],
 		);
 
 		useImperativeHandle(

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -211,7 +211,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 		const trackClientRef = useRef<FrontendTrackingClient | null>(null);
 
 		// One emitter per mount. The session id getter reads through the chat
-		// handle so events pick up the server-assigned id as soon as it exists.
+		// handle so events pick up the session id as soon as it exists.
 		// WaniwaniChat is an in-page mount and reports "inline", matching the
 		// `mode` tag on its chat requests and page.viewed events.
 		const widgetEvents = useMemo(

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -25,6 +25,9 @@ import {
 	saveCachedConfig,
 } from "../embed/remote-config";
 import { useVisibilityGate } from "../embed/use-pathname";
+import type { WidgetEvent } from "../embed/widget-events";
+import { createWidgetEventEmitter } from "../embed/widget-events";
+import { WidgetEventsProvider } from "../embed/widget-events-context";
 import type { Locale, MessageOverrides } from "../i18n";
 import {
 	createChatTrackClient,
@@ -183,18 +186,48 @@ export interface WaniwaniChatProps {
 	 * can't be serialized to the dashboard).
 	 */
 	overrides?: WaniwaniChatOverrides;
+	/**
+	 * Callback fired on chat lifecycle events (`chat.ready`, `message.sent`,
+	 * `message.received`, `session.started`, `thread.changed`, `chat.error`,
+	 * `suggestion.clicked`, `link.clicked`; `chat.opened`/`chat.closed` are
+	 * floating-embed-only and never fire here). Message events never include
+	 * the message text. Use it to mirror widget activity into the host page's
+	 * analytics. Exceptions thrown by the callback are swallowed and never
+	 * break the chat.
+	 */
+	onEvent?: (event: WidgetEvent) => void;
 }
 
 const DEFAULT_API = "https://app.waniwani.ai/api/mcp/chat";
 
 export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 	function WaniwaniChat(props, ref) {
-		const { token, channelId, className, visitorId, overrides } = props;
+		const { token, channelId, className, visitorId, overrides, onEvent } =
+			props;
 
 		// The inner ChatEmbed handle; the ref we expose augments it with the
 		// tracking surface (`track`, `identify`).
 		const innerRef = useRef<ChatHandle>(null);
 		const trackClientRef = useRef<FrontendTrackingClient | null>(null);
+
+		// One emitter per mount. The session id getter reads through the chat
+		// handle so events pick up the server-assigned id as soon as it exists.
+		// WaniwaniChat is an in-page mount and reports "inline", matching the
+		// `mode` tag on its chat requests and page.viewed events.
+		const widgetEvents = useMemo(
+			() =>
+				createWidgetEventEmitter({
+					mode: "inline",
+					getSessionId: () => innerRef.current?.sessionId,
+				}),
+			[],
+		);
+		useEffect(() => {
+			if (!onEvent) {
+				return;
+			}
+			return widgetEvents.subscribe(onEvent);
+		}, [onEvent, widgetEvents]);
 
 		const programmatic = useMemo<Partial<EmbedConfig>>(
 			() => ({
@@ -244,6 +277,15 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 
 		const [remote, setRemote] = useState<Partial<EmbedConfig>>({});
 		const [ready, setReady] = useState<boolean>(false);
+
+		// `chat.ready` once the remote config has resolved.
+		const readyEmittedRef = useRef(false);
+		useEffect(() => {
+			if (ready && !readyEmittedRef.current) {
+				readyEmittedRef.current = true;
+				widgetEvents.emit({ name: "chat.ready" });
+			}
+		}, [ready, widgetEvents]);
 
 		// Top-of-funnel signal, fired once the channel's `/config` resolves so
 		// the event carries the channel's source. Guarded once per page inside
@@ -396,32 +438,34 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 		}
 
 		return (
-			<ChatEmbed
-				ref={innerRef}
-				api={config.api ?? DEFAULT_API}
-				headers={{ Authorization: `Bearer ${config.token}` }}
-				visitorId={visitorId}
-				skipRemoteConfig
-				body={body}
-				appearance={config.appearance}
-				classNames={overrides?.classNames}
-				title={config.title}
-				hideHeader={config.hideHeader}
-				welcomeMessage={config.welcomeMessage}
-				welcome={overrides?.welcome}
-				placeholder={config.placeholder}
-				suggestions={
-					config.suggestions ? { initial: config.suggestions } : undefined
-				}
-				enableThreadHistory={config.enableThreadHistory}
-				showToolCalls={config.showToolCalls}
-				disclaimer={config.disclaimer}
-				allowAttachments={overrides?.allowAttachments}
-				locale={config.locale}
-				messages={overrides?.messages}
-				className={className}
-				initializing={!ready}
-			/>
+			<WidgetEventsProvider value={widgetEvents}>
+				<ChatEmbed
+					ref={innerRef}
+					api={config.api ?? DEFAULT_API}
+					headers={{ Authorization: `Bearer ${config.token}` }}
+					visitorId={visitorId}
+					skipRemoteConfig
+					body={body}
+					appearance={config.appearance}
+					classNames={overrides?.classNames}
+					title={config.title}
+					hideHeader={config.hideHeader}
+					welcomeMessage={config.welcomeMessage}
+					welcome={overrides?.welcome}
+					placeholder={config.placeholder}
+					suggestions={
+						config.suggestions ? { initial: config.suggestions } : undefined
+					}
+					enableThreadHistory={config.enableThreadHistory}
+					showToolCalls={config.showToolCalls}
+					disclaimer={config.disclaimer}
+					allowAttachments={overrides?.allowAttachments}
+					locale={config.locale}
+					messages={overrides?.messages}
+					className={className}
+					initializing={!ready}
+				/>
+			</WidgetEventsProvider>
 		);
 	},
 );


### PR DESCRIPTION
Closes WAN-696

Adds a typed widget-event channel host pages can subscribe to on `WaniWani.chat.init({ onEvent })` and `<WaniwaniChat onEvent>`.

## What

- 10 lifecycle events: `chat.ready`, `chat.opened`/`chat.closed` (floating only), `message.sent`, `message.received`, `session.started`, `thread.changed`, `chat.error`, `suggestion.clicked`, `link.clicked`
- Typed `WidgetEvent` discriminated union (`WidgetEvent`, `WidgetEventName`, `WidgetMode` exported from `@waniwani/sdk/chat`), payload `{ name, mode, sessionId?, timestamp, properties? }`
- Per-mount multi-subscriber emitter behind a React context: future internal consumers (Amplitude module) attach as extra subscribers with zero API change
- Privacy: user/assistant message content never passes through the callback
- Robustness: subscriber exceptions are isolated (console warning, chat unaffected); `message.received` only fires on successful completions (guarded on the AI SDK's `isError`/`isAbort`/`isDisconnect`)
- `WaniwaniChat` reports `mode: "inline"`, matching the platform-wide mode vocabulary so hosts can correlate this stream with platform events
- `ChatEmbed` (BYO primitive) intentionally does not expose `onEvent`

## Why

Tuio needs widget events forwarded into their Amplitude pipeline with the page's own identity attached. Neutral fixed event names; hosts map to their schema in the callback.

## Testing

- 21 new unit/component tests (emitter semantics incl. snapshot iteration and exception isolation, config merge, engine emissions incl. session rotation and queued sends, suggestion/link component events)
- E2E on the playground through a cloudflare tunnel: floating, inline, invalid-token error path, and throwing-callback scenarios verified; sentinel-string check confirms no message content in any payload
- Docs updated: `skills/waniwani-sdk/references/chat-widget.md` (docs-site PR opened separately)

Supersedes the draft in #103.