### PR TITLE
feat(chat): record starter-prompt clicks as suggestion.clicked events (WAN-714)

### DIFF
--- a/src/chat/web/components/suggestions.tsx
+++ b/src/chat/web/components/suggestions.tsx
@@ -38,8 +38,12 @@ export function Suggestions({
 								type="button"
 								onClick={() => onSelect(suggestion)}
 								className={cn(
-									"ww:rounded-full ww:border ww:border-border ww:bg-background ww:px-3.5 ww:py-1.5 ww:text-sm",
-									"ww:text-foreground ww:hover:bg-accent ww:hover:border-primary/30",
+									// `bg-accent`, not `bg-background`: inside the open panel the
+									// pills sit on the background color itself, where a
+									// background-filled pill with a hairline border is
+									// indistinguishable from plain text.
+									"ww:rounded-full ww:border ww:border-border ww:bg-accent ww:px-3.5 ww:py-1.5 ww:text-sm",
+									"ww:text-foreground ww:hover:bg-border ww:hover:border-primary/30",
 									"ww:transition-all ww:duration-200 ww:ease-out ww:cursor-pointer",
 									"ww:animate-[ww-fade-in_0.2s_ease-out_both]",
 								)}

--- a/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
+++ b/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
@@ -1,7 +1,7 @@
-import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { Window } from "happy-dom";
 // Type-only, so it doesn't pull the module in before the globals below exist.
-import type { EmbedConfig } from "../config";
+import type { EmbedConfig, PagePrompt } from "../config";
 
 const win = new Window({ url: "https://host.example/pricing" });
 for (const key of [
@@ -30,51 +30,34 @@ for (const key of [
 // biome-ignore lint/suspicious/noExplicitAny: react act environment flag
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
-// ---------------------------------------------------------------------------
-// fetch stub — every call is parked until the test resolves it by hand, so a
-// response can be delivered *after* a navigation to prove the stale-overwrite
-// guard works. Deliberately does not reject on abort: what's under test is the
-// hook's own `signal.aborted` check, not AbortController itself.
-// ---------------------------------------------------------------------------
-
-interface PendingRequest {
-	url: string;
-	headers: Record<string, string>;
-	signal: AbortSignal | undefined;
-	resolve: (res: { ok: boolean; body: unknown }) => void;
-}
-
-let pending: PendingRequest[] = [];
-
-const originalFetch = globalThis.fetch;
-
-// biome-ignore lint/suspicious/noExplicitAny: minimal fetch stand-in
-(globalThis as any).fetch = (input: any, init: any) =>
-	new Promise((resolveFetch) => {
-		pending.push({
-			url: String(input),
-			headers: (init?.headers ?? {}) as Record<string, string>,
-			signal: init?.signal,
-			resolve: ({ ok, body }) => resolveFetch({ ok, json: async () => body }),
-		});
-	});
-
-// Bun shares one global scope across test files. This stub never settles on
-// its own, so leaving it installed would hang every later file that fetches.
-afterAll(() => {
-	globalThis.fetch = originalFetch;
-});
-
 const { act, createElement } = await import("react");
 const { createRoot } = await import("react-dom/client");
-const { parseSuggestionsResponse, resolveSuggestions, usePageSuggestions } =
-	await import("../use-page-suggestions");
+const {
+	normalizePathname,
+	parsePageSuggestions,
+	pickPagePrompts,
+	resolveSuggestions,
+	usePageSuggestions,
+} = await import("../use-page-suggestions");
+
+const PRICING_PROMPTS: PagePrompt[] = [
+	{ id: "pricing-1", text: "What plans do you offer?", tier: "low" },
+	{ id: "pricing-2", text: "How does per-seat billing work?", tier: "medium" },
+	{ id: "pricing-3", text: "Is there a free trial?", tier: "high" },
+	{ id: "pricing-4", text: "Can I switch plans mid-cycle?" },
+	{ id: "pricing-5", text: "Do you offer annual discounts?" },
+	{ id: "pricing-6", text: "What counts as an active user?" },
+];
 
 const BASE_CONFIG: EmbedConfig = {
 	api: "https://app.waniwani.ai/api/mcp/chat",
 	token: "wwp_test",
 	channelId: "0b3d5f2e-1c4a-4f8b-9d2e-6a7c8b9d0e1f",
 	suggestions: ["Static A", "Static B"],
+	pageSuggestions: [
+		{ url: "/pricing", prompts: PRICING_PROMPTS },
+		{ url: "/docs", prompts: [{ id: "d1", text: "Docs Q", tier: "low" }] },
+	],
 };
 
 /** Mount a probe that surfaces the hook's resolved texts. */
@@ -94,11 +77,6 @@ async function mount(config: EmbedConfig) {
 		get value() {
 			return latest;
 		},
-		async settle(index: number, res: { ok: boolean; body: unknown }) {
-			await act(async () => {
-				pending[index]?.resolve(res);
-			});
-		},
 		async navigate(pathname: string) {
 			await act(async () => {
 				win.history.pushState({}, "", pathname);
@@ -110,73 +88,113 @@ async function mount(config: EmbedConfig) {
 	};
 }
 
-const envelope = (suggestions: unknown) => ({
-	success: true,
-	message: "success",
-	data: { suggestions },
-});
-
 beforeEach(async () => {
-	pending = [];
 	await act(async () => {
 		win.history.pushState({}, "", "/pricing");
 	});
 });
 
-describe("parseSuggestionsResponse", () => {
-	test("reads the enveloped `data.suggestions` shape the API returns", () => {
-		expect(
-			parseSuggestionsResponse(
-				envelope([{ id: "pricing-1", text: "How much?" }]),
-			),
-		).toEqual([{ id: "pricing-1", text: "How much?" }]);
+describe("normalizePathname", () => {
+	test("keeps a bare pathname and reduces a full URL to one", () => {
+		expect(normalizePathname("/pricing")).toBe("/pricing");
+		expect(normalizePathname("https://example.com/pricing")).toBe("/pricing");
 	});
 
-	test("accepts a bare `{ suggestions }` root too", () => {
-		expect(
-			parseSuggestionsResponse({ suggestions: [{ id: null, text: "Hi" }] }),
-		).toEqual([{ id: null, text: "Hi" }]);
+	test("drops query, hash and trailing slashes; root stays /", () => {
+		expect(normalizePathname("/pricing/?utm_source=x#plans")).toBe("/pricing");
+		expect(normalizePathname("https://example.com")).toBe("/");
+		expect(normalizePathname("/")).toBe("/");
 	});
 
-	test("keeps ids so a later click can be attributed", () => {
-		const parsed = parseSuggestionsResponse(
-			envelope([
-				{ id: "a", text: "one" },
-				{ id: null, text: "two" },
+	test("lowercases, so the authored key and the live pathname agree", () => {
+		expect(normalizePathname("/Pricing/Plans")).toBe("/pricing/plans");
+		expect(normalizePathname("https://Example.com/Pricing/?utm=1")).toBe(
+			normalizePathname("/pricing"),
+		);
+	});
+});
+
+describe("pickPagePrompts", () => {
+	test("shows exactly one prompt per tier, low → medium → high", () => {
+		const tiered = PRICING_PROMPTS.slice(0, 3);
+		for (let i = 0; i < 20; i++) {
+			const picked = pickPagePrompts([...tiered]);
+			expect(picked.map((p) => p.tier)).toEqual(["low", "medium", "high"]);
+		}
+	});
+
+	test("a tier with no tagged prompt is filled by an untagged wildcard", () => {
+		const pool: PagePrompt[] = [
+			{ id: "low-1", text: "a", tier: "low" },
+			{ id: "high-1", text: "b", tier: "high" },
+			{ id: "wild-1", text: "c" },
+		];
+		for (let i = 0; i < 10; i++) {
+			const picked = pickPagePrompts(pool);
+			expect(picked.map((p) => p.id).sort()).toEqual([
+				"high-1",
+				"low-1",
+				"wild-1",
+			]);
+		}
+	});
+
+	test("an all-untagged pool keeps the uniform random pick", () => {
+		const untagged = PRICING_PROMPTS.slice(3);
+		const seen = new Set<string | null>();
+		for (let i = 0; i < 40; i++) {
+			const picked = pickPagePrompts(untagged);
+			expect(picked).toHaveLength(3);
+			for (const p of picked) {
+				seen.add(p.id);
+			}
+		}
+		expect(seen.size).toBe(untagged.length);
+	});
+
+	test("fewer prompts than slots shows what exists", () => {
+		expect(
+			pickPagePrompts([{ id: "only", text: "One", tier: "high" }]),
+		).toHaveLength(1);
+	});
+});
+
+describe("parsePageSuggestions", () => {
+	test("reads well-formed entries, keeping ids and tiers", () => {
+		expect(
+			parsePageSuggestions([
+				{
+					url: "/pricing",
+					prompts: [{ id: "p1", text: "How much?", tier: "low" }],
+				},
 			]),
-		);
-		expect(parsed.map((s) => s.id)).toEqual(["a", null]);
+		).toEqual([
+			{
+				url: "/pricing",
+				prompts: [{ id: "p1", text: "How much?", tier: "low" }],
+			},
+		]);
 	});
 
-	test("coerces a non-string id to null rather than dropping the prompt", () => {
-		expect(parseSuggestionsResponse(envelope([{ id: 7, text: "ok" }]))).toEqual(
-			[{ id: null, text: "ok" }],
-		);
+	test("coerces a non-string id to null and drops an unknown tier", () => {
+		const [entry] = parsePageSuggestions([
+			{ url: "/a", prompts: [{ id: 7, text: "ok", tier: "urgent" }] },
+		]);
+		expect(entry.prompts).toEqual([{ id: null, text: "ok", tier: undefined }]);
 	});
 
-	test("drops entries with no usable text", () => {
+	test("drops prompts with no usable text, and entries left empty", () => {
 		expect(
-			parseSuggestionsResponse(
-				envelope([
-					{ id: "a", text: "" },
-					{ id: "b" },
-					null,
-					{ id: "c", text: "kept" },
-				]),
-			),
-		).toEqual([{ id: "c", text: "kept" }]);
+			parsePageSuggestions([
+				{ url: "/a", prompts: [{ id: "x", text: "" }, null] },
+				{ url: "/b", prompts: [{ id: "y", text: "kept" }] },
+			]),
+		).toEqual([{ url: "/b", prompts: [{ id: "y", text: "kept" }] }]);
 	});
 
-	test("degrades to [] on malformed bodies", () => {
-		for (const body of [
-			null,
-			undefined,
-			{},
-			{ data: null },
-			{ data: { suggestions: "nope" } },
-			"not json",
-		]) {
-			expect(parseSuggestionsResponse(body)).toEqual([]);
+	test("degrades to [] on malformed values", () => {
+		for (const value of [null, undefined, {}, "nope", [{ url: 3 }]]) {
+			expect(parsePageSuggestions(value)).toEqual([]);
 		}
 	});
 });
@@ -190,15 +208,8 @@ describe("resolveSuggestions", () => {
 		).toEqual([{ id: "p1", text: "Page prompt" }]);
 	});
 
-	test("falls back when nothing was fetched", () => {
+	test("falls back when the page has no entry", () => {
 		expect(resolveSuggestions(null, fallback)).toEqual([
-			{ id: null, text: "Static A" },
-			{ id: null, text: "Static B" },
-		]);
-	});
-
-	test("treats an empty fetched set as fall-back-client-side", () => {
-		expect(resolveSuggestions([], fallback)).toEqual([
 			{ id: null, text: "Static A" },
 			{ id: null, text: "Static B" },
 		]);
@@ -211,101 +222,47 @@ describe("resolveSuggestions", () => {
 });
 
 describe("usePageSuggestions", () => {
-	test("is inert without the flag — no request, fixed list", async () => {
-		const h = await mount({ ...BASE_CONFIG });
-		expect(pending).toHaveLength(0);
+	test("is inert without pageSuggestions — exactly the fixed list", async () => {
+		const h = await mount({ ...BASE_CONFIG, pageSuggestions: undefined });
 		expect(h.value).toEqual(["Static A", "Static B"]);
 		h.unmount();
 	});
 
-	test("makes no request when the embed has no channelId", async () => {
-		const h = await mount({
-			...BASE_CONFIG,
-			channelId: undefined,
-			dynamicSuggestions: true,
-		});
-		expect(pending).toHaveLength(0);
-		expect(h.value).toEqual(["Static A", "Static B"]);
+	test("shows three of the current page's prompts, one per tier first", async () => {
+		const h = await mount(BASE_CONFIG);
+		expect(h.value).toHaveLength(3);
+		const texts = PRICING_PROMPTS.map((p) => p.text);
+		for (const text of h.value) {
+			expect(texts).toContain(text);
+		}
 		h.unmount();
 	});
 
-	test("fetches the current page's prompts and swaps the pills", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
-		expect(pending).toHaveLength(1);
+	test("swaps the pills on SPA navigation and falls back on unseeded pages", async () => {
+		const h = await mount(BASE_CONFIG);
+		expect(h.value).toHaveLength(3);
 
-		const url = new URL(pending[0].url);
-		expect(url.pathname).toBe("/api/mcp/chat/suggestions");
-		expect(url.searchParams.get("channel")).toBe(BASE_CONFIG.channelId);
-		expect(url.searchParams.get("url")).toBe("/pricing");
-		expect(pending[0].headers.Authorization).toBe("Bearer wwp_test");
-
-		// Fixed list until the response lands — never a blank card.
-		expect(h.value).toEqual(["Static A", "Static B"]);
-
-		await h.settle(0, {
-			ok: true,
-			body: envelope([{ id: "p1", text: "What does Pro cost?" }]),
-		});
-		expect(h.value).toEqual(["What does Pro cost?"]);
-		h.unmount();
-	});
-
-	test("falls back to the fixed list on a non-200", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
-		await h.settle(0, { ok: false, body: { error: "INVALID_CHANNEL" } });
-		expect(h.value).toEqual(["Static A", "Static B"]);
-		h.unmount();
-	});
-
-	test("falls back when the page has no authored prompts", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
-		await h.settle(0, { ok: true, body: envelope([]) });
-		expect(h.value).toEqual(["Static A", "Static B"]);
-		h.unmount();
-	});
-
-	test("refetches with the new pathname on SPA navigation", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
-		await h.settle(0, {
-			ok: true,
-			body: envelope([{ id: "p1", text: "Pricing Q" }]),
-		});
-		expect(h.value).toEqual(["Pricing Q"]);
-
-		await h.navigate("/docs/getting-started");
-		expect(pending).toHaveLength(2);
-		expect(new URL(pending[1].url).searchParams.get("url")).toBe(
-			"/docs/getting-started",
-		);
-
-		await h.settle(1, {
-			ok: true,
-			body: envelope([{ id: "d1", text: "Docs Q" }]),
-		});
-		expect(h.value).toEqual(["Docs Q"]);
-		h.unmount();
-	});
-
-	test("a late response for the previous page never overwrites the current one", async () => {
-		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
 		await h.navigate("/docs");
-
-		// The in-flight request for /pricing was aborted by the navigation.
-		expect(pending).toHaveLength(2);
-		expect(pending[0].signal?.aborted).toBe(true);
-
-		await h.settle(1, {
-			ok: true,
-			body: envelope([{ id: "d1", text: "Docs Q" }]),
-		});
 		expect(h.value).toEqual(["Docs Q"]);
 
-		// /pricing answers late — must be ignored.
-		await h.settle(0, {
-			ok: true,
-			body: envelope([{ id: "p1", text: "Pricing Q" }]),
-		});
+		await h.navigate("/blog/hello");
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("matches the authored entry regardless of casing or query noise", async () => {
+		const h = await mount(BASE_CONFIG);
+		await h.navigate("/Docs/?utm_source=x");
 		expect(h.value).toEqual(["Docs Q"]);
+		h.unmount();
+	});
+
+	test("keeps one picked set stable until the visitor navigates", async () => {
+		const h = await mount(BASE_CONFIG);
+		const first = h.value;
+		await h.navigate("/pricing#anchor");
+		// Same normalized pathname → same memoized pick, no reshuffle.
+		expect(h.value).toEqual(first);
 		h.unmount();
 	});
 });

--- a/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
+++ b/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { Window } from "happy-dom";
 // Type-only, so it doesn't pull the module in before the globals below exist.
 import type { EmbedConfig } from "../config";
+import type { PageSuggestion } from "../use-page-suggestions";
 
 const win = new Window({ url: "https://host.example/pricing" });
 for (const key of [
@@ -77,10 +78,10 @@ const BASE_CONFIG: EmbedConfig = {
 	suggestions: ["Static A", "Static B"],
 };
 
-/** Mount a probe that surfaces the hook's resolved texts. */
+/** Mount a probe that surfaces the hook's resolved prompts. */
 async function mount(config: EmbedConfig) {
 	const container = win.document.createElement("div");
-	let latest: string[] = [];
+	let latest: PageSuggestion[] = [];
 	function Probe() {
 		latest = usePageSuggestions(config);
 		return null;
@@ -91,8 +92,13 @@ async function mount(config: EmbedConfig) {
 		root.render(createElement(Probe));
 	});
 	return {
+		/** The resolved prompts, ids included. */
 		get value() {
 			return latest;
+		},
+		/** Just the rendered texts, which is what most cases care about. */
+		get texts() {
+			return latest.map((s) => s.text);
 		},
 		async settle(index: number, res: { ok: boolean; body: unknown }) {
 			await act(async () => {
@@ -214,7 +220,7 @@ describe("usePageSuggestions", () => {
 	test("is inert without the flag — no request, fixed list", async () => {
 		const h = await mount({ ...BASE_CONFIG });
 		expect(pending).toHaveLength(0);
-		expect(h.value).toEqual(["Static A", "Static B"]);
+		expect(h.texts).toEqual(["Static A", "Static B"]);
 		h.unmount();
 	});
 
@@ -225,7 +231,7 @@ describe("usePageSuggestions", () => {
 			dynamicSuggestions: true,
 		});
 		expect(pending).toHaveLength(0);
-		expect(h.value).toEqual(["Static A", "Static B"]);
+		expect(h.texts).toEqual(["Static A", "Static B"]);
 		h.unmount();
 	});
 
@@ -240,27 +246,40 @@ describe("usePageSuggestions", () => {
 		expect(pending[0].headers.Authorization).toBe("Bearer wwp_test");
 
 		// Fixed list until the response lands — never a blank card.
-		expect(h.value).toEqual(["Static A", "Static B"]);
+		expect(h.texts).toEqual(["Static A", "Static B"]);
 
 		await h.settle(0, {
 			ok: true,
 			body: envelope([{ id: "p1", text: "What does Pro cost?" }]),
 		});
-		expect(h.value).toEqual(["What does Pro cost?"]);
+		expect(h.texts).toEqual(["What does Pro cost?"]);
+		// The authored prompt's id reaches the caller, so a click on it can be
+		// attributed back to the prompt.
+		expect(h.value).toEqual([{ id: "p1", text: "What does Pro cost?" }]);
+		h.unmount();
+	});
+
+	test("hands back id-less prompts when it falls back", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		await h.settle(0, { ok: true, body: envelope([]) });
+		expect(h.value).toEqual([
+			{ id: null, text: "Static A" },
+			{ id: null, text: "Static B" },
+		]);
 		h.unmount();
 	});
 
 	test("falls back to the fixed list on a non-200", async () => {
 		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
 		await h.settle(0, { ok: false, body: { error: "INVALID_CHANNEL" } });
-		expect(h.value).toEqual(["Static A", "Static B"]);
+		expect(h.texts).toEqual(["Static A", "Static B"]);
 		h.unmount();
 	});
 
 	test("falls back when the page has no authored prompts", async () => {
 		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
 		await h.settle(0, { ok: true, body: envelope([]) });
-		expect(h.value).toEqual(["Static A", "Static B"]);
+		expect(h.texts).toEqual(["Static A", "Static B"]);
 		h.unmount();
 	});
 
@@ -270,7 +289,7 @@ describe("usePageSuggestions", () => {
 			ok: true,
 			body: envelope([{ id: "p1", text: "Pricing Q" }]),
 		});
-		expect(h.value).toEqual(["Pricing Q"]);
+		expect(h.texts).toEqual(["Pricing Q"]);
 
 		await h.navigate("/docs/getting-started");
 		expect(pending).toHaveLength(2);
@@ -282,7 +301,7 @@ describe("usePageSuggestions", () => {
 			ok: true,
 			body: envelope([{ id: "d1", text: "Docs Q" }]),
 		});
-		expect(h.value).toEqual(["Docs Q"]);
+		expect(h.texts).toEqual(["Docs Q"]);
 		h.unmount();
 	});
 
@@ -298,14 +317,14 @@ describe("usePageSuggestions", () => {
 			ok: true,
 			body: envelope([{ id: "d1", text: "Docs Q" }]),
 		});
-		expect(h.value).toEqual(["Docs Q"]);
+		expect(h.texts).toEqual(["Docs Q"]);
 
 		// /pricing answers late — must be ignored.
 		await h.settle(0, {
 			ok: true,
 			body: envelope([{ id: "p1", text: "Pricing Q" }]),
 		});
-		expect(h.value).toEqual(["Docs Q"]);
+		expect(h.texts).toEqual(["Docs Q"]);
 		h.unmount();
 	});
 });

--- a/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
+++ b/src/chat/web/embed/__tests__/use-page-suggestions.test.ts
@@ -1,0 +1,311 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+// Type-only, so it doesn't pull the module in before the globals below exist.
+import type { EmbedConfig } from "../config";
+
+const win = new Window({ url: "https://host.example/pricing" });
+for (const key of [
+	"document",
+	"navigator",
+	"history",
+	"location",
+	"HTMLElement",
+	"HTMLDivElement",
+	"Element",
+	"Node",
+	"Text",
+	"Comment",
+	"DocumentFragment",
+	"Event",
+	"CustomEvent",
+	"requestAnimationFrame",
+	"cancelAnimationFrame",
+	"getComputedStyle",
+] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: happy-dom globals for the render harness
+	(globalThis as any)[key] = (win as any)[key];
+}
+// biome-ignore lint/suspicious/noExplicitAny: happy-dom globals for the render harness
+(globalThis as any).window = win;
+// biome-ignore lint/suspicious/noExplicitAny: react act environment flag
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// fetch stub — every call is parked until the test resolves it by hand, so a
+// response can be delivered *after* a navigation to prove the stale-overwrite
+// guard works. Deliberately does not reject on abort: what's under test is the
+// hook's own `signal.aborted` check, not AbortController itself.
+// ---------------------------------------------------------------------------
+
+interface PendingRequest {
+	url: string;
+	headers: Record<string, string>;
+	signal: AbortSignal | undefined;
+	resolve: (res: { ok: boolean; body: unknown }) => void;
+}
+
+let pending: PendingRequest[] = [];
+
+const originalFetch = globalThis.fetch;
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal fetch stand-in
+(globalThis as any).fetch = (input: any, init: any) =>
+	new Promise((resolveFetch) => {
+		pending.push({
+			url: String(input),
+			headers: (init?.headers ?? {}) as Record<string, string>,
+			signal: init?.signal,
+			resolve: ({ ok, body }) => resolveFetch({ ok, json: async () => body }),
+		});
+	});
+
+// Bun shares one global scope across test files. This stub never settles on
+// its own, so leaving it installed would hang every later file that fetches.
+afterAll(() => {
+	globalThis.fetch = originalFetch;
+});
+
+const { act, createElement } = await import("react");
+const { createRoot } = await import("react-dom/client");
+const { parseSuggestionsResponse, resolveSuggestions, usePageSuggestions } =
+	await import("../use-page-suggestions");
+
+const BASE_CONFIG: EmbedConfig = {
+	api: "https://app.waniwani.ai/api/mcp/chat",
+	token: "wwp_test",
+	channelId: "0b3d5f2e-1c4a-4f8b-9d2e-6a7c8b9d0e1f",
+	suggestions: ["Static A", "Static B"],
+};
+
+/** Mount a probe that surfaces the hook's resolved texts. */
+async function mount(config: EmbedConfig) {
+	const container = win.document.createElement("div");
+	let latest: string[] = [];
+	function Probe() {
+		latest = usePageSuggestions(config);
+		return null;
+	}
+	// biome-ignore lint/suspicious/noExplicitAny: happy-dom Element vs DOM Element
+	const root = createRoot(container as any);
+	await act(async () => {
+		root.render(createElement(Probe));
+	});
+	return {
+		get value() {
+			return latest;
+		},
+		async settle(index: number, res: { ok: boolean; body: unknown }) {
+			await act(async () => {
+				pending[index]?.resolve(res);
+			});
+		},
+		async navigate(pathname: string) {
+			await act(async () => {
+				win.history.pushState({}, "", pathname);
+			});
+		},
+		unmount() {
+			act(() => root.unmount());
+		},
+	};
+}
+
+const envelope = (suggestions: unknown) => ({
+	success: true,
+	message: "success",
+	data: { suggestions },
+});
+
+beforeEach(async () => {
+	pending = [];
+	await act(async () => {
+		win.history.pushState({}, "", "/pricing");
+	});
+});
+
+describe("parseSuggestionsResponse", () => {
+	test("reads the enveloped `data.suggestions` shape the API returns", () => {
+		expect(
+			parseSuggestionsResponse(
+				envelope([{ id: "pricing-1", text: "How much?" }]),
+			),
+		).toEqual([{ id: "pricing-1", text: "How much?" }]);
+	});
+
+	test("accepts a bare `{ suggestions }` root too", () => {
+		expect(
+			parseSuggestionsResponse({ suggestions: [{ id: null, text: "Hi" }] }),
+		).toEqual([{ id: null, text: "Hi" }]);
+	});
+
+	test("keeps ids so a later click can be attributed", () => {
+		const parsed = parseSuggestionsResponse(
+			envelope([
+				{ id: "a", text: "one" },
+				{ id: null, text: "two" },
+			]),
+		);
+		expect(parsed.map((s) => s.id)).toEqual(["a", null]);
+	});
+
+	test("coerces a non-string id to null rather than dropping the prompt", () => {
+		expect(parseSuggestionsResponse(envelope([{ id: 7, text: "ok" }]))).toEqual(
+			[{ id: null, text: "ok" }],
+		);
+	});
+
+	test("drops entries with no usable text", () => {
+		expect(
+			parseSuggestionsResponse(
+				envelope([
+					{ id: "a", text: "" },
+					{ id: "b" },
+					null,
+					{ id: "c", text: "kept" },
+				]),
+			),
+		).toEqual([{ id: "c", text: "kept" }]);
+	});
+
+	test("degrades to [] on malformed bodies", () => {
+		for (const body of [
+			null,
+			undefined,
+			{},
+			{ data: null },
+			{ data: { suggestions: "nope" } },
+			"not json",
+		]) {
+			expect(parseSuggestionsResponse(body)).toEqual([]);
+		}
+	});
+});
+
+describe("resolveSuggestions", () => {
+	const fallback = ["Static A", "Static B"];
+
+	test("prefers the page's own prompts", () => {
+		expect(
+			resolveSuggestions([{ id: "p1", text: "Page prompt" }], fallback),
+		).toEqual([{ id: "p1", text: "Page prompt" }]);
+	});
+
+	test("falls back when nothing was fetched", () => {
+		expect(resolveSuggestions(null, fallback)).toEqual([
+			{ id: null, text: "Static A" },
+			{ id: null, text: "Static B" },
+		]);
+	});
+
+	test("treats an empty fetched set as fall-back-client-side", () => {
+		expect(resolveSuggestions([], fallback)).toEqual([
+			{ id: null, text: "Static A" },
+			{ id: null, text: "Static B" },
+		]);
+	});
+
+	test("is empty when there is nothing on either side", () => {
+		expect(resolveSuggestions(null, undefined)).toEqual([]);
+		expect(resolveSuggestions([], [])).toEqual([]);
+	});
+});
+
+describe("usePageSuggestions", () => {
+	test("is inert without the flag — no request, fixed list", async () => {
+		const h = await mount({ ...BASE_CONFIG });
+		expect(pending).toHaveLength(0);
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("makes no request when the embed has no channelId", async () => {
+		const h = await mount({
+			...BASE_CONFIG,
+			channelId: undefined,
+			dynamicSuggestions: true,
+		});
+		expect(pending).toHaveLength(0);
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("fetches the current page's prompts and swaps the pills", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		expect(pending).toHaveLength(1);
+
+		const url = new URL(pending[0].url);
+		expect(url.pathname).toBe("/api/mcp/chat/suggestions");
+		expect(url.searchParams.get("channel")).toBe(BASE_CONFIG.channelId);
+		expect(url.searchParams.get("url")).toBe("/pricing");
+		expect(pending[0].headers.Authorization).toBe("Bearer wwp_test");
+
+		// Fixed list until the response lands — never a blank card.
+		expect(h.value).toEqual(["Static A", "Static B"]);
+
+		await h.settle(0, {
+			ok: true,
+			body: envelope([{ id: "p1", text: "What does Pro cost?" }]),
+		});
+		expect(h.value).toEqual(["What does Pro cost?"]);
+		h.unmount();
+	});
+
+	test("falls back to the fixed list on a non-200", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		await h.settle(0, { ok: false, body: { error: "INVALID_CHANNEL" } });
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("falls back when the page has no authored prompts", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		await h.settle(0, { ok: true, body: envelope([]) });
+		expect(h.value).toEqual(["Static A", "Static B"]);
+		h.unmount();
+	});
+
+	test("refetches with the new pathname on SPA navigation", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		await h.settle(0, {
+			ok: true,
+			body: envelope([{ id: "p1", text: "Pricing Q" }]),
+		});
+		expect(h.value).toEqual(["Pricing Q"]);
+
+		await h.navigate("/docs/getting-started");
+		expect(pending).toHaveLength(2);
+		expect(new URL(pending[1].url).searchParams.get("url")).toBe(
+			"/docs/getting-started",
+		);
+
+		await h.settle(1, {
+			ok: true,
+			body: envelope([{ id: "d1", text: "Docs Q" }]),
+		});
+		expect(h.value).toEqual(["Docs Q"]);
+		h.unmount();
+	});
+
+	test("a late response for the previous page never overwrites the current one", async () => {
+		const h = await mount({ ...BASE_CONFIG, dynamicSuggestions: true });
+		await h.navigate("/docs");
+
+		// The in-flight request for /pricing was aborted by the navigation.
+		expect(pending).toHaveLength(2);
+		expect(pending[0].signal?.aborted).toBe(true);
+
+		await h.settle(1, {
+			ok: true,
+			body: envelope([{ id: "d1", text: "Docs Q" }]),
+		});
+		expect(h.value).toEqual(["Docs Q"]);
+
+		// /pricing answers late — must be ignored.
+		await h.settle(0, {
+			ok: true,
+			body: envelope([{ id: "p1", text: "Pricing Q" }]),
+		});
+		expect(h.value).toEqual(["Docs Q"]);
+		h.unmount();
+	});
+});

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -119,6 +119,16 @@ export interface EmbedConfig {
 	/** Initial suggestion chips displayed before the first message. */
 	suggestions?: string[];
 	/**
+	 * Fetch page-aware starter prompts from `{api}/suggestions` on mount and on
+	 * every SPA navigation, instead of always rendering the fixed
+	 * {@link EmbedConfig.suggestions} list (which stays the fallback whenever
+	 * that request fails or returns nothing).
+	 *
+	 * Normally delivered per channel by `/config` (no `data-*` attribute maps
+	 * to it). Absent everywhere reads as `false`.
+	 */
+	dynamicSuggestions?: boolean;
+	/**
 	 * AI transparency notice rendered under the input (EU AI Act compliance).
 	 * String overrides the default wording; `false` hides it. Surfaced as
 	 * `data-disclaimer` on the embed script tag (use `data-disclaimer="false"`

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -50,16 +50,12 @@ export interface ChatAppearance {
  */
 export type ShowToolCalls = boolean | "titles-only";
 
-/**
- * Intent tier of one authored page prompt: low = discover, medium = compare,
- * high = act. The widget shows one prompt per tier.
- */
+/** Intent tier of a page prompt (discover/compare/act); one shown per tier. */
 export type PagePromptTier = "low" | "medium" | "high";
 
 /**
- * One authored per-page starter prompt as delivered by `/config`. `id` is the
- * authored entry's stable identity (click attribution); `tier` is absent on
- * prompts stored before tiers existed — those fill any tier slot.
+ * One authored page prompt from `/config`. `id` is the entry's stable
+ * identity; untagged (`tier` absent) prompts fill any tier slot.
  */
 export interface PagePrompt {
 	id: string | null;
@@ -142,13 +138,9 @@ export interface EmbedConfig {
 	/** Initial suggestion chips displayed before the first message. */
 	suggestions?: string[];
 	/**
-	 * Per-page starter prompt sets, keyed by normalized pathname. When the
-	 * current page matches an entry, the widget picks one prompt per intent
-	 * tier from it locally — re-picking on every SPA navigation — instead of
-	 * rendering the fixed {@link EmbedConfig.suggestions} list, which stays
-	 * the fallback for pages with no entry.
-	 *
-	 * Delivered per channel by `/config` (no `data-*` attribute maps to it).
+	 * Per-page starter prompt sets from `/config`; the widget picks from the
+	 * entry matching its pathname, falling back to `suggestions`. No `data-*`
+	 * attribute maps to it.
 	 */
 	pageSuggestions?: PageSuggestionsEntry[];
 	/**

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -51,6 +51,29 @@ export interface ChatAppearance {
 export type ShowToolCalls = boolean | "titles-only";
 
 /**
+ * Intent tier of one authored page prompt: low = discover, medium = compare,
+ * high = act. The widget shows one prompt per tier.
+ */
+export type PagePromptTier = "low" | "medium" | "high";
+
+/**
+ * One authored per-page starter prompt as delivered by `/config`. `id` is the
+ * authored entry's stable identity (click attribution); `tier` is absent on
+ * prompts stored before tiers existed — those fill any tier slot.
+ */
+export interface PagePrompt {
+	id: string | null;
+	text: string;
+	tier?: PagePromptTier;
+}
+
+/** Starter prompt set for one page, keyed by normalized pathname. */
+export interface PageSuggestionsEntry {
+	url: string;
+	prompts: PagePrompt[];
+}
+
+/**
  * Configuration for the embeddable chat widget.
  *
  * Resolution priority (later wins):
@@ -119,15 +142,15 @@ export interface EmbedConfig {
 	/** Initial suggestion chips displayed before the first message. */
 	suggestions?: string[];
 	/**
-	 * Fetch page-aware starter prompts from `{api}/suggestions` on mount and on
-	 * every SPA navigation, instead of always rendering the fixed
-	 * {@link EmbedConfig.suggestions} list (which stays the fallback whenever
-	 * that request fails or returns nothing).
+	 * Per-page starter prompt sets, keyed by normalized pathname. When the
+	 * current page matches an entry, the widget picks one prompt per intent
+	 * tier from it locally — re-picking on every SPA navigation — instead of
+	 * rendering the fixed {@link EmbedConfig.suggestions} list, which stays
+	 * the fallback for pages with no entry.
 	 *
-	 * Normally delivered per channel by `/config` (no `data-*` attribute maps
-	 * to it). Absent everywhere reads as `false`.
+	 * Delivered per channel by `/config` (no `data-*` attribute maps to it).
 	 */
-	dynamicSuggestions?: boolean;
+	pageSuggestions?: PageSuggestionsEntry[];
 	/**
 	 * AI transparency notice rendered under the input (EU AI Act compliance).
 	 * String overrides the default wording; `false` hides it. Surfaced as

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -37,6 +37,7 @@ import { cn } from "../lib/utils";
 import { themeToCSSProperties } from "../theme";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
+import { usePageSuggestions } from "./use-page-suggestions";
 import { usePathname, useVisibilityGate } from "./use-pathname";
 import { useScrollAppearance } from "./use-scroll-appearance";
 import { appearTriggerForPath } from "./visibility";
@@ -164,7 +165,10 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 			[userVars],
 		);
 
-		const suggestions = config.suggestions ?? [];
+		// Page-aware starter prompts when the channel opts in, otherwise exactly
+		// `config.suggestions`. Everything below (auto-expand, the card, the
+		// pills, the panel's initial set) reads this one resolved list.
+		const suggestions = usePageSuggestions(config);
 		// The dock is the chat's entry point, so it shows the configured input
 		// placeholder by default (`data-launcher-text` overrides it for a
 		// dock-specific prompt). Typed out like the in-chat input.
@@ -565,8 +569,8 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 									welcomeMessage={config.welcomeMessage}
 									placeholder={config.placeholder}
 									suggestions={
-										config.suggestions
-											? { initial: config.suggestions }
+										suggestions.length > 0
+											? { initial: suggestions }
 											: undefined
 									}
 									enableThreadHistory={config.enableThreadHistory}

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -33,6 +33,10 @@ import { Suggestions } from "../components/suggestions";
 import { useTypingPlaceholder } from "../hooks/use-typing-placeholder";
 import { I18nProvider, useTranslation } from "../i18n";
 import { ChatEmbed } from "../layouts/chat-embed";
+import {
+	fireSuggestionClick,
+	resolveClickAttribution,
+} from "../lib/suggestion-click";
 import { cn } from "../lib/utils";
 import { themeToCSSProperties } from "../theme";
 import type { EmbedConfig } from "./config";
@@ -166,9 +170,51 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 		);
 
 		// Page-aware starter prompts when the channel opts in, otherwise exactly
-		// `config.suggestions`. Everything below (auto-expand, the card, the
-		// pills, the panel's initial set) reads this one resolved list.
-		const suggestions = usePageSuggestions(config);
+		// `config.suggestions`. The objects carry the prompt ids for click
+		// attribution; everything below (auto-expand, the card, the pills, the
+		// panel's initial set) reads the texts — memoized because
+		// `useSuggestions` keys an effect on the `initial` array's identity.
+		const pageSuggestions = usePageSuggestions(config);
+		const suggestions = useMemo(
+			() => pageSuggestions.map((s) => s.text),
+			[pageSuggestions],
+		);
+
+		// Record every starter-prompt click server-side, attributed to the
+		// authored prompt it came from. Rides the same widget-event stream the
+		// host page subscribes to, so there is one click signal, not two — and it
+		// covers both the dock's CTAs and the panel's own pills.
+		useEffect(() => {
+			return widgetEvents.subscribe((event) => {
+				if (event.name !== "suggestion.clicked") {
+					return;
+				}
+				const { text } = event.properties;
+				const { promptId, kind } = resolveClickAttribution(
+					pageSuggestions,
+					text,
+				);
+				void fireSuggestionClick({
+					api: config.api ?? "",
+					token: config.token,
+					channelId: config.channelId,
+					mode: "floating",
+					source: config.source,
+					sessionId: chatRef.current?.sessionId,
+					promptId,
+					kind,
+					text,
+					index: event.properties.index,
+				});
+			});
+		}, [
+			widgetEvents,
+			pageSuggestions,
+			config.api,
+			config.token,
+			config.channelId,
+			config.source,
+		]);
 		// The dock is the chat's entry point, so it shows the configured input
 		// placeholder by default (`data-launcher-text` overrides it for a
 		// dock-specific prompt). Typed out like the in-chat input.

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -35,13 +35,18 @@ import { I18nProvider, useTranslation } from "../i18n";
 import { ChatEmbed } from "../layouts/chat-embed";
 import {
 	fireSuggestionClick,
+	fireSuggestionShown,
 	resolveClickAttribution,
+	resolveShownPrompts,
 } from "../lib/suggestion-click";
 import { cn } from "../lib/utils";
 import { themeToCSSProperties } from "../theme";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
-import { usePageSuggestions } from "./use-page-suggestions";
+import {
+	type PageSuggestion,
+	usePageSuggestions,
+} from "./use-page-suggestions";
 import { usePathname, useVisibilityGate } from "./use-pathname";
 import { useScrollAppearance } from "./use-scroll-appearance";
 import { appearTriggerForPath } from "./visibility";
@@ -180,32 +185,49 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 			[pageSuggestions],
 		);
 
-		// Record every starter-prompt click server-side, attributed to the
-		// authored prompt it came from. Rides the same widget-event stream the
-		// host page subscribes to, so there is one click signal, not two — and it
-		// covers both the dock's CTAs and the panel's own pills.
+		// Record every starter-prompt click and every rendered pill set
+		// server-side, attributed to the authored prompts involved. Rides the
+		// same widget-event stream the host page subscribes to, so there is one
+		// signal per interaction, not two — and it covers both the dock's CTAs
+		// and the panel's own pills.
 		useEffect(() => {
 			return widgetEvents.subscribe((event) => {
-				if (event.name !== "suggestion.clicked") {
+				if (event.name === "suggestion.clicked") {
+					const { text } = event.properties;
+					const { promptId, kind } = resolveClickAttribution(
+						pageSuggestions,
+						text,
+					);
+					void fireSuggestionClick({
+						api: config.api ?? "",
+						token: config.token,
+						channelId: config.channelId,
+						mode: "floating",
+						source: config.source,
+						sessionId: chatRef.current?.sessionId,
+						promptId,
+						kind,
+						text,
+						index: event.properties.index,
+					});
 					return;
 				}
-				const { text } = event.properties;
-				const { promptId, kind } = resolveClickAttribution(
-					pageSuggestions,
-					text,
-				);
-				void fireSuggestionClick({
-					api: config.api ?? "",
-					token: config.token,
-					channelId: config.channelId,
-					mode: "floating",
-					source: config.source,
-					sessionId: chatRef.current?.sessionId,
-					promptId,
-					kind,
-					text,
-					index: event.properties.index,
-				});
+				if (event.name === "suggestions.shown") {
+					const { prompts, kind } = resolveShownPrompts(
+						pageSuggestions,
+						event.properties.texts,
+					);
+					void fireSuggestionShown({
+						api: config.api ?? "",
+						token: config.token,
+						channelId: config.channelId,
+						mode: "floating",
+						source: config.source,
+						sessionId: chatRef.current?.sessionId,
+						prompts,
+						kind,
+					});
+				}
 			});
 		}, [
 			widgetEvents,
@@ -215,6 +237,24 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 			config.channelId,
 			config.source,
 		]);
+
+		// One impression per revealed dock set, keyed on the resolved array's
+		// identity — a new fetch (SPA navigation) is a new array and counts
+		// again; re-renders and collapse/expand cycles of the same set don't.
+		const shownSuggestionsRef = useRef<PageSuggestion[] | null>(null);
+		useEffect(() => {
+			if (!suggestionsVisible || pageSuggestions.length === 0) {
+				return;
+			}
+			if (shownSuggestionsRef.current === pageSuggestions) {
+				return;
+			}
+			shownSuggestionsRef.current = pageSuggestions;
+			widgetEvents.emit({
+				name: "suggestions.shown",
+				properties: { texts: suggestions },
+			});
+		}, [suggestionsVisible, pageSuggestions, suggestions, widgetEvents]);
 		// The dock is the chat's entry point, so it shows the configured input
 		// placeholder by default (`data-launcher-text` overrides it for a
 		// dock-specific prompt). Typed out like the in-chat input.

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -569,7 +569,11 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 									welcomeMessage={config.welcomeMessage}
 									placeholder={config.placeholder}
 									suggestions={
-										suggestions.length > 0
+										// `config.suggestions` may be an explicitly-set empty
+										// array; passing `{ initial: [] }` then (as before this
+										// hook existed) keeps useSuggestions' streamed follow-up
+										// extraction enabled for hosts that rely on it.
+										config.suggestions || suggestions.length > 0
 											? { initial: suggestions }
 											: undefined
 									}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -138,7 +138,13 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 					welcomeMessage={config.welcomeMessage}
 					placeholder={config.placeholder}
 					suggestions={
-						suggestions.length > 0 ? { initial: suggestions } : undefined
+						// `config.suggestions` may be an explicitly-set empty array;
+						// passing `{ initial: [] }` then (as before this hook existed)
+						// keeps useSuggestions' streamed follow-up extraction enabled
+						// for hosts that rely on it.
+						config.suggestions || suggestions.length > 0
+							? { initial: suggestions }
+							: undefined
 					}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -17,6 +17,7 @@ import type { ChatHandle } from "../@types";
 import { ChatEmbed } from "../layouts/chat-embed";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
+import { usePageSuggestions } from "./use-page-suggestions";
 import { useVisibilityGate } from "./use-pathname";
 import { createWidgetEventEmitter } from "./widget-events";
 import { WidgetEventsProvider } from "./widget-events-context";
@@ -109,6 +110,10 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 			[],
 		);
 
+		// Page-aware starter prompts when the channel opts in, otherwise exactly
+		// `config.suggestions`.
+		const suggestions = usePageSuggestions(config);
+
 		// `mode` tags every chat request with the embed surface so server-logged
 		// chat events carry it in `properties.mode`, matching `page.viewed`.
 		const body: Record<string, unknown> = { mode: "inline" };
@@ -133,7 +138,7 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 					welcomeMessage={config.welcomeMessage}
 					placeholder={config.placeholder}
 					suggestions={
-						config.suggestions ? { initial: config.suggestions } : undefined
+						suggestions.length > 0 ? { initial: suggestions } : undefined
 					}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -15,6 +15,10 @@ import {
 } from "react";
 import type { ChatHandle } from "../@types";
 import { ChatEmbed } from "../layouts/chat-embed";
+import {
+	fireSuggestionClick,
+	resolveClickAttribution,
+} from "../lib/suggestion-click";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
 import { usePageSuggestions } from "./use-page-suggestions";
@@ -111,8 +115,49 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 		);
 
 		// Page-aware starter prompts when the channel opts in, otherwise exactly
-		// `config.suggestions`.
-		const suggestions = usePageSuggestions(config);
+		// `config.suggestions`. The objects carry the prompt ids for click
+		// attribution; `ChatEmbed` renders the texts — memoized because
+		// `useSuggestions` keys an effect on the `initial` array's identity.
+		const pageSuggestions = usePageSuggestions(config);
+		const suggestions = useMemo(
+			() => pageSuggestions.map((s) => s.text),
+			[pageSuggestions],
+		);
+
+		// Record every starter-prompt click server-side, attributed to the
+		// authored prompt it came from. Rides the same widget-event stream the
+		// host page subscribes to, so there is one click signal, not two.
+		useEffect(() => {
+			return widgetEvents.subscribe((event) => {
+				if (event.name !== "suggestion.clicked") {
+					return;
+				}
+				const { text } = event.properties;
+				const { promptId, kind } = resolveClickAttribution(
+					pageSuggestions,
+					text,
+				);
+				void fireSuggestionClick({
+					api: config.api ?? "",
+					token: config.token,
+					channelId: config.channelId,
+					mode: "inline",
+					source: config.source,
+					sessionId: chatRef.current?.sessionId,
+					promptId,
+					kind,
+					text,
+					index: event.properties.index,
+				});
+			});
+		}, [
+			widgetEvents,
+			pageSuggestions,
+			config.api,
+			config.token,
+			config.channelId,
+			config.source,
+		]);
 
 		// `mode` tags every chat request with the embed surface so server-logged
 		// chat events carry it in `properties.mode`, matching `page.viewed`.

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -17,7 +17,9 @@ import type { ChatHandle } from "../@types";
 import { ChatEmbed } from "../layouts/chat-embed";
 import {
 	fireSuggestionClick,
+	fireSuggestionShown,
 	resolveClickAttribution,
+	resolveShownPrompts,
 } from "../lib/suggestion-click";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
@@ -124,31 +126,48 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 			[pageSuggestions],
 		);
 
-		// Record every starter-prompt click server-side, attributed to the
-		// authored prompt it came from. Rides the same widget-event stream the
-		// host page subscribes to, so there is one click signal, not two.
+		// Record every starter-prompt click and every rendered pill set
+		// server-side, attributed to the authored prompts involved. Rides the
+		// same widget-event stream the host page subscribes to, so there is one
+		// signal per interaction, not two.
 		useEffect(() => {
 			return widgetEvents.subscribe((event) => {
-				if (event.name !== "suggestion.clicked") {
+				if (event.name === "suggestion.clicked") {
+					const { text } = event.properties;
+					const { promptId, kind } = resolveClickAttribution(
+						pageSuggestions,
+						text,
+					);
+					void fireSuggestionClick({
+						api: config.api ?? "",
+						token: config.token,
+						channelId: config.channelId,
+						mode: "inline",
+						source: config.source,
+						sessionId: chatRef.current?.sessionId,
+						promptId,
+						kind,
+						text,
+						index: event.properties.index,
+					});
 					return;
 				}
-				const { text } = event.properties;
-				const { promptId, kind } = resolveClickAttribution(
-					pageSuggestions,
-					text,
-				);
-				void fireSuggestionClick({
-					api: config.api ?? "",
-					token: config.token,
-					channelId: config.channelId,
-					mode: "inline",
-					source: config.source,
-					sessionId: chatRef.current?.sessionId,
-					promptId,
-					kind,
-					text,
-					index: event.properties.index,
-				});
+				if (event.name === "suggestions.shown") {
+					const { prompts, kind } = resolveShownPrompts(
+						pageSuggestions,
+						event.properties.texts,
+					);
+					void fireSuggestionShown({
+						api: config.api ?? "",
+						token: config.token,
+						channelId: config.channelId,
+						mode: "inline",
+						source: config.source,
+						sessionId: chatRef.current?.sessionId,
+						prompts,
+						kind,
+					});
+				}
 			});
 		}, [
 			widgetEvents,

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -84,6 +84,12 @@ interface RemoteConfigResponse {
 	title: string | null;
 	placeholder: string | null;
 	suggestions: string[] | null;
+	/**
+	 * When true the widget fetches per-page starter prompts from
+	 * `/suggestions` and only uses `suggestions` as the fallback. Absent on
+	 * servers that predate the flag → `false`.
+	 */
+	dynamicSuggestions?: boolean | null;
 	enableThreadHistory?: boolean | null;
 	/**
 	 * Channel-specific event source (e.g. the integration/source this channel
@@ -170,6 +176,9 @@ function remoteToConfigPartial(
 	}
 	if (data.suggestions != null && data.suggestions.length > 0) {
 		out.suggestions = data.suggestions;
+	}
+	if (typeof data.dynamicSuggestions === "boolean") {
+		out.dynamicSuggestions = data.dynamicSuggestions;
 	}
 	if (typeof data.enableThreadHistory === "boolean") {
 		out.enableThreadHistory = data.enableThreadHistory;

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -86,10 +86,8 @@ interface RemoteConfigResponse {
 	placeholder: string | null;
 	suggestions: string[] | null;
 	/**
-	 * Per-page starter prompt sets, keyed by normalized pathname. Present only
-	 * while the channel has the feature switched on; the widget picks from the
-	 * matching entry locally and uses `suggestions` as the fallback. Absent on
-	 * servers that predate the field.
+	 * Per-page starter prompt sets; present only while the channel has the
+	 * feature on. Absent on servers that predate the field.
 	 */
 	pageSuggestions?: unknown;
 	enableThreadHistory?: boolean | null;

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -11,6 +11,7 @@ import { debugLog } from "../lib/debug";
 import { firePageView } from "../lib/page-view";
 import type { EmbedConfig } from "./config";
 import { resolveConfig } from "./config";
+import { parsePageSuggestions } from "./use-page-suggestions";
 import type { VisibilityRules } from "./visibility";
 
 // ---------------------------------------------------------------------------
@@ -85,11 +86,12 @@ interface RemoteConfigResponse {
 	placeholder: string | null;
 	suggestions: string[] | null;
 	/**
-	 * When true the widget fetches per-page starter prompts from
-	 * `/suggestions` and only uses `suggestions` as the fallback. Absent on
-	 * servers that predate the flag → `false`.
+	 * Per-page starter prompt sets, keyed by normalized pathname. Present only
+	 * while the channel has the feature switched on; the widget picks from the
+	 * matching entry locally and uses `suggestions` as the fallback. Absent on
+	 * servers that predate the field.
 	 */
-	dynamicSuggestions?: boolean | null;
+	pageSuggestions?: unknown;
 	enableThreadHistory?: boolean | null;
 	/**
 	 * Channel-specific event source (e.g. the integration/source this channel
@@ -177,8 +179,9 @@ function remoteToConfigPartial(
 	if (data.suggestions != null && data.suggestions.length > 0) {
 		out.suggestions = data.suggestions;
 	}
-	if (typeof data.dynamicSuggestions === "boolean") {
-		out.dynamicSuggestions = data.dynamicSuggestions;
+	const pageSuggestions = parsePageSuggestions(data.pageSuggestions);
+	if (pageSuggestions.length > 0) {
+		out.pageSuggestions = pageSuggestions;
 	}
 	if (typeof data.enableThreadHistory === "boolean") {
 		out.enableThreadHistory = data.enableThreadHistory;

--- a/src/chat/web/embed/use-page-suggestions.ts
+++ b/src/chat/web/embed/use-page-suggestions.ts
@@ -1,142 +1,205 @@
 // ============================================================================
 // usePageSuggestions — starter prompts for the page the widget sits on.
 //
-// A channel with `dynamicSuggestions` on authors prompts per URL, so the pills
-// should change as the visitor moves around the host site. This fetches them
-// from `GET {api}/suggestions` on mount and again on every SPA navigation
-// (via `usePathname`), and falls back to the channel's fixed `suggestions`
-// whenever the request fails, is unauthorized, or comes back empty — the pills
-// are decoration on the entry point, never a hard dependency.
+// A channel with page-aware prompts delivers them in `/config` as
+// `pageSuggestions` entries keyed by normalized pathname. The widget matches
+// its location against those entries locally — no per-page request — and
+// re-picks on every SPA navigation (via `usePathname`). Pages with no entry
+// (or a channel with none) fall back to the channel's fixed `suggestions` —
+// the pills are decoration on the entry point, never a hard dependency.
 // ============================================================================
 
-import { useEffect, useMemo, useState } from "react";
-import { buildApiUrl } from "../lib/api-url";
+import { useMemo } from "react";
 import { debugLog } from "../lib/debug";
-import type { EmbedConfig } from "./config";
+import type {
+	EmbedConfig,
+	PagePrompt,
+	PagePromptTier,
+	PageSuggestionsEntry,
+} from "./config";
 import { usePathname } from "./use-pathname";
 
 /**
  * One starter prompt. `id` identifies an authored per-page prompt so a click
  * can be attributed back to it; it is `null` for prompts coming from the
  * channel's fixed `suggestions` list, which have no stored identity. Ids stop
- * at this hook's fetch state — the embeds render texts — parked there so click
- * attribution can pick them up without re-plumbing the fetch.
+ * at this hook's resolve state — the embeds render texts — parked there so
+ * click attribution can pick them up without re-plumbing the resolve.
  */
 export interface PageSuggestion {
 	id: string | null;
 	text: string;
 }
 
+/** How many of a page's authored prompts the widget shows at a time. */
+const SHOWN_PROMPT_COUNT = 3;
+
 /**
- * Pull the prompt list out of a `/suggestions` response body.
- *
- * The Waniwani API wraps payloads in `{ success, message, data }`; a bare
- * `{ suggestions }` root is accepted too so we stay compatible with raw
- * endpoints, matching how `fetchRemoteConfig` unwraps `/config`. Anything
- * malformed degrades to `[]`, which the caller reads as "use the fallback".
+ * Intent tiers in display order: educational / discovery first, action last.
+ * One prompt is shown per tier, so a visitor sees a next step for every level
+ * of buying intent.
  */
-export function parseSuggestionsResponse(raw: unknown): PageSuggestion[] {
-	const body = raw as {
-		data?: { suggestions?: unknown } | null;
-		suggestions?: unknown;
-	} | null;
-	const list = body?.data?.suggestions ?? body?.suggestions;
-	if (!Array.isArray(list)) {
+const TIER_ORDER: PagePromptTier[] = ["low", "medium", "high"];
+
+function takeRandom<T>(pool: T[]): T | undefined {
+	if (pool.length === 0) {
+		return undefined;
+	}
+	const index = Math.floor(Math.random() * pool.length);
+	const [taken] = pool.splice(index, 1);
+	return taken;
+}
+
+/**
+ * Pick up to {@link SHOWN_PROMPT_COUNT} prompts, one per intent tier in
+ * {@link TIER_ORDER}. A tier with no tagged prompt borrows from the untagged
+ * (wildcard) pool, and any slot still empty is filled from whatever remains —
+ * so a page with at least {@link SHOWN_PROMPT_COUNT} stored prompts always
+ * shows exactly that many, and an all-untagged pool degrades to a uniform
+ * random pick. Random within each pool so exposure spreads across visits.
+ */
+export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
+	const byTier = new Map<PagePromptTier, PagePrompt[]>();
+	const wildcards: PagePrompt[] = [];
+	for (const prompt of prompts) {
+		if (prompt.tier) {
+			const pool = byTier.get(prompt.tier) ?? [];
+			pool.push(prompt);
+			byTier.set(prompt.tier, pool);
+		} else {
+			wildcards.push(prompt);
+		}
+	}
+
+	const picked: PagePrompt[] = [];
+	for (const tier of TIER_ORDER) {
+		const fromTier = takeRandom(byTier.get(tier) ?? []);
+		const choice = fromTier ?? takeRandom(wildcards);
+		if (choice) {
+			picked.push(choice);
+		}
+	}
+
+	const leftovers = [...byTier.values()].flat().concat(wildcards);
+	while (picked.length < Math.min(SHOWN_PROMPT_COUNT, prompts.length)) {
+		const filler = takeRandom(leftovers);
+		if (!filler) {
+			break;
+		}
+		picked.push(filler);
+	}
+	return picked;
+}
+
+/**
+ * Reduce a URL or pathname to the form `pageSuggestions` entries are keyed
+ * by: pathname only, query and hash dropped, no trailing slash (root stays
+ * `/`), lowercased. Mirrors the server's authoring-side normalization, so a
+ * set authored for `https://site.com/Pricing/` is the one a widget on
+ * `/pricing` picks up. Anything unparseable normalizes to `/`.
+ */
+export function normalizePathname(url: string): string {
+	let pathname: string;
+	try {
+		// A base is required to parse a bare pathname; only the pathname
+		// survives, so the base itself is discarded.
+		pathname = new URL(url, "http://localhost").pathname;
+	} catch {
+		pathname = "/";
+	}
+	const trimmed = pathname.replace(/\/+$/, "");
+	return (trimmed === "" ? "/" : trimmed).toLowerCase();
+}
+
+/**
+ * Validate a `pageSuggestions` value from `/config` into typed entries.
+ *
+ * Malformed entries and prompts degrade by dropping out rather than throwing —
+ * remote config is a convenience layer, never required for the widget to
+ * function. An entry left with no usable prompts is dropped whole, so the
+ * page it named falls back to the fixed list.
+ */
+export function parsePageSuggestions(value: unknown): PageSuggestionsEntry[] {
+	if (!Array.isArray(value)) {
 		return [];
 	}
-	return list.flatMap((entry): PageSuggestion[] => {
-		const item = entry as Partial<PageSuggestion> | null;
-		if (typeof item?.text !== "string" || item.text.length === 0) {
+	return value.flatMap((entry): PageSuggestionsEntry[] => {
+		const item = entry as {
+			url?: unknown;
+			prompts?: unknown;
+		} | null;
+		if (
+			typeof item?.url !== "string" ||
+			item.url.length === 0 ||
+			!Array.isArray(item.prompts)
+		) {
 			return [];
 		}
-		return [
-			{ id: typeof item.id === "string" ? item.id : null, text: item.text },
-		];
+		const prompts = item.prompts.flatMap((raw): PagePrompt[] => {
+			const prompt = raw as Partial<PagePrompt> | null;
+			if (typeof prompt?.text !== "string" || prompt.text.length === 0) {
+				return [];
+			}
+			return [
+				{
+					id: typeof prompt.id === "string" ? prompt.id : null,
+					text: prompt.text,
+					tier:
+						prompt.tier === "low" ||
+						prompt.tier === "medium" ||
+						prompt.tier === "high"
+							? prompt.tier
+							: undefined,
+				},
+			];
+		});
+		return prompts.length > 0 ? [{ url: item.url, prompts }] : [];
 	});
 }
 
 /**
- * The list to render: the page's own prompts when we have any, otherwise the
- * channel's fixed `suggestions`. An empty fetched set counts as "nothing
- * authored for this page" and falls back, per the endpoint contract.
+ * The list to render: the page's own picked prompts when we have any,
+ * otherwise the channel's fixed `suggestions`.
  */
 export function resolveSuggestions(
-	fetched: PageSuggestion[] | null,
+	picked: PageSuggestion[] | null,
 	fallback: string[] | undefined,
 ): PageSuggestion[] {
-	if (fetched && fetched.length > 0) {
-		return fetched;
+	if (picked && picked.length > 0) {
+		return picked;
 	}
 	return (fallback ?? []).map((text) => ({ id: null, text }));
 }
 
 /**
  * Resolved starter prompt texts for the current page, with a stable array
- * identity between fetches — `useSuggestions` (inside `ChatEmbed`) keys an
+ * identity between navigations — `useSuggestions` (inside `ChatEmbed`) keys an
  * effect on the `initial` array identity and setStates it, so a fresh array
- * each render would loop.
+ * each render would loop. The random per-tier pick happens inside the memo,
+ * so one set stays up until the visitor navigates.
  *
- * Inert unless the channel reported `dynamicSuggestions: true` — without it
- * (including against servers that predate the flag) this is exactly
- * `config.suggestions`, no request made.
- *
- * `channelId` is required: `/suggestions` takes no environment default and
- * rejects a missing or non-uuid `channel` with a 400, so an embed configured
- * without one stays on the fixed list.
+ * Inert without `config.pageSuggestions` — against servers that predate the
+ * field (or a channel with the feature off, which never receives it) this is
+ * exactly `config.suggestions`.
  */
 export function usePageSuggestions(config: EmbedConfig): string[] {
-	const { api, token, channelId, dynamicSuggestions } = config;
-	// Re-runs the fetch on client-side route changes, not just hard loads.
+	const { pageSuggestions, suggestions } = config;
+	// Re-picks on client-side route changes, not just hard loads.
 	const pathname = usePathname();
-	const [fetched, setFetched] = useState<PageSuggestion[] | null>(null);
 
-	const enabled = Boolean(dynamicSuggestions && api && token && channelId);
-
-	useEffect(() => {
-		if (!enabled || !api || !token || !channelId) {
-			return;
-		}
-		// Aborting on cleanup is what keeps a slow response for the page the
-		// visitor just left from overwriting the page they are on now.
-		const controller = new AbortController();
-		void (async () => {
-			try {
-				const url = buildApiUrl(api, "/suggestions", {
-					channel: channelId,
-					// The pathname this effect run is for — the server normalizes it,
-					// and it is all the host page needs to leak.
-					url: pathname,
-				});
-				const res = await fetch(url, {
-					method: "GET",
-					headers: { Authorization: `Bearer ${token}` },
-					signal: controller.signal,
-				});
-				const items = res.ok ? parseSuggestionsResponse(await res.json()) : [];
-				if (controller.signal.aborted) {
-					return;
-				}
-				debugLog("remote /suggestions response", {
-					pathname,
-					ok: res.ok,
-					count: items.length,
-				});
-				// `null` rather than `[]` so the resolve below reads it as "no
-				// page-specific set" and hands back the channel's fixed list.
-				setFetched(items.length > 0 ? items : null);
-			} catch {
-				// Network error / abort — keep whatever we last resolved to on an
-				// abort, otherwise drop back to the fallback.
-				if (!controller.signal.aborted) {
-					setFetched(null);
-				}
-			}
-		})();
-		return () => controller.abort();
-	}, [enabled, api, token, channelId, pathname]);
-
-	return useMemo(
-		() => resolveSuggestions(fetched, config.suggestions).map((s) => s.text),
-		[fetched, config.suggestions],
-	);
+	return useMemo(() => {
+		const current = normalizePathname(pathname);
+		const page = pageSuggestions?.find(
+			(entry) => normalizePathname(entry.url) === current,
+		);
+		const picked = page
+			? pickPagePrompts(page.prompts).map(({ id, text }) => ({ id, text }))
+			: null;
+		debugLog("page suggestions resolve", {
+			pathname: current,
+			matched: Boolean(page),
+			count: picked?.length ?? 0,
+		});
+		return resolveSuggestions(picked, suggestions).map((s) => s.text);
+	}, [pathname, pageSuggestions, suggestions]);
 }

--- a/src/chat/web/embed/use-page-suggestions.ts
+++ b/src/chat/web/embed/use-page-suggestions.ts
@@ -18,9 +18,9 @@ import { usePathname } from "./use-pathname";
 /**
  * One starter prompt. `id` identifies an authored per-page prompt so a click
  * can be attributed back to it; it is `null` for prompts coming from the
- * channel's fixed `suggestions` list, which have no stored identity. Ids stop
- * at this hook's fetch state — the embeds render texts — parked there so click
- * attribution can pick them up without re-plumbing the fetch.
+ * channel's fixed `suggestions` list, which have no stored identity. The embed
+ * hosts render the texts and keep the objects around so a click can be
+ * resolved to its id (see `resolveClickAttribution` in `lib/suggestion-click`).
  */
 export interface PageSuggestion {
 	id: string | null;
@@ -71,10 +71,10 @@ export function resolveSuggestions(
 }
 
 /**
- * Resolved starter prompt texts for the current page, with a stable array
- * identity between fetches — `useSuggestions` (inside `ChatEmbed`) keys an
- * effect on the `initial` array identity and setStates it, so a fresh array
- * each render would loop.
+ * Resolved starter prompts for the current page, with a stable array identity
+ * between fetches — `useSuggestions` (inside `ChatEmbed`) keys an effect on the
+ * `initial` array identity and setStates it, so a fresh array each render would
+ * loop. Callers deriving the texts must memoize that map for the same reason.
  *
  * Inert unless the channel reported `dynamicSuggestions: true` — without it
  * (including against servers that predate the flag) this is exactly
@@ -84,7 +84,7 @@ export function resolveSuggestions(
  * rejects a missing or non-uuid `channel` with a 400, so an embed configured
  * without one stays on the fixed list.
  */
-export function usePageSuggestions(config: EmbedConfig): string[] {
+export function usePageSuggestions(config: EmbedConfig): PageSuggestion[] {
 	const { api, token, channelId, dynamicSuggestions } = config;
 	// Re-runs the fetch on client-side route changes, not just hard loads.
 	const pathname = usePathname();
@@ -136,7 +136,7 @@ export function usePageSuggestions(config: EmbedConfig): string[] {
 	}, [enabled, api, token, channelId, pathname]);
 
 	return useMemo(
-		() => resolveSuggestions(fetched, config.suggestions).map((s) => s.text),
+		() => resolveSuggestions(fetched, config.suggestions),
 		[fetched, config.suggestions],
 	);
 }

--- a/src/chat/web/embed/use-page-suggestions.ts
+++ b/src/chat/web/embed/use-page-suggestions.ts
@@ -1,7 +1,3 @@
-// Starter prompts for the page the widget sits on: `/config` delivers
-// per-page sets keyed by normalized pathname; the widget matches its location
-// locally, re-picks on SPA navigation, and falls back to the fixed list.
-
 import { useMemo } from "react";
 import { DEFAULT_SUGGESTION_ORIGINS } from "../hooks/use-suggestions";
 import { debugLog } from "../lib/debug";
@@ -34,10 +30,8 @@ function takeRandom<T>(pool: T[]): T | undefined {
 	return taken;
 }
 
-/**
- * Pick up to {@link SHOWN_PROMPT_COUNT} prompts, one per tier; untagged
- * prompts fill any slot, leftovers top up short slots. Random within pools.
- */
+/** Up to {@link SHOWN_PROMPT_COUNT} prompts, one per tier, random within pools;
+ *  untagged prompts fill any slot and leftovers top up short slots. */
 export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 	const byTier = new Map<PagePromptTier, PagePrompt[]>();
 	const wildcards: PagePrompt[] = [];
@@ -70,10 +64,7 @@ export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 	return picked;
 }
 
-/**
- * URL or pathname → the entry key: pathname only, no query/hash/trailing
- * slash, lowercased (mirrors the server's normalization); unparseable → `/`.
- */
+/** URL → entry key: pathname only, lowercased, no query/hash/trailing slash. */
 export function normalizePathname(url: string): string {
 	let pathname: string;
 	try {
@@ -135,12 +126,8 @@ export function resolveSuggestions(
 	return (fallback ?? []).map((text) => ({ id: null, text }));
 }
 
-/**
- * Starter prompt texts for the current page. Memoized: one pick per pathname,
- * stable array identity (useSuggestions keys an effect on it). Inert — exactly
- * `config.suggestions` — without `pageSuggestions` or when the host's
- * `suggestionOrigins` excludes `"page"`.
- */
+/** Starter prompt texts for the current page, else `config.suggestions`.
+ *  @param config the resolved embed config (`pageSuggestions` opts in). */
 export function usePageSuggestions(config: EmbedConfig): string[] {
 	const { pageSuggestions, suggestions, suggestionOrigins } = config;
 	const pathname = usePathname();
@@ -148,6 +135,8 @@ export function usePageSuggestions(config: EmbedConfig): string[] {
 		suggestionOrigins ?? DEFAULT_SUGGESTION_ORIGINS
 	).includes("page");
 
+	// Memoized because the pick is random and the identity has to hold:
+	// `useSuggestions` keys an effect on this array and setStates it.
 	return useMemo(() => {
 		const current = normalizePathname(pathname);
 		const page = pageEnabled

--- a/src/chat/web/embed/use-page-suggestions.ts
+++ b/src/chat/web/embed/use-page-suggestions.ts
@@ -1,12 +1,8 @@
 // ============================================================================
 // usePageSuggestions — starter prompts for the page the widget sits on.
-//
-// A channel with page-aware prompts delivers them in `/config` as
-// `pageSuggestions` entries keyed by normalized pathname. The widget matches
-// its location against those entries locally — no per-page request — and
-// re-picks on every SPA navigation (via `usePathname`). Pages with no entry
-// (or a channel with none) fall back to the channel's fixed `suggestions` —
-// the pills are decoration on the entry point, never a hard dependency.
+// `/config` delivers per-page sets (`pageSuggestions`, keyed by normalized
+// pathname); the widget matches its location locally and re-picks on SPA
+// navigation. Unmatched pages fall back to the fixed `suggestions`.
 // ============================================================================
 
 import { useMemo } from "react";
@@ -20,11 +16,8 @@ import type {
 import { usePathname } from "./use-pathname";
 
 /**
- * One starter prompt. `id` identifies an authored per-page prompt so a click
- * can be attributed back to it; it is `null` for prompts coming from the
- * channel's fixed `suggestions` list, which have no stored identity. Ids stop
- * at this hook's resolve state — the embeds render texts — parked there so
- * click attribution can pick them up without re-plumbing the resolve.
+ * One starter prompt. `id` is the authored entry's identity (click
+ * attribution later); `null` for prompts from the fixed list.
  */
 export interface PageSuggestion {
 	id: string | null;
@@ -34,11 +27,7 @@ export interface PageSuggestion {
 /** How many of a page's authored prompts the widget shows at a time. */
 const SHOWN_PROMPT_COUNT = 3;
 
-/**
- * Intent tiers in display order: educational / discovery first, action last.
- * One prompt is shown per tier, so a visitor sees a next step for every level
- * of buying intent.
- */
+/** Tier display order. One prompt is shown per tier. */
 const TIER_ORDER: PagePromptTier[] = ["low", "medium", "high"];
 
 function takeRandom<T>(pool: T[]): T | undefined {
@@ -51,12 +40,8 @@ function takeRandom<T>(pool: T[]): T | undefined {
 }
 
 /**
- * Pick up to {@link SHOWN_PROMPT_COUNT} prompts, one per intent tier in
- * {@link TIER_ORDER}. A tier with no tagged prompt borrows from the untagged
- * (wildcard) pool, and any slot still empty is filled from whatever remains —
- * so a page with at least {@link SHOWN_PROMPT_COUNT} stored prompts always
- * shows exactly that many, and an all-untagged pool degrades to a uniform
- * random pick. Random within each pool so exposure spreads across visits.
+ * Pick up to {@link SHOWN_PROMPT_COUNT} prompts, one per tier; untagged
+ * prompts fill any slot, leftovers top up short slots. Random within pools.
  */
 export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 	const byTier = new Map<PagePromptTier, PagePrompt[]>();
@@ -73,8 +58,7 @@ export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 
 	const picked: PagePrompt[] = [];
 	for (const tier of TIER_ORDER) {
-		const fromTier = takeRandom(byTier.get(tier) ?? []);
-		const choice = fromTier ?? takeRandom(wildcards);
+		const choice = takeRandom(byTier.get(tier) ?? []) ?? takeRandom(wildcards);
 		if (choice) {
 			picked.push(choice);
 		}
@@ -92,17 +76,13 @@ export function pickPagePrompts(prompts: PagePrompt[]): PagePrompt[] {
 }
 
 /**
- * Reduce a URL or pathname to the form `pageSuggestions` entries are keyed
- * by: pathname only, query and hash dropped, no trailing slash (root stays
- * `/`), lowercased. Mirrors the server's authoring-side normalization, so a
- * set authored for `https://site.com/Pricing/` is the one a widget on
- * `/pricing` picks up. Anything unparseable normalizes to `/`.
+ * URL or pathname → the key `pageSuggestions` entries use: pathname only, no
+ * query/hash/trailing slash, lowercased. Mirrors the server's authoring-side
+ * normalization; unparseable input becomes `/`.
  */
 export function normalizePathname(url: string): string {
 	let pathname: string;
 	try {
-		// A base is required to parse a bare pathname; only the pathname
-		// survives, so the base itself is discarded.
 		pathname = new URL(url, "http://localhost").pathname;
 	} catch {
 		pathname = "/";
@@ -112,12 +92,9 @@ export function normalizePathname(url: string): string {
 }
 
 /**
- * Validate a `pageSuggestions` value from `/config` into typed entries.
- *
- * Malformed entries and prompts degrade by dropping out rather than throwing —
- * remote config is a convenience layer, never required for the widget to
- * function. An entry left with no usable prompts is dropped whole, so the
- * page it named falls back to the fixed list.
+ * Validate a raw `pageSuggestions` value into typed entries. Malformed
+ * entries/prompts drop out instead of throwing; an entry left empty is
+ * dropped whole.
  */
 export function parsePageSuggestions(value: unknown): PageSuggestionsEntry[] {
 	if (!Array.isArray(value)) {
@@ -157,10 +134,7 @@ export function parsePageSuggestions(value: unknown): PageSuggestionsEntry[] {
 	});
 }
 
-/**
- * The list to render: the page's own picked prompts when we have any,
- * otherwise the channel's fixed `suggestions`.
- */
+/** The page's picked prompts when there are any, else the fixed fallback. */
 export function resolveSuggestions(
 	picked: PageSuggestion[] | null,
 	fallback: string[] | undefined,
@@ -172,19 +146,12 @@ export function resolveSuggestions(
 }
 
 /**
- * Resolved starter prompt texts for the current page, with a stable array
- * identity between navigations — `useSuggestions` (inside `ChatEmbed`) keys an
- * effect on the `initial` array identity and setStates it, so a fresh array
- * each render would loop. The random per-tier pick happens inside the memo,
- * so one set stays up until the visitor navigates.
- *
- * Inert without `config.pageSuggestions` — against servers that predate the
- * field (or a channel with the feature off, which never receives it) this is
- * exactly `config.suggestions`.
+ * Starter prompt texts for the current page. Memoized so the pick is stable
+ * per pathname and the array identity doesn't loop `useSuggestions`' effect.
+ * Without `config.pageSuggestions` this is exactly `config.suggestions`.
  */
 export function usePageSuggestions(config: EmbedConfig): string[] {
 	const { pageSuggestions, suggestions } = config;
-	// Re-picks on client-side route changes, not just hard loads.
 	const pathname = usePathname();
 
 	return useMemo(() => {

--- a/src/chat/web/embed/use-page-suggestions.ts
+++ b/src/chat/web/embed/use-page-suggestions.ts
@@ -1,0 +1,142 @@
+// ============================================================================
+// usePageSuggestions — starter prompts for the page the widget sits on.
+//
+// A channel with `dynamicSuggestions` on authors prompts per URL, so the pills
+// should change as the visitor moves around the host site. This fetches them
+// from `GET {api}/suggestions` on mount and again on every SPA navigation
+// (via `usePathname`), and falls back to the channel's fixed `suggestions`
+// whenever the request fails, is unauthorized, or comes back empty — the pills
+// are decoration on the entry point, never a hard dependency.
+// ============================================================================
+
+import { useEffect, useMemo, useState } from "react";
+import { buildApiUrl } from "../lib/api-url";
+import { debugLog } from "../lib/debug";
+import type { EmbedConfig } from "./config";
+import { usePathname } from "./use-pathname";
+
+/**
+ * One starter prompt. `id` identifies an authored per-page prompt so a click
+ * can be attributed back to it; it is `null` for prompts coming from the
+ * channel's fixed `suggestions` list, which have no stored identity. Ids stop
+ * at this hook's fetch state — the embeds render texts — parked there so click
+ * attribution can pick them up without re-plumbing the fetch.
+ */
+export interface PageSuggestion {
+	id: string | null;
+	text: string;
+}
+
+/**
+ * Pull the prompt list out of a `/suggestions` response body.
+ *
+ * The Waniwani API wraps payloads in `{ success, message, data }`; a bare
+ * `{ suggestions }` root is accepted too so we stay compatible with raw
+ * endpoints, matching how `fetchRemoteConfig` unwraps `/config`. Anything
+ * malformed degrades to `[]`, which the caller reads as "use the fallback".
+ */
+export function parseSuggestionsResponse(raw: unknown): PageSuggestion[] {
+	const body = raw as {
+		data?: { suggestions?: unknown } | null;
+		suggestions?: unknown;
+	} | null;
+	const list = body?.data?.suggestions ?? body?.suggestions;
+	if (!Array.isArray(list)) {
+		return [];
+	}
+	return list.flatMap((entry): PageSuggestion[] => {
+		const item = entry as Partial<PageSuggestion> | null;
+		if (typeof item?.text !== "string" || item.text.length === 0) {
+			return [];
+		}
+		return [
+			{ id: typeof item.id === "string" ? item.id : null, text: item.text },
+		];
+	});
+}
+
+/**
+ * The list to render: the page's own prompts when we have any, otherwise the
+ * channel's fixed `suggestions`. An empty fetched set counts as "nothing
+ * authored for this page" and falls back, per the endpoint contract.
+ */
+export function resolveSuggestions(
+	fetched: PageSuggestion[] | null,
+	fallback: string[] | undefined,
+): PageSuggestion[] {
+	if (fetched && fetched.length > 0) {
+		return fetched;
+	}
+	return (fallback ?? []).map((text) => ({ id: null, text }));
+}
+
+/**
+ * Resolved starter prompt texts for the current page, with a stable array
+ * identity between fetches — `useSuggestions` (inside `ChatEmbed`) keys an
+ * effect on the `initial` array identity and setStates it, so a fresh array
+ * each render would loop.
+ *
+ * Inert unless the channel reported `dynamicSuggestions: true` — without it
+ * (including against servers that predate the flag) this is exactly
+ * `config.suggestions`, no request made.
+ *
+ * `channelId` is required: `/suggestions` takes no environment default and
+ * rejects a missing or non-uuid `channel` with a 400, so an embed configured
+ * without one stays on the fixed list.
+ */
+export function usePageSuggestions(config: EmbedConfig): string[] {
+	const { api, token, channelId, dynamicSuggestions } = config;
+	// Re-runs the fetch on client-side route changes, not just hard loads.
+	const pathname = usePathname();
+	const [fetched, setFetched] = useState<PageSuggestion[] | null>(null);
+
+	const enabled = Boolean(dynamicSuggestions && api && token && channelId);
+
+	useEffect(() => {
+		if (!enabled || !api || !token || !channelId) {
+			return;
+		}
+		// Aborting on cleanup is what keeps a slow response for the page the
+		// visitor just left from overwriting the page they are on now.
+		const controller = new AbortController();
+		void (async () => {
+			try {
+				const url = buildApiUrl(api, "/suggestions", {
+					channel: channelId,
+					// The pathname this effect run is for — the server normalizes it,
+					// and it is all the host page needs to leak.
+					url: pathname,
+				});
+				const res = await fetch(url, {
+					method: "GET",
+					headers: { Authorization: `Bearer ${token}` },
+					signal: controller.signal,
+				});
+				const items = res.ok ? parseSuggestionsResponse(await res.json()) : [];
+				if (controller.signal.aborted) {
+					return;
+				}
+				debugLog("remote /suggestions response", {
+					pathname,
+					ok: res.ok,
+					count: items.length,
+				});
+				// `null` rather than `[]` so the resolve below reads it as "no
+				// page-specific set" and hands back the channel's fixed list.
+				setFetched(items.length > 0 ? items : null);
+			} catch {
+				// Network error / abort — keep whatever we last resolved to on an
+				// abort, otherwise drop back to the fallback.
+				if (!controller.signal.aborted) {
+					setFetched(null);
+				}
+			}
+		})();
+		return () => controller.abort();
+	}, [enabled, api, token, channelId, pathname]);
+
+	return useMemo(
+		() => resolveSuggestions(fetched, config.suggestions).map((s) => s.text),
+		[fetched, config.suggestions],
+	);
+}

--- a/src/chat/web/embed/widget-events.ts
+++ b/src/chat/web/embed/widget-events.ts
@@ -44,6 +44,7 @@ export type WidgetEventDetail =
 	| { name: "thread.changed"; properties: { threadId: string } }
 	| { name: "chat.error"; properties: { message: string } }
 	| { name: "suggestion.clicked"; properties: { text: string; index: number } }
+	| { name: "suggestions.shown"; properties: { texts: string[] } }
 	| { name: "link.clicked"; properties: { url: string } };
 
 /** Payload handed to `onEvent` subscribers. Discriminated on `name`. */

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -306,6 +306,23 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 			config: props.suggestions,
 		});
 
+		// Announce every pill set the visitor actually saw, once per set — keyed
+		// on the array identity `useSuggestions` returns (a new array per
+		// config load / streamed turn), so re-renders of the same set stay
+		// silent. The embed hosts subscribe and log one impression per set.
+		const announcedSuggestionsRef = useRef<string[] | null>(null);
+		useEffect(() => {
+			const current = suggestionsState.suggestions;
+			if (current.length === 0 || announcedSuggestionsRef.current === current) {
+				return;
+			}
+			announcedSuggestionsRef.current = current;
+			widgetEvents.emit({
+				name: "suggestions.shown",
+				properties: { texts: current },
+			});
+		}, [suggestionsState.suggestions, widgetEvents]);
+
 		const handleWidgetMessage = useCallback(
 			(message: {
 				role: string;

--- a/src/chat/web/lib/__tests__/suggestion-click.test.ts
+++ b/src/chat/web/lib/__tests__/suggestion-click.test.ts
@@ -17,7 +17,9 @@ for (const key of [
 
 import {
 	fireSuggestionClick,
+	fireSuggestionShown,
 	resolveClickAttribution,
+	resolveShownPrompts,
 } from "../suggestion-click";
 
 interface Captured {
@@ -217,6 +219,110 @@ describe("fireSuggestionClick", () => {
 			await fireSuggestionClick({ ...BASE });
 		} finally {
 			globalThis.fetch = real;
+		}
+	});
+});
+
+describe("resolveShownPrompts", () => {
+	const list = [
+		{ id: "p1", text: "Authored one" },
+		{ id: "p2", text: "Authored two" },
+	];
+
+	test("an authored set keeps every stored id and reads as page", () => {
+		expect(resolveShownPrompts(list, ["Authored one", "Authored two"])).toEqual(
+			{
+				prompts: [
+					{ id: "p1", text: "Authored one" },
+					{ id: "p2", text: "Authored two" },
+				],
+				kind: "page",
+			},
+		);
+	});
+
+	test("texts absent from the list read as a followup set with null ids", () => {
+		expect(resolveShownPrompts(list, ["Streamed A", "Streamed B"])).toEqual({
+			prompts: [
+				{ id: null, text: "Streamed A" },
+				{ id: null, text: "Streamed B" },
+			],
+			kind: "followup",
+		});
+	});
+
+	test("a fixed-list set has no ids and reads as fallback", () => {
+		const fallbackList = [{ id: null, text: "From the fixed list" }];
+		expect(resolveShownPrompts(fallbackList, ["From the fixed list"])).toEqual({
+			prompts: [{ id: null, text: "From the fixed list" }],
+			kind: "fallback",
+		});
+	});
+});
+
+describe("fireSuggestionShown", () => {
+	const SHOWN_BASE = {
+		api: BASE.api,
+		token: BASE.token,
+		channelId: BASE.channelId,
+		mode: BASE.mode,
+		source: BASE.source,
+		prompts: [
+			{ id: "p1", text: "Authored one" },
+			{ id: null, text: "From the fixed list" },
+		],
+		kind: "page",
+	} as const;
+
+	test("POSTs one suggestion.shown event carrying the whole set", async () => {
+		const { calls, restore } = mockFetch();
+		try {
+			await fireSuggestionShown({
+				...SHOWN_BASE,
+				prompts: [...SHOWN_BASE.prompts],
+			});
+			expect(calls).toHaveLength(1);
+			const [call] = calls;
+			expect(call.url).toBe("https://app.waniwani.ai/api/mcp/events/v2/batch");
+			const [ev] = JSON.parse(call.init.body as string).events;
+			expect(ev.name).toBe("suggestion.shown");
+			expect(ev.properties).toMatchObject({
+				prompts: [
+					{ id: "p1", text: "Authored one" },
+					{ id: null, text: "From the fixed list" },
+				],
+				count: 2,
+				kind: "page",
+				channelId: "chan_1",
+				mode: "inline",
+				url: "https://shop.example.com/pricing",
+			});
+		} finally {
+			restore();
+		}
+	});
+
+	test("an empty set is a no-op, not an event", async () => {
+		const { calls, restore } = mockFetch();
+		try {
+			await fireSuggestionShown({ ...SHOWN_BASE, prompts: [] });
+			expect(calls).toHaveLength(0);
+		} finally {
+			restore();
+		}
+	});
+
+	test("is a no-op without an api or token", async () => {
+		const { calls, restore } = mockFetch();
+		try {
+			await fireSuggestionShown({
+				...SHOWN_BASE,
+				prompts: [...SHOWN_BASE.prompts],
+				api: "",
+			});
+			expect(calls).toHaveLength(0);
+		} finally {
+			restore();
 		}
 	});
 });

--- a/src/chat/web/lib/__tests__/suggestion-click.test.ts
+++ b/src/chat/web/lib/__tests__/suggestion-click.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+
+const win = new Window({ url: "https://shop.example.com/pricing" });
+for (const key of [
+	"document",
+	"navigator",
+	"localStorage",
+	"screen",
+	"location",
+] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any)[key] = (win as any)[key];
+}
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).window = win;
+
+import {
+	fireSuggestionClick,
+	resolveClickAttribution,
+} from "../suggestion-click";
+
+interface Captured {
+	url: string;
+	init: RequestInit;
+}
+
+function mockFetch(): { calls: Captured[]; restore: () => void } {
+	const calls: Captured[] = [];
+	const real = globalThis.fetch;
+	// biome-ignore lint/suspicious/noExplicitAny: test stub
+	(globalThis as any).fetch = async (url: any, init: any) => {
+		calls.push({ url: String(url), init });
+		return new Response(null, { status: 202 });
+	};
+	return {
+		calls,
+		restore: () => {
+			globalThis.fetch = real;
+		},
+	};
+}
+
+const BASE = {
+	api: "https://app.waniwani.ai/api/mcp/chat",
+	token: "wwp_test",
+	channelId: "chan_1",
+	mode: "inline",
+	source: "acme-web",
+	promptId: "prompt_1",
+	kind: "page",
+	text: "What does Pro cost?",
+	index: 0,
+} as const;
+
+beforeEach(() => {
+	try {
+		localStorage.clear();
+	} catch {
+		// ignore
+	}
+});
+
+describe("resolveClickAttribution", () => {
+	const list = [
+		{ id: "p1", text: "Authored" },
+		{ id: null, text: "From the fixed list" },
+	];
+
+	test("an authored prompt keeps its stored id", () => {
+		expect(resolveClickAttribution(list, "Authored")).toEqual({
+			promptId: "p1",
+			kind: "page",
+		});
+	});
+
+	test("a fallback prompt has no id to attribute to", () => {
+		expect(resolveClickAttribution(list, "From the fixed list")).toEqual({
+			promptId: null,
+			kind: "fallback",
+		});
+	});
+
+	test("a text that is not in the rendered list reads as a followup", () => {
+		expect(resolveClickAttribution(list, "Something streamed")).toEqual({
+			promptId: null,
+			kind: "followup",
+		});
+		expect(resolveClickAttribution([], "Anything")).toEqual({
+			promptId: null,
+			kind: "followup",
+		});
+	});
+
+	test("duplicate texts attribute to the first match", () => {
+		expect(
+			resolveClickAttribution(
+				[
+					{ id: "first", text: "Same" },
+					{ id: "second", text: "Same" },
+				],
+				"Same",
+			),
+		).toEqual({ promptId: "first", kind: "page" });
+	});
+});
+
+describe("fireSuggestionClick", () => {
+	test("POSTs a suggestion.clicked event to the canonical ingest with the prompt id", async () => {
+		const { calls, restore } = mockFetch();
+		try {
+			await fireSuggestionClick({ ...BASE });
+			expect(calls).toHaveLength(1);
+			const [call] = calls;
+			// Same canonical V2 batch ingest `page.viewed` uses.
+			expect(call.url).toBe("https://app.waniwani.ai/api/mcp/events/v2/batch");
+			expect(call.init.method).toBe("POST");
+			const headers = call.init.headers as Record<string, string>;
+			expect(headers.Authorization).toBe("Bearer wwp_test");
+
+			const batch = JSON.parse(call.init.body as string);
+			expect(batch.events).toHaveLength(1);
+			const [ev] = batch.events;
+			expect(ev.type).toBe("mcp.event");
+			expect(ev.name).toBe("suggestion.clicked");
+			expect(ev.source).toBe("acme-web");
+			expect(typeof ev.correlation.visitorId).toBe("string");
+			expect(ev.correlation.visitorId.length).toBeGreaterThan(0);
+			expect(ev.properties).toMatchObject({
+				promptId: "prompt_1",
+				kind: "page",
+				text: "What does Pro cost?",
+				index: 0,
+				channelId: "chan_1",
+				mode: "inline",
+				url: "https://shop.example.com/pricing",
+			});
+		} finally {
+			restore();
+		}
+	});
+
+	test("carries the session id only once a conversation exists", async () => {
+		const { calls, restore } = mockFetch();
+		try {
+			// The usual case: the starter click is what starts the conversation.
+			await fireSuggestionClick({ ...BASE });
+			await fireSuggestionClick({ ...BASE, sessionId: "sess_1" });
+			expect(calls).toHaveLength(2);
+			const first = JSON.parse(calls[0].init.body as string).events[0];
+			const second = JSON.parse(calls[1].init.body as string).events[0];
+			expect("sessionId" in first.correlation).toBe(false);
+			expect(second.correlation.sessionId).toBe("sess_1");
+		} finally {
+			restore();
+		}
+	});
+
+	test("fires on every click — no once-per-page guard", async () => {
+		const { calls, restore } = mockFetch();
+		try {
+			await fireSuggestionClick({ ...BASE });
+			await fireSuggestionClick({ ...BASE });
+			expect(calls).toHaveLength(2);
+		} finally {
+			restore();
+		}
+	});
+
+	test("fires without a source tag when the channel has no configured source", async () => {
+		const { calls, restore } = mockFetch();
+		try {
+			await fireSuggestionClick({ ...BASE, source: undefined });
+			expect(calls).toHaveLength(1);
+			const [ev] = JSON.parse(calls[0].init.body as string).events;
+			expect("source" in ev).toBe(false);
+			expect(ev.properties.channelId).toBe("chan_1");
+		} finally {
+			restore();
+		}
+	});
+
+	test("sends a null promptId for a fallback prompt", async () => {
+		const { calls, restore } = mockFetch();
+		try {
+			await fireSuggestionClick({
+				...BASE,
+				promptId: null,
+				kind: "fallback",
+			});
+			const [ev] = JSON.parse(calls[0].init.body as string).events;
+			expect(ev.properties.promptId).toBe(null);
+			expect(ev.properties.kind).toBe("fallback");
+		} finally {
+			restore();
+		}
+	});
+
+	test("is a no-op without an api or token", async () => {
+		const { calls, restore } = mockFetch();
+		try {
+			await fireSuggestionClick({ ...BASE, api: "" });
+			await fireSuggestionClick({ ...BASE, token: "" });
+			expect(calls).toHaveLength(0);
+		} finally {
+			restore();
+		}
+	});
+
+	test("never throws when the network is down", async () => {
+		const real = globalThis.fetch;
+		// biome-ignore lint/suspicious/noExplicitAny: test stub
+		(globalThis as any).fetch = async () => {
+			throw new Error("network down");
+		};
+		try {
+			await fireSuggestionClick({ ...BASE });
+		} finally {
+			globalThis.fetch = real;
+		}
+	});
+});

--- a/src/chat/web/lib/suggestion-click.ts
+++ b/src/chat/web/lib/suggestion-click.ts
@@ -1,17 +1,22 @@
 // ============================================================================
-// Suggestion-click event — fired every time a visitor clicks a starter prompt.
+// Suggestion events — `suggestion.clicked` for every starter-prompt click and
+// `suggestion.shown` for every pill set the visitor actually saw.
 //
-// This is what makes authored per-page prompts measurable: the event carries
-// the prompt's stored id in `properties.promptId`, so a click attributes back
-// to the prompt that earned it. Page-level CTR is clicks ÷ `page.viewed`.
+// Together they make authored per-page prompts measurable per prompt id: a
+// click attributes back to the prompt that earned it (`properties.promptId`),
+// a shown set records which prompts had the chance to earn one
+// (`properties.prompts`), and per-prompt CTR is clicks(id) ÷ shown sets
+// containing that id. A shown set is one event carrying all its pills, not an
+// event per pill.
 //
 // Same canonical ingest, envelope, and auth as `page.viewed`
 // (`POST /api/mcp/events/v2/batch` with the public `wwp_` token) — see
 // `page-view.ts` for why no widget JWT is involved. Two differences: there is
-// no once-per-page guard (every click counts, and clicking submits the message
-// and clears the pills, so clicks are naturally rate-limited), and identity is
-// the synchronous `getOrCreateVisitorId()` — the device/referrer context rides
-// on `page.viewed` already, so there is nothing to await here.
+// no once-per-page guard (the render/click sites own their own dedupe — a
+// click submits the message and clears the pills, a shown set is keyed on the
+// resolved list's identity), and identity is the synchronous
+// `getOrCreateVisitorId()` — the device/referrer context rides on
+// `page.viewed` already, so there is nothing to await here.
 // ============================================================================
 
 import type { PageSuggestion } from "../embed/use-page-suggestions";
@@ -74,10 +79,70 @@ export function resolveClickAttribution(
 	return { promptId: match.id, kind: match.id ? "page" : "fallback" };
 }
 
+interface PostSuggestionEventOptions {
+	api: string;
+	token: string;
+	name: "suggestion.clicked" | "suggestion.shown";
+	source?: string;
+	sessionId?: string;
+	properties: Record<string, unknown>;
+}
+
+/**
+ * Envelope + POST shared by both suggestion events. Fire-and-forget: resolves
+ * once the request is dispatched (or skipped) and never throws — tracking must
+ * never break the host page or the widget.
+ */
+async function postSuggestionEvent(
+	opts: PostSuggestionEventOptions,
+): Promise<void> {
+	const { api, token, name, source, sessionId, properties } = opts;
+	if (typeof window === "undefined" || !api || !token) {
+		return;
+	}
+
+	try {
+		const now = new Date().toISOString();
+		const body = JSON.stringify({
+			sentAt: now,
+			source: { sdk: "@waniwani/sdk", version: "0.1.0" },
+			events: [
+				{
+					id: crypto.randomUUID(),
+					type: "mcp.event",
+					name,
+					source,
+					timestamp: now,
+					// `sessionId` is dropped by JSON.stringify while undefined, so an
+					// event that precedes the first exchange carries visitor id only.
+					correlation: { visitorId: getOrCreateVisitorId(), sessionId },
+					properties: {
+						...properties,
+						// Raw href, same as `page.viewed` — normalized at query time.
+						url: window.location.href,
+					},
+					metadata: {},
+				},
+			],
+		});
+
+		await fetch(eventsEndpoint(api), {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+			},
+			body,
+			// A click submits a message and may navigate; keep the send alive.
+			keepalive: true,
+		});
+	} catch {
+		// Never surface a tracking failure. A dropped event is a dropped event.
+	}
+}
+
 /**
  * Emit a `suggestion.clicked` event for one starter-prompt click.
- * Fire-and-forget: resolves once the request is dispatched (or skipped) and
- * never throws — tracking must never break the host page or the widget.
  */
 export async function fireSuggestionClick(
 	opts: FireSuggestionClickOptions,
@@ -94,52 +159,87 @@ export async function fireSuggestionClick(
 		text,
 		index,
 	} = opts;
-	if (typeof window === "undefined" || !api || !token) {
+	await postSuggestionEvent({
+		api,
+		token,
+		name: "suggestion.clicked",
+		source,
+		sessionId,
+		properties: {
+			promptId,
+			kind,
+			// Org-authored copy, and DLP-redacted server-side regardless.
+			text,
+			index,
+			channelId,
+			mode,
+		},
+	});
+}
+
+/** A prompt as it appeared in a rendered set, for impression logging. */
+export interface ShownPrompt {
+	id: string | null;
+	text: string;
+}
+
+/**
+ * Attribute a rendered set back to the list it was resolved from, one entry
+ * per pill. The set-level `kind` is the first pill's: rendered sets are
+ * homogeneous (a page row is all-authored, the fixed list all-null, streamed
+ * follow-ups absent from the list entirely), so a mixed set only arises from
+ * a render racing an SPA-nav refetch and the first pill is as truthful as any.
+ */
+export function resolveShownPrompts(
+	list: PageSuggestion[],
+	texts: string[],
+): { prompts: ShownPrompt[]; kind: SuggestionKind } {
+	const prompts = texts.map((text) => ({
+		id: resolveClickAttribution(list, text).promptId,
+		text,
+	}));
+	const kind: SuggestionKind =
+		texts.length > 0 ? resolveClickAttribution(list, texts[0]).kind : "page";
+	return { prompts, kind };
+}
+
+export interface FireSuggestionShownOptions {
+	api: string;
+	token: string;
+	channelId?: string;
+	mode?: "inline" | "floating";
+	source?: string;
+	sessionId?: string;
+	prompts: ShownPrompt[];
+	kind: SuggestionKind;
+}
+
+/**
+ * Emit one `suggestion.shown` event for a rendered pill set. One event per
+ * set, not per pill: the per-prompt ids ride in `properties.prompts`, so
+ * per-prompt impressions stay queryable while a three-pill render costs one
+ * row.
+ */
+export async function fireSuggestionShown(
+	opts: FireSuggestionShownOptions,
+): Promise<void> {
+	const { api, token, channelId, mode, source, sessionId, prompts, kind } =
+		opts;
+	if (prompts.length === 0) {
 		return;
 	}
-
-	try {
-		const now = new Date().toISOString();
-		const body = JSON.stringify({
-			sentAt: now,
-			source: { sdk: "@waniwani/sdk", version: "0.1.0" },
-			events: [
-				{
-					id: crypto.randomUUID(),
-					type: "mcp.event",
-					name: "suggestion.clicked",
-					source,
-					timestamp: now,
-					// `sessionId` is dropped by JSON.stringify while undefined, so a
-					// click that precedes the first exchange carries visitor id only.
-					correlation: { visitorId: getOrCreateVisitorId(), sessionId },
-					properties: {
-						promptId,
-						kind,
-						// Org-authored copy, and DLP-redacted server-side regardless.
-						text,
-						index,
-						channelId,
-						mode,
-						// Raw href, same as `page.viewed` — normalized at query time.
-						url: window.location.href,
-					},
-					metadata: {},
-				},
-			],
-		});
-
-		await fetch(eventsEndpoint(api), {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${token}`,
-			},
-			body,
-			// The click submits a message and may navigate; keep the send alive.
-			keepalive: true,
-		});
-	} catch {
-		// Never surface a tracking failure. A dropped click is a dropped click.
-	}
+	await postSuggestionEvent({
+		api,
+		token,
+		name: "suggestion.shown",
+		source,
+		sessionId,
+		properties: {
+			prompts,
+			count: prompts.length,
+			kind,
+			channelId,
+			mode,
+		},
+	});
 }

--- a/src/chat/web/lib/suggestion-click.ts
+++ b/src/chat/web/lib/suggestion-click.ts
@@ -1,0 +1,145 @@
+// ============================================================================
+// Suggestion-click event — fired every time a visitor clicks a starter prompt.
+//
+// This is what makes authored per-page prompts measurable: the event carries
+// the prompt's stored id in `properties.promptId`, so a click attributes back
+// to the prompt that earned it. Page-level CTR is clicks ÷ `page.viewed`.
+//
+// Same canonical ingest, envelope, and auth as `page.viewed`
+// (`POST /api/mcp/events/v2/batch` with the public `wwp_` token) — see
+// `page-view.ts` for why no widget JWT is involved. Two differences: there is
+// no once-per-page guard (every click counts, and clicking submits the message
+// and clears the pills, so clicks are naturally rate-limited), and identity is
+// the synchronous `getOrCreateVisitorId()` — the device/referrer context rides
+// on `page.viewed` already, so there is nothing to await here.
+// ============================================================================
+
+import type { PageSuggestion } from "../embed/use-page-suggestions";
+import { eventsEndpoint } from "./page-view";
+import { getOrCreateVisitorId } from "./visitor-context";
+
+/** Where the clicked prompt came from. */
+export type SuggestionKind = "page" | "fallback" | "followup";
+
+export interface FireSuggestionClickOptions {
+	/** Chat API base, e.g. `https://app.waniwani.ai/api/mcp/chat`. */
+	api: string;
+	/** Public token (`wwp_...`). */
+	token: string;
+	/** Agent channel ID, when known. */
+	channelId?: string;
+	/** Embed surface the click happened on. */
+	mode?: "inline" | "floating";
+	/**
+	 * Channel-specific event source from the resolved `/config`, same tag
+	 * `page.viewed` carries. Omitted from the event entirely when absent — the
+	 * click still attributes to its channel via `properties.channelId`.
+	 */
+	source?: string;
+	/**
+	 * Conversation session id when one exists. Usually absent: a starter prompt
+	 * is normally the click that *starts* the conversation.
+	 */
+	sessionId?: string;
+	/** Stored id of the authored prompt, `null` when it has no identity. */
+	promptId: string | null;
+	kind: SuggestionKind;
+	/** The clicked prompt text. */
+	text: string;
+	/** Position in the rendered list, from the widget event. */
+	index: number;
+}
+
+/**
+ * Attribute a clicked prompt text back to the list it was rendered from: an
+ * authored per-page prompt keeps its stored id (`kind: "page"`), one from the
+ * channel's fixed list has none (`kind: "fallback"`).
+ *
+ * Two identical texts on one page attribute to the first match. Duplicate
+ * texts within a page are pathological authoring, not worth plumbing the
+ * rendered index through for.
+ */
+export function resolveClickAttribution(
+	list: PageSuggestion[],
+	text: string,
+): { promptId: string | null; kind: SuggestionKind } {
+	const match = list.find((s) => s.text === text);
+	if (!match) {
+		// ponytail: not in the current page list → treat as a followup. Today the
+		// WaniWani server never streams followups so this is near-unreachable
+		// (only a click racing an SPA-nav refetch); generated follow-ups make it
+		// real.
+		return { promptId: null, kind: "followup" };
+	}
+	return { promptId: match.id, kind: match.id ? "page" : "fallback" };
+}
+
+/**
+ * Emit a `suggestion.clicked` event for one starter-prompt click.
+ * Fire-and-forget: resolves once the request is dispatched (or skipped) and
+ * never throws — tracking must never break the host page or the widget.
+ */
+export async function fireSuggestionClick(
+	opts: FireSuggestionClickOptions,
+): Promise<void> {
+	const {
+		api,
+		token,
+		channelId,
+		mode,
+		source,
+		sessionId,
+		promptId,
+		kind,
+		text,
+		index,
+	} = opts;
+	if (typeof window === "undefined" || !api || !token) {
+		return;
+	}
+
+	try {
+		const now = new Date().toISOString();
+		const body = JSON.stringify({
+			sentAt: now,
+			source: { sdk: "@waniwani/sdk", version: "0.1.0" },
+			events: [
+				{
+					id: crypto.randomUUID(),
+					type: "mcp.event",
+					name: "suggestion.clicked",
+					source,
+					timestamp: now,
+					// `sessionId` is dropped by JSON.stringify while undefined, so a
+					// click that precedes the first exchange carries visitor id only.
+					correlation: { visitorId: getOrCreateVisitorId(), sessionId },
+					properties: {
+						promptId,
+						kind,
+						// Org-authored copy, and DLP-redacted server-side regardless.
+						text,
+						index,
+						channelId,
+						mode,
+						// Raw href, same as `page.viewed` — normalized at query time.
+						url: window.location.href,
+					},
+					metadata: {},
+				},
+			],
+		});
+
+		await fetch(eventsEndpoint(api), {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+			},
+			body,
+			// The click submits a message and may navigate; keep the send alive.
+			keepalive: true,
+		});
+	} catch {
+		// Never surface a tracking failure. A dropped click is a dropped click.
+	}
+}


### PR DESCRIPTION
Closes WAN-714

## Summary

Click tracking for page-aware starter prompts — the M1 line item "Track which suggestions get clicked via `mcp_events_v2`", and the consumer the prompt ids were plumbed for. **Stacked on #106** (base: `andrew/wan-702-page-aware-starter-prompts`); retargets to `main` after #106 merges. sdk-only — zero app changes: the ingest endpoint, `wwp_` auth, and DLP property redaction already accept this event.

Every starter-prompt click in the embeds now fires a `suggestion.clicked` event to the same canonical V2 batch ingest `page.viewed` uses (`POST /api/mcp/events/v2/batch`, fire-and-forget, `keepalive`). Properties: `promptId` (stored id of the authored prompt, `null` for fixed-list fallbacks), `kind` (`page` | `fallback` | `followup` — the last is the ready slot for M2 generated follow-ups), `text`, `index`, `channelId`, `mode`, raw `url`. Correlation: `visitorId` always, plus `sessionId` once a conversation exists (a starter click usually predates it).

Mechanics: `usePageSuggestions` now returns `{id, text}` objects (the ids were parked in its fetch state for exactly this); each embed host derives the rendered texts through a memo — the `initial` array-identity contract `useSuggestions` depends on still holds — and subscribes to the existing `suggestion.clicked` widget event, resolving the click via the pure `resolveClickAttribution`. The public host-page widget event is unchanged (`{text, index}`). Two identical texts on one page attribute to the first match — pathological authoring, accepted.

## How to see it working

Same setup as #106 (WaniWani-AI/app#924 running locally with its seeded prompts):

1. `bun run build` here, serve a static page with the embed snippet from #106's body.
2. Click a pill on a seeded page → devtools Network shows `POST {origin}/api/mcp/events/v2/batch` with `name: "suggestion.clicked"`, the seeded prompt's `promptId`, and `kind: "page"`.
3. Click a pill on an unseeded page (fixed-list fallback) → `promptId: null`, `kind: "fallback"`.
4. Send a message first, then click a pill → the event now carries `correlation.sessionId`; before the first exchange it doesn't.

## Review focus

- `suggestion-click.ts` mirrors `page-view.ts`'s envelope field-for-field, minus the once-per-page guard (every click counts; clicks are naturally rate-limited — clicking submits the message and clears the pills).
- The hook's return-type change and the memoized text derivation in both hosts (stable array identity).
- Gates run locally since the base isn't `main`: typecheck ✓, lint ✓, `bun test` 463 pass / 2 fail — the two `useChatEngine – thread history` failures pre-exist on the base branch (verified with these changes stashed) and on `main`, as already noted in #106's body. The two touched test files: 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**Update (epic gap-closing):** adds `suggestion.shown` — one event per rendered pill set (dock CTAs on reveal, panel pill row per set incl. follow-ups), carrying per-prompt ids/texts. With `suggestion.clicked` this makes per-prompt CTR queryable: clicks(id) ÷ shown sets containing the id. Also: pill contrast fix (bg-accent).
