### PR TITLE
feat(chat): fetch page-aware starter prompts on mount and SPA navigation (WAN-702)

### DIFF
--- a/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
+++ b/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
@@ -1,7 +1,7 @@
-import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { Window } from "happy-dom";
 // Type-only, so it doesn't pull the module in before the globals below exist.
-import type { EmbedConfig } from "../config";
+import type { EmbedConfig, PagePrompt } from "../config";
 
 const win = new Window({ url: "https://host.example/pricing" });
 for (const key of [
@@ -30,51 +30,34 @@ for (const key of [
 // biome-ignore lint/suspicious/noExplicitAny: react act environment flag
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
-// ---------------------------------------------------------------------------
-// fetch stub — every call is parked until the test resolves it by hand, so a
-// response can be delivered *after* a navigation to prove the stale-overwrite
-// guard works. Deliberately does not reject on abort: what's under test is the
-// hook's own `signal.aborted` check, not AbortController itself.
-// ---------------------------------------------------------------------------
-
-interface PendingRequest {
-	url: string;
-	headers: Record<string, string>;
-	signal: AbortSignal | undefined;
-	resolve: (res: { ok: boolean; body: unknown }) => void;
-}
-
-let pending: PendingRequest[] = [];
-
-const originalFetch = globalThis.fetch;
-
-// biome-ignore lint/suspicious/noExplicitAny: minimal fetch stand-in
-(globalThis as any).fetch = (input: any, init: any) =>
-	new Promise((resolveFetch) => {
-		pending.push({
-			url: String(input),
-			headers: (init?.headers ?? {}) as Record<string, string>,
-			signal: init?.signal,
-			resolve: ({ ok, body }) => resolveFetch({ ok, json: async () => body }),
-		});
-	});
-
-// Bun shares one global scope across test files. This stub never settles on
-// its own, so leaving it installed would hang every later file that fetches.
-afterAll(() => {
-	globalThis.fetch = originalFetch;
-});
-
 const { act, createElement } = await import("react");
 const { createRoot } = await import("react-dom/client");
-const { parseSuggestionsResponse, resolveSuggestions, usePageSuggestions } =
-	await import("../use-page-suggestions");
+const {
+	normalizePathname,
+	parsePageSuggestions,
+	pickPagePrompts,
+	resolveSuggestions,
+	usePageSuggestions,
+} = await import("../use-page-suggestions");
+
+const PRICING_PROMPTS: PagePrompt[] = [
+	{ id: "pricing-1", text: "What plans do you offer?", tier: "low" },
+	{ id: "pricing-2", text: "How does per-seat billing work?", tier: "medium" },
+	{ id: "pricing-3", text: "Is there a free trial?", tier: "high" },
+	{ id: "pricing-4", text: "Can I switch plans mid-cycle?" },
+	{ id: "pricing-5", text: "Do you offer annual discounts?" },
+	{ id: "pricing-6", text: "What counts as an active user?" },
+];
 
 const BASE_CONFIG: EmbedConfig = {
 	api: "https://app.waniwani.ai/api/mcp/chat",
 	token: "wwp_test",
 	channelId: "0b3d5f2e-1c4a-4f8b-9d2e-6a7c8b9d0e1f",
 	suggestions: ["Static A", "Static B"],
+	pageSuggestions: [
+		{ url: "/pricing", prompts: PRICING_PROMPTS },
+		{ url: "/docs", prompts: [{ id: "d1", text: "Docs Q", tier: "low" }] },
+	],
 };
 
 /** Mount a probe that surfaces the hook's resolved texts. */
@@ -94,11 +77,6 @@ async function mount(config: EmbedConfig) {
 		get value() {
 			return latest;
 		},
-		async settle(index: number, res: { ok: boolean; body: unknown }) {
-			await act(async () => {
-				pending[index]?.resolve(res);
-			});
-		},
 		async navigate(pathname: string) {
 			await act(async () => {
 				win.history.pushState({}, "", pathname);
@@ -110,73 +88,113 @@ async function mount(config: EmbedConfig) {
 	};
 }
 
-const envelope = (suggestions: unknown) => ({
-	success: true,
-	message: "success",
-	data: { suggestions },
-});
-
 beforeEach(async () => {
-	pending = [];
 	await act(async () => {
 		win.history.pushState({}, "", "/pricing");
 	});
 });
 
-describe("parseSuggestionsResponse", () => {
-	test("reads the enveloped `data.suggestions` shape the API returns", () => {
-		expect(
-			parseSuggestionsResponse(
-				envelope([{ id: "pricing-1", text: "How much?" }]),
-			),
-		).toEqual([{ id: "pricing-1", text: "How much?" }]);
+describe("normalizePathname", () => {
+	test("keeps a bare pathname and reduces a full URL to one", () => {
+		expect(normalizePathname("/pricing")).toBe("/pricing");
+		expect(normalizePathname("https://example.com/pricing")).toBe("/pricing");
 	});
 
-	test("accepts a bare `{ suggestions }` root too", () => {
-		expect(
-			parseSuggestionsResponse({ suggestions: [{ id: null, text: "Hi" }] }),
-		).toEqual([{ id: null, text: "Hi" }]);
+	test("drops query, hash and trailing slashes; root stays /", () => {
+		expect(normalizePathname("/pricing/?utm_source=x#plans")).toBe("/pricing");
+		expect(normalizePathname("https://example.com")).toBe("/");
+		expect(normalizePathname("/")).toBe("/");
 	});
 
-	test("keeps ids so a later click can be attributed", () => {
-		const parsed = parseSuggestionsResponse(
-			envelope([
-				{ id: "a", text: "one" },
-				{ id: null, text: "two" },
+	test("lowercases, so the authored key and the live pathname agree", () => {
+		expect(normalizePathname("/Pricing/Plans")).toBe("/pricing/plans");
+		expect(normalizePathname("https://Example.com/Pricing/?utm=1")).toBe(
+			normalizePathname("/pricing"),
+		);
+	});
+});
+
+describe("pickPagePrompts", () => {
+	test("shows exactly one prompt per tier, low → medium → high", () => {
+		const tiered = PRICING_PROMPTS.slice(0, 3);
+		for (let i = 0; i < 20; i++) {
+			const picked = pickPagePrompts([...tiered]);
+			expect(picked.map((p) => p.tier)).toEqual(["low", "medium", "high"]);
+		}
+	});
+
+	test("a tier with no tagged prompt is filled by an untagged wildcard", () => {
+		const pool: PagePrompt[] = [
+			{ id: "low-1", text: "a", tier: "low" },
+			{ id: "high-1", text: "b", tier: "high" },
+			{ id: "wild-1", text: "c" },
+		];
+		for (let i = 0; i < 10; i++) {
+			const picked = pickPagePrompts(pool);
+			expect(picked.map((p) => p.id).sort()).toEqual([
+				"high-1",
+				"low-1",
+				"wild-1",
+			]);
+		}
+	});
+
+	test("an all-untagged pool keeps the uniform random pick", () => {
+		const untagged = PRICING_PROMPTS.slice(3);
+		const seen = new Set<string | null>();
+		for (let i = 0; i < 40; i++) {
+			const picked = pickPagePrompts(untagged);
+			expect(picked).toHaveLength(3);
+			for (const p of picked) {
+				seen.add(p.id);
+			}
+		}
+		expect(seen.size).toBe(untagged.length);
+	});
+
+	test("fewer prompts than slots shows what exists", () => {
+		expect(
+			pickPagePrompts([{ id: "only", text: "One", tier: "high" }]),
+		).toHaveLength(1);
+	});
+});
+
+describe("parsePageSuggestions", () => {
+	test("reads well-formed entries, keeping ids and tiers", () => {
+		expect(
+			parsePageSuggestions([
+				{
+					url: "/pricing",
+					prompts: [{ id: "p1", text: "How much?", tier: "low" }],
+				},
 			]),
-		);
-		expect(parsed.map((s) => s.id)).toEqual(["a", null]);
+		).toEqual([
+			{
+				url: "/pricing",
+				prompts: [{ id: "p1", text: "How much?", tier: "low" }],
+			},
+		]);
 	});
 
-	test("coerces a non-string id to null rather than dropping the prompt", () => {
-		expect(parseSuggestionsResponse(envelope([{ id: 7, text: "ok" }]))).toEqual(
-			[{ id: null, text: "ok" }],
-		);
+	test("coerces a non-string id to null and drops an unknown tier", () => {
+		const [entry] = parsePageSuggestions([
+			{ url: "/a", prompts: [{ id: 7, text: "ok", tier: "urgent" }] },
+		]);
+		expect(entry.prompts).toEqual([{ id: null, text: "ok", tier: undefined }]);
 	});
 
-	test("drops entries with no usable text", () => {
+	test("drops prompts with no usable text, and entries left empty", () => {
 		expect(
-			parseSuggestionsResponse(
-				envelope([
-					{ id: "a", text: "" },
-					{ id: "b" },
-					null,
-					{ id: "c", text: "kept" },
-				]),
-			),
-		).toEqual([{ id: "c", text: "kept" }]);
+			parsePageSuggestions([
+				{ url: "/a", prompts: [{ id: "x", text: "" }, null] },
+				{ url: "/b", prompts: [{ id: "y", text: "kept" }] },
+			]),
+		).toEqual([{ url: "/b", prompts: [{ id: "y", text: "kept" }] }]);
 	});
 
-	test("degrades to [] on malformed bodies", () => {
-		for (const body of [
-			null,
-			undefined,
-			{},
-			{ data: null },
-			{ data: { suggestions: "nope" } },
-			"not json",
-		]) {
-			expect(parseSuggestionsResponse(body)).toEqual([]);
+	test("degrades to [] on malformed values", () => {
+		for (const value of [null, undefined, {}, "nope", [{ url: 3 }]]) {
+			expect(parsePageSuggestions(value)).toEqual([]);
 		}
 	});
 });
@@ -190,15 +208,8 @@ describe("resolveSuggestions", () => {
 		).toEqual([{ id: "p1", text: "Page prompt" }]);
 	});
 
-	test("falls back when nothing was fetched", () => {
+	test("falls back when the page has no entry", () => {
 		expect(resolveSuggestions(null, fallback)).toEqual([
-			{ id: null, text: "Static A" },
-			{ id: null, text: "Static B" },
-		]);
-	});
-
-	test("treats an empty fetched set as fall-back-client-side", () => {
-		expect(resolveSuggestions([], fallback)).toEqual([
 			{ id: null, text: "Static A" },
 			{ id: null, text: "Static B" },
 		]);
@@ -211,101 +222,47 @@ describe("resolveSuggestions", () => {
 });
 
 describe("usePageSuggestions", () => {
-	test("is inert without the flag — no request, fixed list", async () => {
-		const h = await mount({ ...BASE_CONFIG });
-		expect(pending).toHaveLength(0);
+	test("is inert without pageSuggestions — exactly the fixed list", async () => {
+		const h = await mount({ ...BASE_CONFIG, pageSuggestions: undefined });
 		expect(h.value).toEqual(["Static A", "Static B"]);
 		h.unmount();
 	});
 
-	test("makes no request when the embed has no channelId", async () => {
-		const h = await mount({
-			...BASE_CONFIG,
-			channelId: undefined,
-			dynamicSuggestions: true,
-		});
-		expect(pending).toHaveLength(0);
-		expect(h.value).toEqual(["Static A", "Static B"]);
+	test("shows three of the current page's prompts, one per tier first", async () => {
+		const h = await mount(BASE_CONFIG);
+		expect(h.value).toHaveLength(3);
+		const texts = PRICING_PROMPTS.map((p) => p.text);
+		for (const text of h.value) {
+			expect(texts).toContain(text);
+		}
 		h.unmount();
 	});
 
-	test("fetches the current page's prompts and swaps the pills", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
-		expect(pending).toHaveLength(1);
+	test("swaps the pills on SPA navigation and falls back on unseeded pages", async () => {
+		const h = await mount(BASE_CONFIG);
+		expect(h.value).toHaveLength(3);
 
-		const url = new URL(pending[0].url);
-		expect(url.pathname).toBe("/api/mcp/chat/suggestions");
-		expect(url.searchParams.get("channel")).toBe(BASE_CONFIG.channelId);
-		expect(url.searchParams.get("url")).toBe("/pricing");
-		expect(pending[0].headers.Authorization).toBe("Bearer wwp_test");
-
-		// Fixed list until the response lands — never a blank card.
-		expect(h.value).toEqual(["Static A", "Static B"]);
-
-		await h.settle(0, {
-			ok: true,
-			body: envelope([{ id: "p1", text: "What does Pro cost?" }]),
-		});
-		expect(h.value).toEqual(["What does Pro cost?"]);
-		h.unmount();
-	});
-
-	test("falls back to the fixed list on a non-200", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
-		await h.settle(0, { ok: false, body: { error: "INVALID_CHANNEL" } });
-		expect(h.value).toEqual(["Static A", "Static B"]);
-		h.unmount();
-	});
-
-	test("falls back when the page has no authored prompts", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
-		await h.settle(0, { ok: true, body: envelope([]) });
-		expect(h.value).toEqual(["Static A", "Static B"]);
-		h.unmount();
-	});
-
-	test("refetches with the new pathname on SPA navigation", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
-		await h.settle(0, {
-			ok: true,
-			body: envelope([{ id: "p1", text: "Pricing Q" }]),
-		});
-		expect(h.value).toEqual(["Pricing Q"]);
-
-		await h.navigate("/docs/getting-started");
-		expect(pending).toHaveLength(2);
-		expect(new URL(pending[1].url).searchParams.get("url")).toBe(
-			"/docs/getting-started",
-		);
-
-		await h.settle(1, {
-			ok: true,
-			body: envelope([{ id: "d1", text: "Docs Q" }]),
-		});
-		expect(h.value).toEqual(["Docs Q"]);
-		h.unmount();
-	});
-
-	test("a late response for the previous page never overwrites the current one", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
 		await h.navigate("/docs");
-
-		// The in-flight request for /pricing was aborted by the navigation.
-		expect(pending).toHaveLength(2);
-		expect(pending[0].signal?.aborted).toBe(true);
-
-		await h.settle(1, {
-			ok: true,
-			body: envelope([{ id: "d1", text: "Docs Q" }]),
-		});
 		expect(h.value).toEqual(["Docs Q"]);
 
-		// /pricing answers late — must be ignored.
-		await h.settle(0, {
-			ok: true,
-			body: envelope([{ id: "p1", text: "Pricing Q" }]),
-		});
+		await h.navigate("/blog/hello");
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("matches the authored entry regardless of casing or query noise", async () => {
+		const h = await mount(BASE_CONFIG);
+		await h.navigate("/Docs/?utm_source=x");
 		expect(h.value).toEqual(["Docs Q"]);
+		h.unmount();
+	});
+
+	test("keeps one picked set stable until the visitor navigates", async () => {
+		const h = await mount(BASE_CONFIG);
+		const first = h.value;
+		await h.navigate("/pricing#anchor");
+		// Same normalized pathname → same memoized pick, no reshuffle.
+		expect(h.value).toEqual(first);
 		h.unmount();
 	});
 });

--- a/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
+++ b/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
@@ -1,0 +1,311 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+// Type-only, so it doesn't pull the module in before the globals below exist.
+import type { EmbedConfig } from "../config";
+
+const win = new Window({ url: "https://host.example/pricing" });
+for (const key of [
+	"document",
+	"navigator",
+	"history",
+	"location",
+	"HTMLElement",
+	"HTMLDivElement",
+	"Element",
+	"Node",
+	"Text",
+	"Comment",
+	"DocumentFragment",
+	"Event",
+	"CustomEvent",
+	"requestAnimationFrame",
+	"cancelAnimationFrame",
+	"getComputedStyle",
+] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: happy-dom globals for the render harness
+	(globalThis as any)[key] = (win as any)[key];
+}
+// biome-ignore lint/suspicious/noExplicitAny: happy-dom globals for the render harness
+(globalThis as any).window = win;
+// biome-ignore lint/suspicious/noExplicitAny: react act environment flag
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// fetch stub — every call is parked until the test resolves it by hand, so a
+// response can be delivered *after* a navigation to prove the stale-overwrite
+// guard works. Deliberately does not reject on abort: what's under test is the
+// hook's own `signal.aborted` check, not AbortController itself.
+// ---------------------------------------------------------------------------
+
+interface PendingRequest {
+	url: string;
+	headers: Record<string, string>;
+	signal: AbortSignal | undefined;
+	resolve: (res: { ok: boolean; body: unknown }) => void;
+}
+
+let pending: PendingRequest[] = [];
+
+const originalFetch = globalThis.fetch;
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal fetch stand-in
+(globalThis as any).fetch = (input: any, init: any) =>
+	new Promise((resolveFetch) => {
+		pending.push({
+			url: String(input),
+			headers: (init?.headers ?? {}) as Record<string, string>,
+			signal: init?.signal,
+			resolve: ({ ok, body }) => resolveFetch({ ok, json: async () => body }),
+		});
+	});
+
+// Bun shares one global scope across test files. This stub never settles on
+// its own, so leaving it installed would hang every later file that fetches.
+afterAll(() => {
+	globalThis.fetch = originalFetch;
+});
+
+const { act, createElement } = await import("react");
+const { createRoot } = await import("react-dom/client");
+const { parseSuggestionsResponse, resolveSuggestions, usePageSuggestions } =
+	await import("../use-page-suggestions");
+
+const BASE_CONFIG: EmbedConfig = {
+	api: "https://app.waniwani.ai/api/mcp/chat",
+	token: "wwp_test",
+	channelId: "0b3d5f2e-1c4a-4f8b-9d2e-6a7c8b9d0e1f",
+	suggestions: ["Static A", "Static B"],
+};
+
+/** Mount a probe that surfaces the hook's resolved texts. */
+async function mount(config: EmbedConfig) {
+	const container = win.document.createElement("div");
+	let latest: string[] = [];
+	function Probe() {
+		latest = usePageSuggestions(config);
+		return null;
+	}
+	// biome-ignore lint/suspicious/noExplicitAny: happy-dom Element vs DOM Element
+	const root = createRoot(container as any);
+	await act(async () => {
+		root.render(createElement(Probe));
+	});
+	return {
+		get value() {
+			return latest;
+		},
+		async settle(index: number, res: { ok: boolean; body: unknown }) {
+			await act(async () => {
+				pending[index]?.resolve(res);
+			});
+		},
+		async navigate(pathname: string) {
+			await act(async () => {
+				win.history.pushState({}, "", pathname);
+			});
+		},
+		unmount() {
+			act(() => root.unmount());
+		},
+	};
+}
+
+const envelope = (suggestions: unknown) => ({
+	success: true,
+	message: "success",
+	data: { suggestions },
+});
+
+beforeEach(async () => {
+	pending = [];
+	await act(async () => {
+		win.history.pushState({}, "", "/pricing");
+	});
+});
+
+describe("parseSuggestionsResponse", () => {
+	test("reads the enveloped `data.suggestions` shape the API returns", () => {
+		expect(
+			parseSuggestionsResponse(
+				envelope([{ id: "pricing-1", text: "How much?" }]),
+			),
+		).toEqual([{ id: "pricing-1", text: "How much?" }]);
+	});
+
+	test("accepts a bare `{ suggestions }` root too", () => {
+		expect(
+			parseSuggestionsResponse({ suggestions: [{ id: null, text: "Hi" }] }),
+		).toEqual([{ id: null, text: "Hi" }]);
+	});
+
+	test("keeps ids so a later click can be attributed", () => {
+		const parsed = parseSuggestionsResponse(
+			envelope([
+				{ id: "a", text: "one" },
+				{ id: null, text: "two" },
+			]),
+		);
+		expect(parsed.map((s) => s.id)).toEqual(["a", null]);
+	});
+
+	test("coerces a non-string id to null rather than dropping the prompt", () => {
+		expect(parseSuggestionsResponse(envelope([{ id: 7, text: "ok" }]))).toEqual(
+			[{ id: null, text: "ok" }],
+		);
+	});
+
+	test("drops entries with no usable text", () => {
+		expect(
+			parseSuggestionsResponse(
+				envelope([
+					{ id: "a", text: "" },
+					{ id: "b" },
+					null,
+					{ id: "c", text: "kept" },
+				]),
+			),
+		).toEqual([{ id: "c", text: "kept" }]);
+	});
+
+	test("degrades to [] on malformed bodies", () => {
+		for (const body of [
+			null,
+			undefined,
+			{},
+			{ data: null },
+			{ data: { suggestions: "nope" } },
+			"not json",
+		]) {
+			expect(parseSuggestionsResponse(body)).toEqual([]);
+		}
+	});
+});
+
+describe("resolveSuggestions", () => {
+	const fallback = ["Static A", "Static B"];
+
+	test("prefers the page's own prompts", () => {
+		expect(
+			resolveSuggestions([{ id: "p1", text: "Page prompt" }], fallback),
+		).toEqual([{ id: "p1", text: "Page prompt" }]);
+	});
+
+	test("falls back when nothing was fetched", () => {
+		expect(resolveSuggestions(null, fallback)).toEqual([
+			{ id: null, text: "Static A" },
+			{ id: null, text: "Static B" },
+		]);
+	});
+
+	test("treats an empty fetched set as fall-back-client-side", () => {
+		expect(resolveSuggestions([], fallback)).toEqual([
+			{ id: null, text: "Static A" },
+			{ id: null, text: "Static B" },
+		]);
+	});
+
+	test("is empty when there is nothing on either side", () => {
+		expect(resolveSuggestions(null, undefined)).toEqual([]);
+		expect(resolveSuggestions([], [])).toEqual([]);
+	});
+});
+
+describe("usePageSuggestions", () => {
+	test("is inert without the flag — no request, fixed list", async () => {
+		const h = await mount({ ...BASE_CONFIG });
+		expect(pending).toHaveLength(0);
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("makes no request when the embed has no channelId", async () => {
+		const h = await mount({
+			...BASE_CONFIG,
+			channelId: undefined,
+			dynamicSuggestions: true,
+		});
+		expect(pending).toHaveLength(0);
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("fetches the current page's prompts and swaps the pills", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		expect(pending).toHaveLength(1);
+
+		const url = new URL(pending[0].url);
+		expect(url.pathname).toBe("/api/mcp/chat/suggestions");
+		expect(url.searchParams.get("channel")).toBe(BASE_CONFIG.channelId);
+		expect(url.searchParams.get("url")).toBe("/pricing");
+		expect(pending[0].headers.Authorization).toBe("Bearer wwp_test");
+
+		// Fixed list until the response lands — never a blank card.
+		expect(h.value).toEqual(["Static A", "Static B"]);
+
+		await h.settle(0, {
+			ok: true,
+			body: envelope([{ id: "p1", text: "What does Pro cost?" }]),
+		});
+		expect(h.value).toEqual(["What does Pro cost?"]);
+		h.unmount();
+	});
+
+	test("falls back to the fixed list on a non-200", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		await h.settle(0, { ok: false, body: { error: "INVALID_CHANNEL" } });
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("falls back when the page has no authored prompts", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		await h.settle(0, { ok: true, body: envelope([]) });
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("refetches with the new pathname on SPA navigation", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		await h.settle(0, {
+			ok: true,
+			body: envelope([{ id: "p1", text: "Pricing Q" }]),
+		});
+		expect(h.value).toEqual(["Pricing Q"]);
+
+		await h.navigate("/docs/getting-started");
+		expect(pending).toHaveLength(2);
+		expect(new URL(pending[1].url).searchParams.get("url")).toBe(
+			"/docs/getting-started",
+		);
+
+		await h.settle(1, {
+			ok: true,
+			body: envelope([{ id: "d1", text: "Docs Q" }]),
+		});
+		expect(h.value).toEqual(["Docs Q"]);
+		h.unmount();
+	});
+
+	test("a late response for the previous page never overwrites the current one", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		await h.navigate("/docs");
+
+		// The in-flight request for /pricing was aborted by the navigation.
+		expect(pending).toHaveLength(2);
+		expect(pending[0].signal?.aborted).toBe(true);
+
+		await h.settle(1, {
+			ok: true,
+			body: envelope([{ id: "d1", text: "Docs Q" }]),
+		});
+		expect(h.value).toEqual(["Docs Q"]);
+
+		// /pricing answers late — must be ignored.
+		await h.settle(0, {
+			ok: true,
+			body: envelope([{ id: "p1", text: "Pricing Q" }]),
+		});
+		expect(h.value).toEqual(["Docs Q"]);
+		h.unmount();
+	});
+});

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -119,6 +119,16 @@ export interface EmbedConfig {
 	/** Initial suggestion chips displayed before the first message. */
 	suggestions?: string[];
 	/**
+	 * Fetch page-aware starter prompts from `{api}/suggestions` on mount and on
+	 * every SPA navigation, instead of always rendering the fixed
+	 * {@link EmbedConfig.suggestions} list (which stays the fallback whenever
+	 * that request fails or returns nothing).
+	 *
+	 * Normally delivered per channel by `/config` (no `data-*` attribute maps
+	 * to it). Absent everywhere reads as `false`.
+	 */
+	dynamicSuggestions?: boolean;
+	/**
 	 * AI transparency notice rendered under the input (EU AI Act compliance).
 	 * String overrides the default wording; `false` hides it. Surfaced as
 	 * `data-disclaimer` on the embed script tag (use `data-disclaimer="false"`

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -50,16 +50,12 @@ export interface ChatAppearance {
  */
 export type ShowToolCalls = boolean | "titles-only";
 
-/**
- * Intent tier of one authored page prompt: low = discover, medium = compare,
- * high = act. The widget shows one prompt per tier.
- */
+/** Intent tier of a page prompt (discover/compare/act); one shown per tier. */
 export type PagePromptTier = "low" | "medium" | "high";
 
 /**
- * One authored per-page starter prompt as delivered by `/config`. `id` is the
- * authored entry's stable identity (click attribution); `tier` is absent on
- * prompts stored before tiers existed — those fill any tier slot.
+ * One authored page prompt from `/config`. `id` is the entry's stable
+ * identity; untagged (`tier` absent) prompts fill any tier slot.
  */
 export interface PagePrompt {
 	id: string | null;
@@ -142,13 +138,9 @@ export interface EmbedConfig {
 	/** Initial suggestion chips displayed before the first message. */
 	suggestions?: string[];
 	/**
-	 * Per-page starter prompt sets, keyed by normalized pathname. When the
-	 * current page matches an entry, the widget picks one prompt per intent
-	 * tier from it locally — re-picking on every SPA navigation — instead of
-	 * rendering the fixed {@link EmbedConfig.suggestions} list, which stays
-	 * the fallback for pages with no entry.
-	 *
-	 * Delivered per channel by `/config` (no `data-*` attribute maps to it).
+	 * Per-page starter prompt sets from `/config`; the widget picks from the
+	 * entry matching its pathname, falling back to `suggestions`. No `data-*`
+	 * attribute maps to it.
 	 */
 	pageSuggestions?: PageSuggestionsEntry[];
 	/**

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -51,6 +51,29 @@ export interface ChatAppearance {
 export type ShowToolCalls = boolean | "titles-only";
 
 /**
+ * Intent tier of one authored page prompt: low = discover, medium = compare,
+ * high = act. The widget shows one prompt per tier.
+ */
+export type PagePromptTier = "low" | "medium" | "high";
+
+/**
+ * One authored per-page starter prompt as delivered by `/config`. `id` is the
+ * authored entry's stable identity (click attribution); `tier` is absent on
+ * prompts stored before tiers existed — those fill any tier slot.
+ */
+export interface PagePrompt {
+	id: string | null;
+	text: string;
+	tier?: PagePromptTier;
+}
+
+/** Starter prompt set for one page, keyed by normalized pathname. */
+export interface PageSuggestionsEntry {
+	url: string;
+	prompts: PagePrompt[];
+}
+
+/**
  * Configuration for the embeddable chat widget.
  *
  * Resolution priority (later wins):
@@ -119,15 +142,15 @@ export interface EmbedConfig {
 	/** Initial suggestion chips displayed before the first message. */
 	suggestions?: string[];
 	/**
-	 * Fetch page-aware starter prompts from `{api}/suggestions` on mount and on
-	 * every SPA navigation, instead of always rendering the fixed
-	 * {@link EmbedConfig.suggestions} list (which stays the fallback whenever
-	 * that request fails or returns nothing).
+	 * Per-page starter prompt sets, keyed by normalized pathname. When the
+	 * current page matches an entry, the widget picks one prompt per intent
+	 * tier from it locally — re-picking on every SPA navigation — instead of
+	 * rendering the fixed {@link EmbedConfig.suggestions} list, which stays
+	 * the fallback for pages with no entry.
 	 *
-	 * Normally delivered per channel by `/config` (no `data-*` attribute maps
-	 * to it). Absent everywhere reads as `false`.
+	 * Delivered per channel by `/config` (no `data-*` attribute maps to it).
 	 */
-	dynamicSuggestions?: boolean;
+	pageSuggestions?: PageSuggestionsEntry[];
 	/**
 	 * AI transparency notice rendered under the input (EU AI Act compliance).
 	 * String overrides the default wording; `false` hides it. Surfaced as

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -37,6 +37,7 @@ import { cn } from "../lib/utils";
 import { themeToCSSProperties } from "../theme";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
+import { usePageSuggestions } from "./use-page-suggestions";
 import { usePathname, useVisibilityGate } from "./use-pathname";
 import { useScrollAppearance } from "./use-scroll-appearance";
 import { appearTriggerForPath } from "./visibility";
@@ -164,7 +165,10 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 			[userVars],
 		);
 
-		const suggestions = config.suggestions ?? [];
+		// Page-aware starter prompts when the channel opts in, otherwise exactly
+		// `config.suggestions`. Everything below (auto-expand, the card, the
+		// pills, the panel's initial set) reads this one resolved list.
+		const suggestions = usePageSuggestions(config);
 		// The dock is the chat's entry point, so it shows the configured input
 		// placeholder by default (`data-launcher-text` overrides it for a
 		// dock-specific prompt). Typed out like the in-chat input.
@@ -565,8 +569,8 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 									welcomeMessage={config.welcomeMessage}
 									placeholder={config.placeholder}
 									suggestions={
-										config.suggestions
-											? { initial: config.suggestions }
+										suggestions.length > 0
+											? { initial: suggestions }
 											: undefined
 									}
 									enableThreadHistory={config.enableThreadHistory}

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -569,7 +569,11 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 									welcomeMessage={config.welcomeMessage}
 									placeholder={config.placeholder}
 									suggestions={
-										suggestions.length > 0
+										// `config.suggestions` may be an explicitly-set empty
+										// array; passing `{ initial: [] }` then (as before this
+										// hook existed) keeps useSuggestions' streamed follow-up
+										// extraction enabled for hosts that rely on it.
+										config.suggestions || suggestions.length > 0
 											? { initial: suggestions }
 											: undefined
 									}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -138,7 +138,13 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 					welcomeMessage={config.welcomeMessage}
 					placeholder={config.placeholder}
 					suggestions={
-						suggestions.length > 0 ? { initial: suggestions } : undefined
+						// `config.suggestions` may be an explicitly-set empty array;
+						// passing `{ initial: [] }` then (as before this hook existed)
+						// keeps useSuggestions' streamed follow-up extraction enabled
+						// for hosts that rely on it.
+						config.suggestions || suggestions.length > 0
+							? { initial: suggestions }
+							: undefined
 					}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -17,6 +17,7 @@ import type { ChatHandle } from "../@types";
 import { ChatEmbed } from "../layouts/chat-embed";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
+import { usePageSuggestions } from "./use-page-suggestions";
 import { useVisibilityGate } from "./use-pathname";
 import { createWidgetEventEmitter } from "./widget-events";
 import { WidgetEventsProvider } from "./widget-events-context";
@@ -109,6 +110,10 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 			[],
 		);
 
+		// Page-aware starter prompts when the channel opts in, otherwise exactly
+		// `config.suggestions`.
+		const suggestions = usePageSuggestions(config);
+
 		// `mode` tags every chat request with the embed surface so server-logged
 		// chat events carry it in `properties.mode`, matching `page.viewed`.
 		const body: Record<string, unknown> = { mode: "inline" };
@@ -133,7 +138,7 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 					welcomeMessage={config.welcomeMessage}
 					placeholder={config.placeholder}
 					suggestions={
-						config.suggestions ? { initial: config.suggestions } : undefined
+						suggestions.length > 0 ? { initial: suggestions } : undefined
 					}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -84,6 +84,12 @@ interface RemoteConfigResponse {
 	title: string | null;
 	placeholder: string | null;
 	suggestions: string[] | null;
+	/**
+	 * When true the widget fetches per-page starter prompts from
+	 * `/suggestions` and only uses `suggestions` as the fallback. Absent on
+	 * servers that predate the flag → `false`.
+	 */
+	dynamicSuggestions?: boolean | null;
 	enableThreadHistory?: boolean | null;
 	/**
 	 * Channel-specific event source (e.g. the integration/source this channel
@@ -170,6 +176,9 @@ function remoteToConfigPartial(
 	}
 	if (data.suggestions != null && data.suggestions.length > 0) {
 		out.suggestions = data.suggestions;
+	}
+	if (typeof data.dynamicSuggestions === "boolean") {
+		out.dynamicSuggestions = data.dynamicSuggestions;
 	}
 	if (typeof data.enableThreadHistory === "boolean") {
 		out.enableThreadHistory = data.enableThreadHistory;

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -86,10 +86,8 @@ interface RemoteConfigResponse {
 	placeholder: string | null;
 	suggestions: string[] | null;
 	/**
-	 * Per-page starter prompt sets, keyed by normalized pathname. Present only
-	 * while the channel has the feature switched on; the widget picks from the
-	 * matching entry locally and uses `suggestions` as the fallback. Absent on
-	 * servers that predate the field.
+	 * Per-page starter prompt sets; present only while the channel has the
+	 * feature on. Absent on servers that predate the field.
 	 */
 	pageSuggestions?: unknown;
 	enableThreadHistory?: boolean | null;

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -11,6 +11,7 @@ import { debugLog } from "../lib/debug";
 import { firePageView } from "../lib/page-view";
 import type { EmbedConfig } from "./config";
 import { resolveConfig } from "./config";
+import { parsePageSuggestions } from "./use-page-suggestions";
 import type { VisibilityRules } from "./visibility";
 
 // ---------------------------------------------------------------------------
@@ -85,11 +86,12 @@ interface RemoteConfigResponse {
 	placeholder: string | null;
 	suggestions: string[] | null;
 	/**
-	 * When true the widget fetches per-page starter prompts from
-	 * `/suggestions` and only uses `suggestions` as the fallback. Absent on
-	 * servers that predate the flag → `false`.
+	 * Per-page starter prompt sets, keyed by normalized pathname. Present only
+	 * while the channel has the feature switched on; the widget picks from the
+	 * matching entry locally and uses `suggestions` as the fallback. Absent on
+	 * servers that predate the field.
 	 */
-	dynamicSuggestions?: boolean | null;
+	pageSuggestions?: unknown;
 	enableThreadHistory?: boolean | null;
 	/**
 	 * Channel-specific event source (e.g. the integration/source this channel
@@ -177,8 +179,9 @@ function remoteToConfigPartial(
 	if (data.suggestions != null && data.suggestions.length > 0) {
 		out.suggestions = data.suggestions;
 	}
-	if (typeof data.dynamicSuggestions === "boolean") {
-		out.dynamicSuggestions = data.dynamicSuggestions;
+	const pageSuggestions = parsePageSuggestions(data.pageSuggestions);
+	if (pageSuggestions.length > 0) {
+		out.pageSuggestions = pageSuggestions;
 	}
 	if (typeof data.enableThreadHistory === "boolean") {
 		out.enableThreadHistory = data.enableThreadHistory;

--- a/src/chat/web/embed/use-page-suggestions.ts
+++ b/src/chat/web/embed/use-page-suggestions.ts
@@ -1,142 +1,205 @@
 // ============================================================================
 // usePageSuggestions — starter prompts for the page the widget sits on.
 //
-// A channel with `dynamicSuggestions` on authors prompts per URL, so the pills
-// should change as the visitor moves around the host site. This fetches them
-// from `GET {api}/suggestions` on mount and again on every SPA navigation
-// (via `usePathname`), and falls back to the channel's fixed `suggestions`
-// whenever the request fails, is unauthorized, or comes back empty — the pills
-// are decoration on the entry point, never a hard dependency.
+// A channel with page-aware prompts delivers them in `/config` as
+// `pageSuggestions` entries keyed by normalized pathname. The widget matches
+// its location against those entries locally — no per-page request — and
+// re-picks on every SPA navigation (via `usePathname`). Pages with no entry
+// (or a channel with none) fall back to the channel's fixed `suggestions` —
+// the pills are decoration on the entry point, never a hard dependency.
 // ============================================================================
 
-import { useEffect, useMemo, useState } from "react";
-import { buildApiUrl } from "../lib/api-url";
+import { useMemo } from "react";
 import { debugLog } from "../lib/debug";
-import type { EmbedConfig } from "./config";
+import type {
+	EmbedConfig,
+	PagePrompt,
+	PagePromptTier,
+	PageSuggestionsEntry,
+} from "./config";
 import { usePathname } from "./use-pathname";
 
 /**
  * One starter prompt. `id` identifies an authored per-page prompt so a click
  * can be attributed back to it; it is `null` for prompts coming from the
  * channel's fixed `suggestions` list, which have no stored identity. Ids stop
- * at this hook's fetch state — the embeds render texts — parked there so click
- * attribution can pick them up without re-plumbing the fetch.
+ * at this hook's resolve state — the embeds render texts — parked there so
+ * click attribution can pick them up without re-plumbing the resolve.
  */
 export interface PageSuggestion {
 	id: string | null;
 	text: string;
 }
 
+/** How many of a page's authored prompts the widget shows at a time. */
+const SHOWN_PROMPT_COUNT = 3;
+
 /**
- * Pull the prompt list out of a `/suggestions` response body.
- *
- * The Waniwani API wraps payloads in `{ success, message, data }`; a bare
- * `{ suggestions }` root is accepted too so we stay compatible with raw
- * endpoints, matching how `fetchRemoteConfig` unwraps `/config`. Anything
- * malformed degrades to `[]`, which the caller reads as "use the fallback".
+ * Intent tiers in display order: educational / discovery first, action last.
+ * One prompt is shown per tier, so a visitor sees a next step for every level
+ * of buying intent.
  */
-export function parseSuggestionsResponse(raw: unknown): PageSuggestion[] {
-	const body = raw as {
-		data?: { suggestions?: unknown } | null;
-		suggestions?: unknown;
-	} | null;
-	const list = body?.data?.suggestions ?? body?.suggestions;
-	if (!Array.isArray(list)) {
+const TIER_ORDER: PagePromptTier[] = ["low", "medium", "high"];
+
+function takeRandom<T>(pool: T[]): T | undefined {
+	if (pool.length === 0) {
+		return undefined;
+	}
+	const index = Math.floor(Math.random() * pool.length);
+	const [taken] = pool.splice(index, 1);
+	return taken;
+}
+
+/**
+ * Pick up to {@link SHOWN_PROMPT_COUNT} prompts, one per intent tier in
+ * {@link TIER_ORDER}. A tier with no tagged prompt borrows from the untagged
+ * (wildcard) pool, and any slot still empty is filled from whatever remains —
+ * so a page with at least {@link SHOWN_PROMPT_COUNT} stored prompts always
+ * shows exactly that many, and an all-untagged pool degrades to a uniform
+ * random pick. Random within each pool so exposure spreads across visits.
+ */
+export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
+	const byTier = new Map<PagePromptTier, PagePrompt[]>();
+	const wildcards: PagePrompt[] = [];
+	for (const prompt of prompts) {
+		if (prompt.tier) {
+			const pool = byTier.get(prompt.tier) ?? [];
+			pool.push(prompt);
+			byTier.set(prompt.tier, pool);
+		} else {
+			wildcards.push(prompt);
+		}
+	}
+
+	const picked: PagePrompt[] = [];
+	for (const tier of TIER_ORDER) {
+		const fromTier = takeRandom(byTier.get(tier) ?? []);
+		const choice = fromTier ?? takeRandom(wildcards);
+		if (choice) {
+			picked.push(choice);
+		}
+	}
+
+	const leftovers = [...byTier.values()].flat().concat(wildcards);
+	while (picked.length < Math.min(SHOWN_PROMPT_COUNT, prompts.length)) {
+		const filler = takeRandom(leftovers);
+		if (!filler) {
+			break;
+		}
+		picked.push(filler);
+	}
+	return picked;
+}
+
+/**
+ * Reduce a URL or pathname to the form `pageSuggestions` entries are keyed
+ * by: pathname only, query and hash dropped, no trailing slash (root stays
+ * `/`), lowercased. Mirrors the server's authoring-side normalization, so a
+ * set authored for `https://site.com/Pricing/` is the one a widget on
+ * `/pricing` picks up. Anything unparseable normalizes to `/`.
+ */
+export function normalizePathname(url: string): string {
+	let pathname: string;
+	try {
+		// A base is required to parse a bare pathname; only the pathname
+		// survives, so the base itself is discarded.
+		pathname = new URL(url, "http://localhost").pathname;
+	} catch {
+		pathname = "/";
+	}
+	const trimmed = pathname.replace(/\/+$/, "");
+	return (trimmed === "" ? "/" : trimmed).toLowerCase();
+}
+
+/**
+ * Validate a `pageSuggestions` value from `/config` into typed entries.
+ *
+ * Malformed entries and prompts degrade by dropping out rather than throwing —
+ * remote config is a convenience layer, never required for the widget to
+ * function. An entry left with no usable prompts is dropped whole, so the
+ * page it named falls back to the fixed list.
+ */
+export function parsePageSuggestions(value: unknown): PageSuggestionsEntry[] {
+	if (!Array.isArray(value)) {
 		return [];
 	}
-	return list.flatMap((entry): PageSuggestion[] => {
-		const item = entry as Partial<PageSuggestion> | null;
-		if (typeof item?.text !== "string" || item.text.length === 0) {
+	return value.flatMap((entry): PageSuggestionsEntry[] => {
+		const item = entry as {
+			url?: unknown;
+			prompts?: unknown;
+		} | null;
+		if (
+			typeof item?.url !== "string" ||
+			item.url.length === 0 ||
+			!Array.isArray(item.prompts)
+		) {
 			return [];
 		}
-		return [
-			{ id: typeof item.id === "string" ? item.id : null, text: item.text },
-		];
+		const prompts = item.prompts.flatMap((raw): PagePrompt[] => {
+			const prompt = raw as Partial<PagePrompt> | null;
+			if (typeof prompt?.text !== "string" || prompt.text.length === 0) {
+				return [];
+			}
+			return [
+				{
+					id: typeof prompt.id === "string" ? prompt.id : null,
+					text: prompt.text,
+					tier:
+						prompt.tier === "low" ||
+						prompt.tier === "medium" ||
+						prompt.tier === "high"
+							? prompt.tier
+							: undefined,
+				},
+			];
+		});
+		return prompts.length > 0 ? [{ url: item.url, prompts }] : [];
 	});
 }
 
 /**
- * The list to render: the page's own prompts when we have any, otherwise the
- * channel's fixed `suggestions`. An empty fetched set counts as "nothing
- * authored for this page" and falls back, per the endpoint contract.
+ * The list to render: the page's own picked prompts when we have any,
+ * otherwise the channel's fixed `suggestions`.
  */
 export function resolveSuggestions(
-	fetched: PageSuggestion[] | null,
+	picked: PageSuggestion[] | null,
 	fallback: string[] | undefined,
 ): PageSuggestion[] {
-	if (fetched && fetched.length > 0) {
-		return fetched;
+	if (picked && picked.length > 0) {
+		return picked;
 	}
 	return (fallback ?? []).map((text) => ({ id: null, text }));
 }
 
 /**
  * Resolved starter prompt texts for the current page, with a stable array
- * identity between fetches — `useSuggestions` (inside `ChatEmbed`) keys an
+ * identity between navigations — `useSuggestions` (inside `ChatEmbed`) keys an
  * effect on the `initial` array identity and setStates it, so a fresh array
- * each render would loop.
+ * each render would loop. The random per-tier pick happens inside the memo,
+ * so one set stays up until the visitor navigates.
  *
- * Inert unless the channel reported `dynamicSuggestions: true` — without it
- * (including against servers that predate the flag) this is exactly
- * `config.suggestions`, no request made.
- *
- * `channelId` is required: `/suggestions` takes no environment default and
- * rejects a missing or non-uuid `channel` with a 400, so an embed configured
- * without one stays on the fixed list.
+ * Inert without `config.pageSuggestions` — against servers that predate the
+ * field (or a channel with the feature off, which never receives it) this is
+ * exactly `config.suggestions`.
  */
 export function usePageSuggestions(config: EmbedConfig): string[] {
-	const { api, token, channelId, dynamicSuggestions } = config;
-	// Re-runs the fetch on client-side route changes, not just hard loads.
+	const { pageSuggestions, suggestions } = config;
+	// Re-picks on client-side route changes, not just hard loads.
 	const pathname = usePathname();
-	const [fetched, setFetched] = useState<PageSuggestion[] | null>(null);
 
-	const enabled = Boolean(dynamicSuggestions && api && token && channelId);
-
-	useEffect(() => {
-		if (!enabled || !api || !token || !channelId) {
-			return;
-		}
-		// Aborting on cleanup is what keeps a slow response for the page the
-		// visitor just left from overwriting the page they are on now.
-		const controller = new AbortController();
-		void (async () => {
-			try {
-				const url = buildApiUrl(api, "/suggestions", {
-					channel: channelId,
-					// The pathname this effect run is for — the server normalizes it,
-					// and it is all the host page needs to leak.
-					url: pathname,
-				});
-				const res = await fetch(url, {
-					method: "GET",
-					headers: { Authorization: `Bearer ${token}` },
-					signal: controller.signal,
-				});
-				const items = res.ok ? parseSuggestionsResponse(await res.json()) : [];
-				if (controller.signal.aborted) {
-					return;
-				}
-				debugLog("remote /suggestions response", {
-					pathname,
-					ok: res.ok,
-					count: items.length,
-				});
-				// `null` rather than `[]` so the resolve below reads it as "no
-				// page-specific set" and hands back the channel's fixed list.
-				setFetched(items.length > 0 ? items : null);
-			} catch {
-				// Network error / abort — keep whatever we last resolved to on an
-				// abort, otherwise drop back to the fallback.
-				if (!controller.signal.aborted) {
-					setFetched(null);
-				}
-			}
-		})();
-		return () => controller.abort();
-	}, [enabled, api, token, channelId, pathname]);
-
-	return useMemo(
-		() => resolveSuggestions(fetched, config.suggestions).map((s) => s.text),
-		[fetched, config.suggestions],
-	);
+	return useMemo(() => {
+		const current = normalizePathname(pathname);
+		const page = pageSuggestions?.find(
+			(entry) => normalizePathname(entry.url) === current,
+		);
+		const picked = page
+			? pickPagePrompts(page.prompts).map(({ id, text }) => ({ id, text }))
+			: null;
+		debugLog("page suggestions resolve", {
+			pathname: current,
+			matched: Boolean(page),
+			count: picked?.length ?? 0,
+		});
+		return resolveSuggestions(picked, suggestions).map((s) => s.text);
+	}, [pathname, pageSuggestions, suggestions]);
 }

--- a/src/chat/web/embed/use-page-suggestions.ts
+++ b/src/chat/web/embed/use-page-suggestions.ts
@@ -1,7 +1,3 @@
-// Starter prompts for the page the widget sits on: `/config` delivers
-// per-page sets keyed by normalized pathname; the widget matches its location
-// locally, re-picks on SPA navigation, and falls back to the fixed list.
-
 import { useMemo } from "react";
 import { DEFAULT_SUGGESTION_ORIGINS } from "../hooks/use-suggestions";
 import { debugLog } from "../lib/debug";
@@ -34,10 +30,8 @@ function takeRandom<T>(pool: T[]): T | undefined {
 	return taken;
 }
 
-/**
- * Pick up to {@link SHOWN_PROMPT_COUNT} prompts, one per tier; untagged
- * prompts fill any slot, leftovers top up short slots. Random within pools.
- */
+/** Up to {@link SHOWN_PROMPT_COUNT} prompts, one per tier, random within pools;
+ *  untagged prompts fill any slot and leftovers top up short slots. */
 export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 	const byTier = new Map<PagePromptTier, PagePrompt[]>();
 	const wildcards: PagePrompt[] = [];
@@ -70,10 +64,7 @@ export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 	return picked;
 }
 
-/**
- * URL or pathname → the entry key: pathname only, no query/hash/trailing
- * slash, lowercased (mirrors the server's normalization); unparseable → `/`.
- */
+/** URL → entry key: pathname only, lowercased, no query/hash/trailing slash. */
 export function normalizePathname(url: string): string {
 	let pathname: string;
 	try {
@@ -135,12 +126,8 @@ export function resolveSuggestions(
 	return (fallback ?? []).map((text) => ({ id: null, text }));
 }
 
-/**
- * Starter prompt texts for the current page. Memoized: one pick per pathname,
- * stable array identity (useSuggestions keys an effect on it). Inert — exactly
- * `config.suggestions` — without `pageSuggestions` or when the host's
- * `suggestionOrigins` excludes `"page"`.
- */
+/** Starter prompt texts for the current page, else `config.suggestions`.
+ *  @param config the resolved embed config (`pageSuggestions` opts in). */
 export function usePageSuggestions(config: EmbedConfig): string[] {
 	const { pageSuggestions, suggestions, suggestionOrigins } = config;
 	const pathname = usePathname();
@@ -148,6 +135,8 @@ export function usePageSuggestions(config: EmbedConfig): string[] {
 		suggestionOrigins ?? DEFAULT_SUGGESTION_ORIGINS
 	).includes("page");
 
+	// Memoized because the pick is random and the identity has to hold:
+	// `useSuggestions` keys an effect on this array and setStates it.
 	return useMemo(() => {
 		const current = normalizePathname(pathname);
 		const page = pageEnabled

--- a/src/chat/web/embed/use-page-suggestions.ts
+++ b/src/chat/web/embed/use-page-suggestions.ts
@@ -1,12 +1,8 @@
 // ============================================================================
 // usePageSuggestions — starter prompts for the page the widget sits on.
-//
-// A channel with page-aware prompts delivers them in `/config` as
-// `pageSuggestions` entries keyed by normalized pathname. The widget matches
-// its location against those entries locally — no per-page request — and
-// re-picks on every SPA navigation (via `usePathname`). Pages with no entry
-// (or a channel with none) fall back to the channel's fixed `suggestions` —
-// the pills are decoration on the entry point, never a hard dependency.
+// `/config` delivers per-page sets (`pageSuggestions`, keyed by normalized
+// pathname); the widget matches its location locally and re-picks on SPA
+// navigation. Unmatched pages fall back to the fixed `suggestions`.
 // ============================================================================
 
 import { useMemo } from "react";
@@ -20,11 +16,8 @@ import type {
 import { usePathname } from "./use-pathname";
 
 /**
- * One starter prompt. `id` identifies an authored per-page prompt so a click
- * can be attributed back to it; it is `null` for prompts coming from the
- * channel's fixed `suggestions` list, which have no stored identity. Ids stop
- * at this hook's resolve state — the embeds render texts — parked there so
- * click attribution can pick them up without re-plumbing the resolve.
+ * One starter prompt. `id` is the authored entry's identity (click
+ * attribution later); `null` for prompts from the fixed list.
  */
 export interface PageSuggestion {
 	id: string | null;
@@ -34,11 +27,7 @@ export interface PageSuggestion {
 /** How many of a page's authored prompts the widget shows at a time. */
 const SHOWN_PROMPT_COUNT = 3;
 
-/**
- * Intent tiers in display order: educational / discovery first, action last.
- * One prompt is shown per tier, so a visitor sees a next step for every level
- * of buying intent.
- */
+/** Tier display order. One prompt is shown per tier. */
 const TIER_ORDER: PagePromptTier[] = ["low", "medium", "high"];
 
 function takeRandom<T>(pool: T[]): T | undefined {
@@ -51,12 +40,8 @@ function takeRandom<T>(pool: T[]): T | undefined {
 }
 
 /**
- * Pick up to {@link SHOWN_PROMPT_COUNT} prompts, one per intent tier in
- * {@link TIER_ORDER}. A tier with no tagged prompt borrows from the untagged
- * (wildcard) pool, and any slot still empty is filled from whatever remains —
- * so a page with at least {@link SHOWN_PROMPT_COUNT} stored prompts always
- * shows exactly that many, and an all-untagged pool degrades to a uniform
- * random pick. Random within each pool so exposure spreads across visits.
+ * Pick up to {@link SHOWN_PROMPT_COUNT} prompts, one per tier; untagged
+ * prompts fill any slot, leftovers top up short slots. Random within pools.
  */
 export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 	const byTier = new Map<PagePromptTier, PagePrompt[]>();
@@ -73,8 +58,7 @@ export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 
 	const picked: PagePrompt[] = [];
 	for (const tier of TIER_ORDER) {
-		const fromTier = takeRandom(byTier.get(tier) ?? []);
-		const choice = fromTier ?? takeRandom(wildcards);
+		const choice = takeRandom(byTier.get(tier) ?? []) ?? takeRandom(wildcards);
 		if (choice) {
 			picked.push(choice);
 		}
@@ -92,17 +76,13 @@ export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 }
 
 /**
- * Reduce a URL or pathname to the form `pageSuggestions` entries are keyed
- * by: pathname only, query and hash dropped, no trailing slash (root stays
- * `/`), lowercased. Mirrors the server's authoring-side normalization, so a
- * set authored for `https://site.com/Pricing/` is the one a widget on
- * `/pricing` picks up. Anything unparseable normalizes to `/`.
+ * URL or pathname → the key `pageSuggestions` entries use: pathname only, no
+ * query/hash/trailing slash, lowercased. Mirrors the server's authoring-side
+ * normalization; unparseable input becomes `/`.
  */
 export function normalizePathname(url: string): string {
 	let pathname: string;
 	try {
-		// A base is required to parse a bare pathname; only the pathname
-		// survives, so the base itself is discarded.
 		pathname = new URL(url, "http://localhost").pathname;
 	} catch {
 		pathname = "/";
@@ -112,12 +92,9 @@ export function normalizePathname(url: string): string {
 }
 
 /**
- * Validate a `pageSuggestions` value from `/config` into typed entries.
- *
- * Malformed entries and prompts degrade by dropping out rather than throwing —
- * remote config is a convenience layer, never required for the widget to
- * function. An entry left with no usable prompts is dropped whole, so the
- * page it named falls back to the fixed list.
+ * Validate a raw `pageSuggestions` value into typed entries. Malformed
+ * entries/prompts drop out instead of throwing; an entry left empty is
+ * dropped whole.
  */
 export function parsePageSuggestions(value: unknown): PageSuggestionsEntry[] {
 	if (!Array.isArray(value)) {
@@ -157,10 +134,7 @@ export function parsePageSuggestions(value: unknown): PageSuggestionsEntry[] {
 	});
 }
 
-/**
- * The list to render: the page's own picked prompts when we have any,
- * otherwise the channel's fixed `suggestions`.
- */
+/** The page's picked prompts when there are any, else the fixed fallback. */
 export function resolveSuggestions(
 	picked: PageSuggestion[] | null,
 	fallback: string[] | undefined,
@@ -172,19 +146,12 @@ export function resolveSuggestions(
 }
 
 /**
- * Resolved starter prompt texts for the current page, with a stable array
- * identity between navigations — `useSuggestions` (inside `ChatEmbed`) keys an
- * effect on the `initial` array identity and setStates it, so a fresh array
- * each render would loop. The random per-tier pick happens inside the memo,
- * so one set stays up until the visitor navigates.
- *
- * Inert without `config.pageSuggestions` — against servers that predate the
- * field (or a channel with the feature off, which never receives it) this is
- * exactly `config.suggestions`.
+ * Starter prompt texts for the current page. Memoized so the pick is stable
+ * per pathname and the array identity doesn't loop `useSuggestions`' effect.
+ * Without `config.pageSuggestions` this is exactly `config.suggestions`.
  */
 export function usePageSuggestions(config: EmbedConfig): string[] {
 	const { pageSuggestions, suggestions } = config;
-	// Re-picks on client-side route changes, not just hard loads.
 	const pathname = usePathname();
 
 	return useMemo(() => {

--- a/src/chat/web/embed/use-page-suggestions.ts
+++ b/src/chat/web/embed/use-page-suggestions.ts
@@ -1,0 +1,142 @@
+// ============================================================================
+// usePageSuggestions — starter prompts for the page the widget sits on.
+//
+// A channel with `dynamicSuggestions` on authors prompts per URL, so the pills
+// should change as the visitor moves around the host site. This fetches them
+// from `GET {api}/suggestions` on mount and again on every SPA navigation
+// (via `usePathname`), and falls back to the channel's fixed `suggestions`
+// whenever the request fails, is unauthorized, or comes back empty — the pills
+// are decoration on the entry point, never a hard dependency.
+// ============================================================================
+
+import { useEffect, useMemo, useState } from "react";
+import { buildApiUrl } from "../lib/api-url";
+import { debugLog } from "../lib/debug";
+import type { EmbedConfig } from "./config";
+import { usePathname } from "./use-pathname";
+
+/**
+ * One starter prompt. `id` identifies an authored per-page prompt so a click
+ * can be attributed back to it; it is `null` for prompts coming from the
+ * channel's fixed `suggestions` list, which have no stored identity. Ids stop
+ * at this hook's fetch state — the embeds render texts — parked there so click
+ * attribution can pick them up without re-plumbing the fetch.
+ */
+export interface PageSuggestion {
+	id: string | null;
+	text: string;
+}
+
+/**
+ * Pull the prompt list out of a `/suggestions` response body.
+ *
+ * The Waniwani API wraps payloads in `{ success, message, data }`; a bare
+ * `{ suggestions }` root is accepted too so we stay compatible with raw
+ * endpoints, matching how `fetchRemoteConfig` unwraps `/config`. Anything
+ * malformed degrades to `[]`, which the caller reads as "use the fallback".
+ */
+export function parseSuggestionsResponse(raw: unknown): PageSuggestion[] {
+	const body = raw as {
+		data?: { suggestions?: unknown } | null;
+		suggestions?: unknown;
+	} | null;
+	const list = body?.data?.suggestions ?? body?.suggestions;
+	if (!Array.isArray(list)) {
+		return [];
+	}
+	return list.flatMap((entry): PageSuggestion[] => {
+		const item = entry as Partial<PageSuggestion> | null;
+		if (typeof item?.text !== "string" || item.text.length === 0) {
+			return [];
+		}
+		return [
+			{ id: typeof item.id === "string" ? item.id : null, text: item.text },
+		];
+	});
+}
+
+/**
+ * The list to render: the page's own prompts when we have any, otherwise the
+ * channel's fixed `suggestions`. An empty fetched set counts as "nothing
+ * authored for this page" and falls back, per the endpoint contract.
+ */
+export function resolveSuggestions(
+	fetched: PageSuggestion[] | null,
+	fallback: string[] | undefined,
+): PageSuggestion[] {
+	if (fetched && fetched.length > 0) {
+		return fetched;
+	}
+	return (fallback ?? []).map((text) => ({ id: null, text }));
+}
+
+/**
+ * Resolved starter prompt texts for the current page, with a stable array
+ * identity between fetches — `useSuggestions` (inside `ChatEmbed`) keys an
+ * effect on the `initial` array identity and setStates it, so a fresh array
+ * each render would loop.
+ *
+ * Inert unless the channel reported `dynamicSuggestions: true` — without it
+ * (including against servers that predate the flag) this is exactly
+ * `config.suggestions`, no request made.
+ *
+ * `channelId` is required: `/suggestions` takes no environment default and
+ * rejects a missing or non-uuid `channel` with a 400, so an embed configured
+ * without one stays on the fixed list.
+ */
+export function usePageSuggestions(config: EmbedConfig): string[] {
+	const { api, token, channelId, dynamicSuggestions } = config;
+	// Re-runs the fetch on client-side route changes, not just hard loads.
+	const pathname = usePathname();
+	const [fetched, setFetched] = useState<PageSuggestion[] | null>(null);
+
+	const enabled = Boolean(dynamicSuggestions && api && token && channelId);
+
+	useEffect(() => {
+		if (!enabled || !api || !token || !channelId) {
+			return;
+		}
+		// Aborting on cleanup is what keeps a slow response for the page the
+		// visitor just left from overwriting the page they are on now.
+		const controller = new AbortController();
+		void (async () => {
+			try {
+				const url = buildApiUrl(api, "/suggestions", {
+					channel: channelId,
+					// The pathname this effect run is for — the server normalizes it,
+					// and it is all the host page needs to leak.
+					url: pathname,
+				});
+				const res = await fetch(url, {
+					method: "GET",
+					headers: { Authorization: `Bearer ${token}` },
+					signal: controller.signal,
+				});
+				const items = res.ok ? parseSuggestionsResponse(await res.json()) : [];
+				if (controller.signal.aborted) {
+					return;
+				}
+				debugLog("remote /suggestions response", {
+					pathname,
+					ok: res.ok,
+					count: items.length,
+				});
+				// `null` rather than `[]` so the resolve below reads it as "no
+				// page-specific set" and hands back the channel's fixed list.
+				setFetched(items.length > 0 ? items : null);
+			} catch {
+				// Network error / abort — keep whatever we last resolved to on an
+				// abort, otherwise drop back to the fallback.
+				if (!controller.signal.aborted) {
+					setFetched(null);
+				}
+			}
+		})();
+		return () => controller.abort();
+	}, [enabled, api, token, channelId, pathname]);
+
+	return useMemo(
+		() => resolveSuggestions(fetched, config.suggestions).map((s) => s.text),
+		[fetched, config.suggestions],
+	);
+}


### PR DESCRIPTION
Closes WAN-702

## Summary

Widget half of the M1 walking skeleton of [Dynamic prompt suggestions](https://linear.app/waniwani/project/dynamic-prompt-suggestions-536757cd54d5) — server half: WaniWani-AI/app#924.

When `/config` reports `dynamicSuggestions: true`, the embed fetches page-aware starter prompts from `{api}/suggestions` on mount and on every SPA navigation (via the existing `usePathname` pushState/replaceState patch) and swaps the pills — floating and inline. In-flight requests abort on navigation so a slow response for the page the visitor just left can never overwrite the current one; any failure or empty set falls back to the channel's fixed `suggestions`. Channels without the flag — including servers that predate it — see zero behavior change and no request.

`usePageSuggestions` returns a stable-identity `string[]` (`useSuggestions` inside `ChatEmbed` keys an effect on the `initial` array identity); ids from authored prompts stay in the hook's fetch state, ready for the click-tracking ticket.

## How to see it working

Needs WaniWani-AI/app#924 running locally with seeded prompts (seed SQL in that PR's description):

1. `bun run build` here (`dist/` is gitignored).
2. Serve a static page with:
   ```html
   <script src="/dist/chat/embed.js" defer data-token="wwp_…" data-channel-id="<uuid>" data-api="http://localhost:3000/api/mcp/chat" data-mode="floating"></script>
   ```
3. On `/pricing` the pills show 3 of the 6 seeded prompts; `history.pushState({}, "", "/docs")` in the console refetches for `/docs` (fixed list if unseeded). `window.WANIWANI_DEBUG = true` logs the `/suggestions` responses.

## Review focus

- `parseSuggestionsResponse` reads the enveloped `body.data.suggestions` (bare-root fallback mirrors `fetchRemoteConfig`).
- The abort behavior and its test: "a late response for the previous page never overwrites the current one".
- Release timing: publishing rolls out to every deployed embed via jsdelivr `@latest` — do not release until app#924 is deployed to production. (The two pre-existing `useChatEngine – thread history` test failures are on `main` too, unrelated.)
