### PR TITLE
feat(chat): render flow-driven suggestion pills

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -80,7 +80,7 @@ The dashboard owns the agent's display and behavior config. Use `overrides` only
 | `welcome` | `WelcomeConfig` | Rich welcome screen (icon, title, suggestion cards). Takes precedence over `welcomeMessage` |
 | `placeholder` | `string` | Input placeholder |
 | `suggestions` | `string[]` | Starter suggestion chips, shown before the first message |
-| `dynamicSuggestions` | `boolean` | Per-turn pills a flow drives via `interrupt({ suggestions })`. Enabled by default (set `false` to hide them while keeping `suggestions`, the starter prompts). See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
+| `dynamicSuggestions` | `boolean` | Opt-in for the per-turn pills a flow drives via `interrupt({ suggestions })`. Disabled by default — set `true` to render them; `suggestions` (the starter prompts) show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
 | `enableThreadHistory` | `boolean` | Persist conversations across reloads in IndexedDB |
 | `showToolCalls` | `boolean \| "titles-only"` | How the agent's tool-call activity renders, grouped into one collapsible "chain of thought". `true` (default) — each step expandable to its request/response JSON. `"titles-only"` — step labels only, no JSON. `false` — hides the chain entirely (including the reasoning trace); only the generic "On it…" indicator shows while the agent works. MCP App widgets always render regardless. |
 | `allowAttachments` | `boolean` | Enable file attachments in the input |
@@ -101,19 +101,24 @@ The pill row above the input has two sources:
   step with one open question. These refresh after each reply and describe the
   question the agent just asked.
 
-Flow-driven pills need no configuration: writing `suggestions` in the flow is the
-opt-in. They recompute every turn, so a reply that carries none clears the row.
+Flow-driven pills are opt-in: the flow declaring `suggestions` is not enough on
+its own — the host chat surface must enable them too. Once enabled, they
+recompute every turn, so a reply that carries none clears the row. To enable
+them:
 
-To turn flow-driven pills off while keeping the starter prompts:
+- `<WaniwaniChat>`: `overrides={{ dynamicSuggestions: true }}`
+- `<script>` embed: `data-dynamic-suggestions="true"`
+- `<ChatEmbed>` (self-hosted primitive only): `suggestions={{ dynamic: true }}`
+  (optionally alongside `initial: [...]` starter prompts), or
+  `suggestions={false}` to hide the pill row entirely
 
-- `<WaniwaniChat>`: `overrides={{ dynamicSuggestions: false }}`
-- `<script>` embed: `data-dynamic-suggestions="false"`
-- `<ChatEmbed>` (self-hosted primitive only): `suggestions={{ initial: [...], dynamic: false }}`,
-  or `suggestions={false}` to hide the pill row entirely
+Without the opt-in, the flow still sends its suggestions to the assistant as
+candidate answers — only the clickable pill row is withheld.
 
 `<WaniwaniChat>` and the `<script>` embed have no equivalent of `ChatEmbed`'s
-`suggestions={false}`: there is always a pill row once starter prompts or a
-flow supply pills, and `dynamicSuggestions: false` only stops the flow from adding to it.
+`suggestions={false}`: there is always a pill row once starter prompts (or an
+opted-in flow) supply pills, and `dynamicSuggestions` only controls the
+flow-driven ones.
 
 Overrides win over dashboard config when both are set.
 
@@ -273,7 +278,7 @@ The chat fits within whatever bound you set and scrolls internally — no need t
 | `data-welcome-message` | No | Greeting shown before first message |
 | `data-placeholder` | No | Input field placeholder text |
 | `data-suggestions` | No | Comma-separated suggestion chips |
-| `data-dynamic-suggestions` | No | `"true"` (default)/`"false"`: per-turn pills a flow drives via `interrupt({ suggestions })`. `"false"` keeps `data-suggestions` (starter prompts) but stops the flow from adding to the row. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
+| `data-dynamic-suggestions` | No | `"false"` (default)/`"true"`: opt-in for the per-turn pills a flow drives via `interrupt({ suggestions })`. Set `"true"` to render them; `data-suggestions` (starter prompts) show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
 | `data-enable-thread-history` | No | `"true"`/`"false"` — persist threads in IndexedDB, show thread menu in header |
 | `data-show-tool-calls` | No | Tool-call activity rendering (grouped into one collapsible chain). `"true"` (default) — steps expandable to request/response JSON. `"titles-only"` — step labels only. `"false"` — hides the chain and the reasoning trace; only the "On it…" indicator shows |
 | `data-css` | No | URL to custom stylesheet (injected into Shadow DOM) |

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -80,7 +80,7 @@ The dashboard owns the agent's display and behavior config. Use `overrides` only
 | `welcome` | `WelcomeConfig` | Rich welcome screen (icon, title, suggestion cards). Takes precedence over `welcomeMessage` |
 | `placeholder` | `string` | Input placeholder |
 | `suggestions` | `string[]` | Starter suggestion chips, shown before the first message |
-| `dynamicSuggestions` | `boolean` | Opt-in for the per-turn pills a flow drives via `interrupt({ suggestions })`. Disabled by default — set `true` to render them; `suggestions` (the starter prompts) show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
+| `flowSuggestions` | `boolean` | Opt-in for the per-turn pills a flow drives via `interrupt({ suggestions })`. Disabled by default — set `true` to render them; `suggestions` (the starter prompts) show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
 | `enableThreadHistory` | `boolean` | Persist conversations across reloads in IndexedDB |
 | `showToolCalls` | `boolean \| "titles-only"` | How the agent's tool-call activity renders, grouped into one collapsible "chain of thought". `true` (default) — each step expandable to its request/response JSON. `"titles-only"` — step labels only, no JSON. `false` — hides the chain entirely (including the reasoning trace); only the generic "On it…" indicator shows while the agent works. MCP App widgets always render regardless. |
 | `allowAttachments` | `boolean` | Enable file attachments in the input |
@@ -106,8 +106,8 @@ its own — the host chat surface must enable them too. Once enabled, they
 recompute every turn, so a reply that carries none clears the row. To enable
 them:
 
-- `<WaniwaniChat>`: `overrides={{ dynamicSuggestions: true }}`
-- `<script>` embed: `data-dynamic-suggestions="true"`
+- `<WaniwaniChat>`: `overrides={{ flowSuggestions: true }}`
+- `<script>` embed: `data-flow-suggestions="true"`
 - `<ChatEmbed>` (self-hosted primitive only): `suggestions={{ dynamic: true }}`
   (optionally alongside `initial: [...]` starter prompts), or
   `suggestions={false}` to hide the pill row entirely
@@ -117,7 +117,7 @@ candidate answers — only the clickable pill row is withheld.
 
 `<WaniwaniChat>` and the `<script>` embed have no equivalent of `ChatEmbed`'s
 `suggestions={false}`: there is always a pill row once starter prompts (or an
-opted-in flow) supply pills, and `dynamicSuggestions` only controls the
+opted-in flow) supply pills, and `flowSuggestions` only controls the
 flow-driven ones.
 
 Overrides win over dashboard config when both are set.
@@ -278,7 +278,7 @@ The chat fits within whatever bound you set and scrolls internally — no need t
 | `data-welcome-message` | No | Greeting shown before first message |
 | `data-placeholder` | No | Input field placeholder text |
 | `data-suggestions` | No | Comma-separated suggestion chips |
-| `data-dynamic-suggestions` | No | `"false"` (default)/`"true"`: opt-in for the per-turn pills a flow drives via `interrupt({ suggestions })`. Set `"true"` to render them; `data-suggestions` (starter prompts) show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
+| `data-flow-suggestions` | No | `"false"` (default)/`"true"`: opt-in for the per-turn pills a flow drives via `interrupt({ suggestions })`. Set `"true"` to render them; `data-suggestions` (starter prompts) show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
 | `data-enable-thread-history` | No | `"true"`/`"false"` — persist threads in IndexedDB, show thread menu in header |
 | `data-show-tool-calls` | No | Tool-call activity rendering (grouped into one collapsible chain). `"true"` (default) — steps expandable to request/response JSON. `"titles-only"` — step labels only. `"false"` — hides the chain and the reasoning trace; only the "On it…" indicator shows |
 | `data-css` | No | URL to custom stylesheet (injected into Shadow DOM) |

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -80,6 +80,7 @@ The dashboard owns the agent's display and behavior config. Use `overrides` only
 | `welcome` | `WelcomeConfig` | Rich welcome screen (icon, title, suggestion cards). Takes precedence over `welcomeMessage` |
 | `placeholder` | `string` | Input placeholder |
 | `suggestions` | `string[]` | Starter suggestion chips, shown before the first message |
+| `dynamicSuggestions` | `boolean` | Per-turn pills a flow drives via `interrupt({ suggestions })`. Enabled by default (set `false` to hide them while keeping `suggestions`, the starter prompts). See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
 | `enableThreadHistory` | `boolean` | Persist conversations across reloads in IndexedDB |
 | `showToolCalls` | `boolean \| "titles-only"` | How the agent's tool-call activity renders, grouped into one collapsible "chain of thought". `true` (default) — each step expandable to its request/response JSON. `"titles-only"` — step labels only, no JSON. `false` — hides the chain entirely (including the reasoning trace); only the generic "On it…" indicator shows while the agent works. MCP App widgets always render regardless. |
 | `allowAttachments` | `boolean` | Enable file attachments in the input |
@@ -103,8 +104,16 @@ The pill row above the input has two sources:
 Flow-driven pills need no configuration: writing `suggestions` in the flow is the
 opt-in. They recompute every turn, so a reply that carries none clears the row.
 
-To turn them off, pass `suggestions={{ initial: [...], dynamic: false }}` to keep
-starter prompts only, or `suggestions={false}` to hide the pill row entirely.
+To turn flow-driven pills off while keeping the starter prompts:
+
+- `<WaniwaniChat>`: `overrides={{ dynamicSuggestions: false }}`
+- `<script>` embed: `data-dynamic-suggestions="false"`
+- `<ChatEmbed>` (self-hosted primitive only): `suggestions={{ initial: [...], dynamic: false }}`,
+  or `suggestions={false}` to hide the pill row entirely
+
+`<WaniwaniChat>` and the `<script>` embed have no equivalent of `ChatEmbed`'s
+`suggestions={false}`: there is always a pill row once starter prompts or a
+flow supply pills, and `dynamicSuggestions: false` only stops the flow from adding to it.
 
 Overrides win over dashboard config when both are set.
 
@@ -264,6 +273,7 @@ The chat fits within whatever bound you set and scrolls internally — no need t
 | `data-welcome-message` | No | Greeting shown before first message |
 | `data-placeholder` | No | Input field placeholder text |
 | `data-suggestions` | No | Comma-separated suggestion chips |
+| `data-dynamic-suggestions` | No | `"true"` (default)/`"false"`: per-turn pills a flow drives via `interrupt({ suggestions })`. `"false"` keeps `data-suggestions` (starter prompts) but stops the flow from adding to the row. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
 | `data-enable-thread-history` | No | `"true"`/`"false"` — persist threads in IndexedDB, show thread menu in header |
 | `data-show-tool-calls` | No | Tool-call activity rendering (grouped into one collapsible chain). `"true"` (default) — steps expandable to request/response JSON. `"titles-only"` — step labels only. `"false"` — hides the chain and the reasoning trace; only the "On it…" indicator shows |
 | `data-css` | No | URL to custom stylesheet (injected into Shadow DOM) |

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -80,7 +80,7 @@ The dashboard owns the agent's display and behavior config. Use `overrides` only
 | `welcome` | `WelcomeConfig` | Rich welcome screen (icon, title, suggestion cards). Takes precedence over `welcomeMessage` |
 | `placeholder` | `string` | Input placeholder |
 | `suggestions` | `string[]` | Starter suggestion chips, shown before the first message |
-| `flowSuggestions` | `boolean` | Opt-in for the per-turn pills a flow drives via `interrupt({ suggestions })`. Disabled by default — set `true` to render them; `suggestions` (the starter prompts) show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
+| `suggestionOrigins` | `SuggestionOrigin[]` | Which providers may fill the per-turn pill row (`"channel"`, `"page"`, `"flow"`, `"followup"`). Defaults to `["channel", "page", "followup"]` — include `"flow"` to render the pills a flow drives via `interrupt({ suggestions })`. `suggestions` (the starter prompts) are unaffected and show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
 | `enableThreadHistory` | `boolean` | Persist conversations across reloads in IndexedDB |
 | `showToolCalls` | `boolean \| "titles-only"` | How the agent's tool-call activity renders, grouped into one collapsible "chain of thought". `true` (default) — each step expandable to its request/response JSON. `"titles-only"` — step labels only, no JSON. `false` — hides the chain entirely (including the reasoning trace); only the generic "On it…" indicator shows while the agent works. MCP App widgets always render regardless. |
 | `allowAttachments` | `boolean` | Enable file attachments in the input |
@@ -93,32 +93,38 @@ The dashboard owns the agent's display and behavior config. Use `overrides` only
 
 #### Where the suggestion pills come from
 
-The pill row above the input has two sources:
+The pill row above the input can be filled by up to four origins, each gated
+independently by `suggestionOrigins`:
 
-- **Starter prompts**: the `suggestions` above, configured per channel in the
+- **`"channel"`**: the `suggestions` above, configured per channel in the
   dashboard. Shown only until the visitor's first message.
-- **Flow-driven pills**: a connected MCP's flow declaring `suggestions` on a
-  step with one open question. These refresh after each reply and describe the
-  question the agent just asked.
+- **`"page"`**: per-URL starter prompts configured in the dashboard for the
+  current page.
+- **`"flow"`**: a connected MCP's flow declaring `suggestions` on a step with
+  one open question. These refresh after each reply and describe the question
+  the agent just asked.
+- **`"followup"`**: pills generated from the conversation and streamed as a
+  `data-suggestions` part (self-hosted backends only).
 
-Flow-driven pills are opt-in: the flow declaring `suggestions` is not enough on
-its own — the host chat surface must enable them too. Once enabled, they
-recompute every turn, so a reply that carries none clears the row. To enable
-them:
+`suggestionOrigins` defaults to `["channel", "page", "followup"]` when unset:
+starter prompts and generated follow-ups render, and flow-driven pills stay
+opt-in. Once `"flow"` is enabled, pills recompute every turn, so a reply that
+carries none clears the row. To opt in:
 
-- `<WaniwaniChat>`: `overrides={{ flowSuggestions: true }}`
-- `<script>` embed: `data-flow-suggestions="true"`
-- `<ChatEmbed>` (self-hosted primitive only): `suggestions={{ dynamic: true }}`
+- `<WaniwaniChat>`: `overrides={{ suggestionOrigins: ["channel", "page", "flow", "followup"] }}`
+  (or any subset including `"flow"`)
+- `<script>` embed: `data-suggestion-origins="channel,page,flow,followup"`
+- `<ChatEmbed>` (self-hosted primitive only): `suggestions={{ origins: ["flow"] }}`
   (optionally alongside `initial: [...]` starter prompts), or
   `suggestions={false}` to hide the pill row entirely
 
-Without the opt-in, the flow still sends its suggestions to the assistant as
-candidate answers — only the clickable pill row is withheld.
+Without `"flow"` enabled, the flow still sends its suggestions to the
+assistant as candidate answers — only the clickable pill row is withheld.
 
 `<WaniwaniChat>` and the `<script>` embed have no equivalent of `ChatEmbed`'s
-`suggestions={false}`: there is always a pill row once starter prompts (or an
-opted-in flow) supply pills, and `flowSuggestions` only controls the
-flow-driven ones.
+`suggestions={false}`: there is always a pill row once at least one enabled
+origin supplies pills, and `suggestionOrigins` only controls which origins are
+allowed to fill it.
 
 Overrides win over dashboard config when both are set.
 
@@ -278,7 +284,7 @@ The chat fits within whatever bound you set and scrolls internally — no need t
 | `data-welcome-message` | No | Greeting shown before first message |
 | `data-placeholder` | No | Input field placeholder text |
 | `data-suggestions` | No | Comma-separated suggestion chips |
-| `data-flow-suggestions` | No | `"false"` (default)/`"true"`: opt-in for the per-turn pills a flow drives via `interrupt({ suggestions })`. Set `"true"` to render them; `data-suggestions` (starter prompts) show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
+| `data-suggestion-origins` | No | Comma-separated list of `channel`, `page`, `flow`, `followup` — which providers may fill the per-turn pill row. Defaults to `channel,page,followup` when unset (`flow` stays opt-in); an empty attribute means no origins render. Unknown values are dropped. `data-suggestions` (starter prompts) show either way. See [Where the suggestion pills come from](#where-the-suggestion-pills-come-from) |
 | `data-enable-thread-history` | No | `"true"`/`"false"` — persist threads in IndexedDB, show thread menu in header |
 | `data-show-tool-calls` | No | Tool-call activity rendering (grouped into one collapsible chain). `"true"` (default) — steps expandable to request/response JSON. `"titles-only"` — step labels only. `"false"` — hides the chain and the reasoning trace; only the "On it…" indicator shows |
 | `data-css` | No | URL to custom stylesheet (injected into Shadow DOM) |
@@ -794,7 +800,7 @@ Both hosted surfaces accept an `onEvent` callback — `WaniWani.chat.init({ onEv
 | `session.started` | Server assigned the session id on the first exchange (restored threads don't re-fire) | `{ sessionId }` |
 | `thread.changed` | Thread created or switched (requires thread history; the top-level `sessionId` is the target thread's session, `undefined` for a fresh thread) | `{ threadId }` |
 | `chat.error` | Chat request failed | `{ message }` (truncated to 200 chars) |
-| `suggestion.clicked` | Suggestion pill or welcome card clicked (dock pills, in-chat pills, welcome cards) | `{ text, index, source }` (`index` is `-1` when the origin is unknown; `source` is `"flow"` when a connected MCP's flow drove the pills, `"initial"` for operator-configured starter prompts) |
+| `suggestion.clicked` | Suggestion pill or welcome card clicked (dock pills, in-chat pills, welcome cards) | `{ text, index, origin }` (`index` is `-1` when the position is unknown; `origin` is one of `"channel"`, `"page"`, `"flow"`, `"followup"` — see [Where the suggestion pills come from](#where-the-suggestion-pills-come-from)) |
 | `link.clicked` | Anchor clicked inside the conversation | `{ url }` (absolute URL) |
 
 Do not assume `chat.opened` precedes the first `message.sent`: a send from the docked bar opens the panel and sends in one action, and the open transition is reported after the send.
@@ -831,7 +837,7 @@ Notes:
 
 - **Programmatic-only on the script embed.** A function cannot be expressed as a `data-*` attribute, so `onEvent` has no declarative equivalent — pass it to `WaniWani.chat.init()`.
 - **Exceptions are swallowed.** An error thrown by your callback is caught and logged as a console warning; it never breaks the widget.
-- **Privacy.** Message content never passes through this channel — the host learns *that* a message was exchanged, never what was said. Suggestion text is always author-controlled configuration (operator-authored starter prompts, or developer-authored flow suggestions), never visitor-typed content, which is why `suggestion.clicked` can safely carry it.
+- **Privacy.** Message content never passes through this channel — the host learns *that* a message was exchanged, never what was said. Suggestion text is always author-controlled configuration or agent-generated (operator-authored starter prompts, developer-authored flow suggestions, or conversation-driven follow-ups), never visitor-typed content, which is why `suggestion.clicked` can safely carry it.
 - **Separate from the `track()` taxonomy.** Some `onEvent` names (`session.started`, `link.clicked`) also exist as event names in the hosted `track()` funnel taxonomy ([events.md](./events.md)) — same concepts, but a separate client-side channel with different payload shapes. `onEvent` events are not `client.track()` events, do not feed the platform funnel dashboard, and should not be forwarded into `client.track()` as-is even where names coincide.
 - **`ChatEmbed` does not expose `onEvent`** — like `track`/`identify`, it is a hosted-surface feature.
 

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -79,7 +79,7 @@ The dashboard owns the agent's display and behavior config. Use `overrides` only
 | `welcomeMessage` | `string` | Greeting shown before the first user message |
 | `welcome` | `WelcomeConfig` | Rich welcome screen (icon, title, suggestion cards). Takes precedence over `welcomeMessage` |
 | `placeholder` | `string` | Input placeholder |
-| `suggestions` | `string[]` | Initial suggestion chips |
+| `suggestions` | `string[]` | Starter suggestion chips, shown before the first message |
 | `enableThreadHistory` | `boolean` | Persist conversations across reloads in IndexedDB |
 | `showToolCalls` | `boolean \| "titles-only"` | How the agent's tool-call activity renders, grouped into one collapsible "chain of thought". `true` (default) — each step expandable to its request/response JSON. `"titles-only"` — step labels only, no JSON. `false` — hides the chain entirely (including the reasoning trace); only the generic "On it…" indicator shows while the agent works. MCP App widgets always render regardless. |
 | `allowAttachments` | `boolean` | Enable file attachments in the input |
@@ -89,6 +89,22 @@ The dashboard owns the agent's display and behavior config. Use `overrides` only
 | `locale` | `"en" \| "fr" \| "es"` | UI language for built-in labels. Auto-detected from `<html lang>` / `navigator.language` when omitted; falls back to English |
 | `messages` | `MessageOverrides` | Per-key overrides on top of the resolved locale catalog — see [Languages](#languages) |
 | `disablePageView` | `boolean` | Opt out of the top-of-funnel `page.viewed` event fired once on mount. Defaults to `false`. Set `true` on surfaces where a page view is noise — an already-authenticated app shell, an internal tool, a preview — so it doesn't pollute the funnel. See [Tracked events](#event-tracking) |
+
+#### Where the suggestion pills come from
+
+The pill row above the input has two sources:
+
+- **Starter prompts**: the `suggestions` above, configured per channel in the
+  dashboard. Shown only until the visitor's first message.
+- **Flow-driven pills**: a connected MCP's flow declaring `suggestions` on a
+  step with one open question. These refresh after each reply and describe the
+  question the agent just asked.
+
+Flow-driven pills need no configuration: writing `suggestions` in the flow is the
+opt-in. They recompute every turn, so a reply that carries none clears the row.
+
+To turn them off, pass `suggestions={{ initial: [...], dynamic: false }}` to keep
+starter prompts only, or `suggestions={false}` to hide the pill row entirely.
 
 Overrides win over dashboard config when both are set.
 
@@ -763,7 +779,7 @@ Both hosted surfaces accept an `onEvent` callback — `WaniWani.chat.init({ onEv
 | `session.started` | Server assigned the session id on the first exchange (restored threads don't re-fire) | `{ sessionId }` |
 | `thread.changed` | Thread created or switched (requires thread history; the top-level `sessionId` is the target thread's session, `undefined` for a fresh thread) | `{ threadId }` |
 | `chat.error` | Chat request failed | `{ message }` (truncated to 200 chars) |
-| `suggestion.clicked` | Suggestion pill or welcome card clicked (dock pills, in-chat pills, welcome cards) | `{ text, index }` (`index` is `-1` when the origin is unknown) |
+| `suggestion.clicked` | Suggestion pill or welcome card clicked (dock pills, in-chat pills, welcome cards) | `{ text, index, source }` (`index` is `-1` when the origin is unknown; `source` is `"flow"` when a connected MCP's flow drove the pills, `"initial"` for operator-configured starter prompts) |
 | `link.clicked` | Anchor clicked inside the conversation | `{ url }` (absolute URL) |
 
 Do not assume `chat.opened` precedes the first `message.sent`: a send from the docked bar opens the panel and sends in one action, and the open transition is reported after the send.
@@ -800,7 +816,7 @@ Notes:
 
 - **Programmatic-only on the script embed.** A function cannot be expressed as a `data-*` attribute, so `onEvent` has no declarative equivalent — pass it to `WaniWani.chat.init()`.
 - **Exceptions are swallowed.** An error thrown by your callback is caught and logged as a console warning; it never breaks the widget.
-- **Privacy.** Message content never passes through this channel — the host learns *that* a message was exchanged, never what was said. Suggestion text is operator-authored config, so `suggestion.clicked` may carry it.
+- **Privacy.** Message content never passes through this channel — the host learns *that* a message was exchanged, never what was said. Suggestion text is always author-controlled configuration (operator-authored starter prompts, or developer-authored flow suggestions), never visitor-typed content, which is why `suggestion.clicked` can safely carry it.
 - **Separate from the `track()` taxonomy.** Some `onEvent` names (`session.started`, `link.clicked`) also exist as event names in the hosted `track()` funnel taxonomy ([events.md](./events.md)) — same concepts, but a separate client-side channel with different payload shapes. `onEvent` events are not `client.track()` events, do not feed the platform funnel dashboard, and should not be forwarded into `client.track()` as-is even where names coincide.
 - **`ChatEmbed` does not expose `onEvent`** — like `track`/`identify`, it is a hosted-surface feature.
 

--- a/skills/waniwani-sdk/references/flows.md
+++ b/skills/waniwani-sdk/references/flows.md
@@ -171,10 +171,13 @@ One field = single question. Multiple fields = multiple questions asked together
 Suggestions serve two audiences at once. The assistant receives them as candidate
 answers on every host, regardless of any configuration. In the Waniwani chat
 widget they can also render as clickable pills above the input — clicking one
-sends it as the visitor's answer — but only when the host chat surface opts in:
-`overrides={{ flowSuggestions: true }}` on `<WaniwaniChat>`,
-`data-flow-suggestions="true"` on the `<script>` embed, or
-`suggestions={{ dynamic: true }}` on `<ChatEmbed>`.
+sends it as the visitor's answer — but only when the host chat surface's
+suggestion origins include `"flow"` (one of four origins: `"channel"`,
+`"page"`, `"flow"`, `"followup"`; `"flow"` stays opt-in by default):
+`overrides={{ suggestionOrigins: ["channel", "page", "flow", "followup"] }}`
+on `<WaniwaniChat>`, `data-suggestion-origins="channel,page,flow,followup"` on
+the `<script>` embed, or `suggestions={{ origins: ["flow"] }}` on
+`<ChatEmbed>`.
 
 Pills appear only when the step has **exactly one question still open**. That is
 evaluated at runtime, not from how you wrote the call: a four-question interrupt

--- a/skills/waniwani-sdk/references/flows.md
+++ b/skills/waniwani-sdk/references/flows.md
@@ -169,8 +169,12 @@ One field = single question. Multiple fields = multiple questions asked together
 ```
 
 Suggestions serve two audiences at once. The assistant receives them as candidate
-answers on every host. In the Waniwani chat widget they also render as clickable
-pills above the input; clicking one sends it as the visitor's answer.
+answers on every host, regardless of any configuration. In the Waniwani chat
+widget they can also render as clickable pills above the input — clicking one
+sends it as the visitor's answer — but only when the host chat surface opts in:
+`overrides={{ dynamicSuggestions: true }}` on `<WaniwaniChat>`,
+`data-dynamic-suggestions="true"` on the `<script>` embed, or
+`suggestions={{ dynamic: true }}` on `<ChatEmbed>`.
 
 Pills appear only when the step has **exactly one question still open**. That is
 evaluated at runtime, not from how you wrote the call: a four-question interrupt

--- a/skills/waniwani-sdk/references/flows.md
+++ b/skills/waniwani-sdk/references/flows.md
@@ -172,8 +172,8 @@ Suggestions serve two audiences at once. The assistant receives them as candidat
 answers on every host, regardless of any configuration. In the Waniwani chat
 widget they can also render as clickable pills above the input — clicking one
 sends it as the visitor's answer — but only when the host chat surface opts in:
-`overrides={{ dynamicSuggestions: true }}` on `<WaniwaniChat>`,
-`data-dynamic-suggestions="true"` on the `<script>` embed, or
+`overrides={{ flowSuggestions: true }}` on `<WaniwaniChat>`,
+`data-flow-suggestions="true"` on the `<script>` embed, or
 `suggestions={{ dynamic: true }}` on `<ChatEmbed>`.
 
 Pills appear only when the step has **exactly one question still open**. That is

--- a/skills/waniwani-sdk/references/flows.md
+++ b/skills/waniwani-sdk/references/flows.md
@@ -168,6 +168,17 @@ One field = single question. Multiple fields = multiple questions asked together
 )
 ```
 
+Suggestions serve two audiences at once. The assistant receives them as candidate
+answers on every host. In the Waniwani chat widget they also render as clickable
+pills above the input; clicking one sends it as the visitor's answer.
+
+Pills appear only when the step has **exactly one question still open**. That is
+evaluated at runtime, not from how you wrote the call: a four-question interrupt
+where three fields are already filled has one open question, so it gets pills. A
+step with two or more open questions gets none, because no single pill could
+answer them all. Other MCP hosts (ChatGPT, Claude) are unaffected either way:
+they have no pill row, and what they receive is unchanged.
+
 ### Multiple Questions
 
 ```ts

--- a/skills/waniwani-sdk/references/upgrading.md
+++ b/skills/waniwani-sdk/references/upgrading.md
@@ -31,36 +31,6 @@ One behavioral note (not a break): `messageBorderRadius` / `--ww-msg-radius` is 
 
 This list mirrors the changelog so you can apply migrations without a network fetch. Always cross-check against the live changelog for anything newer than this file.
 
-### 0.19.0: `suggestion.clicked` requires a `properties.source` field
-
-`suggestion.clicked` (part of `WidgetEventDetail` / `WidgetEvent` from `@waniwani/sdk/chat`) gained a required `properties.source: "flow" | "initial"` field. Consumers who only *read* the event through `onEvent` (the overwhelmingly common case) need no changes: it is a new, always-populated field. Only code that *constructs* a `suggestion.clicked` event literal (test fixtures, a custom adapter) needs updating.
-
-Auto-fix, per hand-constructed event literal:
-
-1. Add `source: "initial"` (or `"flow"`, if the fixture stands in for a flow-driven pill) to the `properties` of every `{ name: "suggestion.clicked", ... }` literal.
-
-```ts
-// Before
-const event: WidgetEvent = {
-  mode: "inline",
-  timestamp: Date.now(),
-  name: "suggestion.clicked",
-  properties: { text: "Book a demo", index: 0 },
-};
-
-// After
-const event: WidgetEvent = {
-  mode: "inline",
-  timestamp: Date.now(),
-  name: "suggestion.clicked",
-  properties: { text: "Book a demo", index: 0, source: "initial" },
-};
-```
-
-No `@deprecated` shim: `source` stays required rather than optional, since a guaranteed field is better DX for readers (the primary audience) than an optional one every reader would have to narrow.
-
-After applying, run `bun run typecheck && bun test`. `tsc` finds every construction site: any literal missing `properties.source` fails to typecheck against `WidgetEventDetail`.
-
 ### 0.18.0: quote and purchase events removed from the taxonomy
 
 The event names `quote.requested`, `quote.succeeded`, `quote.failed`, and `purchase.completed` are removed from `EVENT_TYPES` and the `TrackEvent` union. The typed revenue taxonomy covers these funnel stages. Removed with them: the `QuoteSucceededProperties` and `PurchaseCompletedProperties` type exports, and the legacy input fields `quoteAmount`, `quoteCurrency`, `purchaseAmount`, `purchaseCurrency` on `LegacyTrackEvent`. `link.clicked` (and `LinkClickedProperties`, legacy `linkUrl`) stays.

--- a/skills/waniwani-sdk/references/upgrading.md
+++ b/skills/waniwani-sdk/references/upgrading.md
@@ -31,6 +31,36 @@ One behavioral note (not a break): `messageBorderRadius` / `--ww-msg-radius` is 
 
 This list mirrors the changelog so you can apply migrations without a network fetch. Always cross-check against the live changelog for anything newer than this file.
 
+### 0.19.0: `suggestion.clicked` requires a `properties.source` field
+
+`suggestion.clicked` (part of `WidgetEventDetail` / `WidgetEvent` from `@waniwani/sdk/chat`) gained a required `properties.source: "flow" | "initial"` field. Consumers who only *read* the event through `onEvent` (the overwhelmingly common case) need no changes: it is a new, always-populated field. Only code that *constructs* a `suggestion.clicked` event literal (test fixtures, a custom adapter) needs updating.
+
+Auto-fix, per hand-constructed event literal:
+
+1. Add `source: "initial"` (or `"flow"`, if the fixture stands in for a flow-driven pill) to the `properties` of every `{ name: "suggestion.clicked", ... }` literal.
+
+```ts
+// Before
+const event: WidgetEvent = {
+  mode: "inline",
+  timestamp: Date.now(),
+  name: "suggestion.clicked",
+  properties: { text: "Book a demo", index: 0 },
+};
+
+// After
+const event: WidgetEvent = {
+  mode: "inline",
+  timestamp: Date.now(),
+  name: "suggestion.clicked",
+  properties: { text: "Book a demo", index: 0, source: "initial" },
+};
+```
+
+No `@deprecated` shim: `source` stays required rather than optional, since a guaranteed field is better DX for readers (the primary audience) than an optional one every reader would have to narrow.
+
+After applying, run `bun run typecheck && bun test`. `tsc` finds every construction site: any literal missing `properties.source` fails to typecheck against `WidgetEventDetail`.
+
 ### 0.18.0: quote and purchase events removed from the taxonomy
 
 The event names `quote.requested`, `quote.succeeded`, `quote.failed`, and `purchase.completed` are removed from `EVENT_TYPES` and the `TrackEvent` union. The typed revenue taxonomy covers these funnel stages. Removed with them: the `QuoteSucceededProperties` and `PurchaseCompletedProperties` type exports, and the legacy input fields `quoteAmount`, `quoteCurrency`, `purchaseAmount`, `purchaseCurrency` on `LegacyTrackEvent`. `link.clicked` (and `LinkClickedProperties`, legacy `linkUrl`) stays.

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -94,8 +94,10 @@ export interface SuggestionsConfig {
 	 */
 	initial?: string[];
 	/**
-	 * Enable AI-generated suggestions after each response.
-	 * Defaults to `true` when suggestions config is provided.
+	 * Per-turn suggestion pills driven by a flow's `interrupt({ suggestions })`.
+	 * Defaults to `true` — declaring `suggestions` in the flow is the opt-in,
+	 * so this stays enabled even when no suggestions config is passed at all.
+	 * Set `false` to keep only the `initial` starter prompts.
 	 */
 	dynamic?: boolean;
 }
@@ -184,8 +186,11 @@ export interface ChatBaseProps {
 	/** Callback fired when a response is received */
 	onResponseReceived?: () => void;
 	/**
-	 * Enable AI-generated suggestions after each response.
-	 * `true` enables with defaults (3 suggestions), object allows config, `false`/undefined disables.
+	 * Suggestion pill configuration. An object sets starter prompts
+	 * (`initial`) and the flow-driven per-turn pills (`dynamic`); `false`
+	 * hides the pill row entirely. Leaving it unset does NOT disable
+	 * flow-driven pills — they render whenever a connected flow declares
+	 * `suggestions` on a step with one open question.
 	 */
 	suggestions?: boolean | SuggestionsConfig;
 	/**

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -87,6 +87,9 @@ export interface WelcomeConfig {
 // Suggestions
 // ============================================================================
 
+/** Where a suggestion pill came from. */
+export type SuggestionOrigin = "channel" | "page" | "flow" | "followup";
+
 export interface SuggestionsConfig {
 	/**
 	 * Initial suggestions to show before the user sends their first message.
@@ -94,11 +97,13 @@ export interface SuggestionsConfig {
 	 */
 	initial?: string[];
 	/**
-	 * Per-turn suggestion behavior. `true` additionally enables flow-driven
-	 * pills (`interrupt({ suggestions })` rendered as clickable answers). Left
-	 * unset, an object config keeps streamed `data-suggestions` parts enabled
-	 * but flow-driven pills stay off. `false` disables all per-turn
-	 * suggestions.
+	 * Which providers may fill the pill row. Omitted, this defaults to
+	 * `["channel", "page", "followup"]`: starter prompts and generated
+	 * follow-ups render, flow-driven pills stay opt-in.
+	 */
+	origins?: SuggestionOrigin[];
+	/**
+	 * @deprecated Use `origins`. `true` maps to every origin, `false` to none.
 	 */
 	dynamic?: boolean;
 }
@@ -188,9 +193,10 @@ export interface ChatBaseProps {
 	onResponseReceived?: () => void;
 	/**
 	 * Suggestion pill configuration. Unset: no suggestions. An object sets
-	 * starter prompts (`initial`) and per-turn behavior (`dynamic`);
-	 * `dynamic: true` opts into flow-driven pills. `true` enables everything
-	 * with defaults; `false` hides the pill row entirely.
+	 * starter prompts (`initial`) and which origins may fill the per-turn
+	 * pill row (`origins`); `origins: ["flow"]` (or any list including
+	 * `"flow"`) opts into flow-driven pills. `true` enables every origin with
+	 * defaults; `false` hides the pill row entirely.
 	 */
 	suggestions?: boolean | SuggestionsConfig;
 	/**

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -94,10 +94,11 @@ export interface SuggestionsConfig {
 	 */
 	initial?: string[];
 	/**
-	 * Per-turn suggestion pills driven by a flow's `interrupt({ suggestions })`.
-	 * Defaults to `true` — declaring `suggestions` in the flow is the opt-in,
-	 * so this stays enabled even when no suggestions config is passed at all.
-	 * Set `false` to keep only the `initial` starter prompts.
+	 * Per-turn suggestion behavior. `true` additionally enables flow-driven
+	 * pills (`interrupt({ suggestions })` rendered as clickable answers). Left
+	 * unset, an object config keeps streamed `data-suggestions` parts enabled
+	 * but flow-driven pills stay off. `false` disables all per-turn
+	 * suggestions.
 	 */
 	dynamic?: boolean;
 }
@@ -186,11 +187,10 @@ export interface ChatBaseProps {
 	/** Callback fired when a response is received */
 	onResponseReceived?: () => void;
 	/**
-	 * Suggestion pill configuration. An object sets starter prompts
-	 * (`initial`) and the flow-driven per-turn pills (`dynamic`); `false`
-	 * hides the pill row entirely. Leaving it unset does NOT disable
-	 * flow-driven pills — they render whenever a connected flow declares
-	 * `suggestions` on a step with one open question.
+	 * Suggestion pill configuration. Unset: no suggestions. An object sets
+	 * starter prompts (`initial`) and per-turn behavior (`dynamic`);
+	 * `dynamic: true` opts into flow-driven pills. `true` enables everything
+	 * with defaults; `false` hides the pill row entirely.
 	 */
 	suggestions?: boolean | SuggestionsConfig;
 	/**

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -88,7 +88,20 @@ export interface WelcomeConfig {
 // ============================================================================
 
 /** Where a suggestion pill came from. */
-export type SuggestionOrigin = "channel" | "page" | "flow" | "followup";
+/**
+ * Every place a suggestion pill can come from. The single source of truth:
+ * {@link SuggestionOrigin} derives from it, and runtime validation reads it,
+ * so adding an origin is a one-line change.
+ */
+export const SUGGESTION_ORIGINS = [
+	"channel",
+	"page",
+	"flow",
+	"followup",
+] as const;
+
+/** Where a suggestion pill came from. */
+export type SuggestionOrigin = (typeof SUGGESTION_ORIGINS)[number];
 
 export interface SuggestionsConfig {
 	/**

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -478,7 +478,7 @@ describe("resolveConfig — assistantBubble precedence", () => {
 });
 
 describe("resolveConfig — dynamicSuggestions", () => {
-	test("undefined when unspecified — consumers default to enabled", () => {
+	test("undefined when unspecified — flow pills stay off unless opted in", () => {
 		const config = resolveConfig({ token: "tok" });
 		expect(config.dynamicSuggestions).toBeUndefined();
 	});
@@ -488,19 +488,19 @@ describe("resolveConfig — dynamicSuggestions", () => {
 		expect(config.dynamicSuggestions).toBe(false);
 	});
 
-	test("programmatic true keeps flow-driven pills enabled", () => {
+	test("programmatic true opts into flow-driven pills", () => {
 		const config = resolveConfig({ token: "tok", dynamicSuggestions: true });
 		expect(config.dynamicSuggestions).toBe(true);
 	});
 });
 
 describe("parseConfigFromScript — data-dynamic-suggestions", () => {
-	test("undefined when unspecified — pills stay enabled by default", async () => {
+	test("undefined when unspecified — no opt-in", async () => {
 		const cfg = await parseWithAttrs({ "data-token": "tok" });
 		expect(cfg.dynamicSuggestions).toBeUndefined();
 	});
 
-	test("'false' opts out of flow-driven pills", async () => {
+	test("'false' explicitly keeps flow-driven pills off", async () => {
 		const cfg = await parseWithAttrs({
 			"data-token": "tok",
 			"data-dynamic-suggestions": "false",

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -477,50 +477,74 @@ describe("resolveConfig — assistantBubble precedence", () => {
 	});
 });
 
-describe("resolveConfig — flowSuggestions", () => {
-	test("undefined when unspecified — flow pills stay off unless opted in", () => {
+describe("resolveConfig — suggestionOrigins", () => {
+	test("undefined when unspecified — defaults apply downstream", () => {
 		const config = resolveConfig({ token: "tok" });
-		expect(config.flowSuggestions).toBeUndefined();
+		expect(config.suggestionOrigins).toBeUndefined();
 	});
 
-	test("programmatic false disables flow-driven pills", () => {
-		const config = resolveConfig({ token: "tok", flowSuggestions: false });
-		expect(config.flowSuggestions).toBe(false);
+	test("programmatic empty array disables every origin", () => {
+		const config = resolveConfig({ token: "tok", suggestionOrigins: [] });
+		expect(config.suggestionOrigins).toEqual([]);
 	});
 
-	test("programmatic true opts into flow-driven pills", () => {
-		const config = resolveConfig({ token: "tok", flowSuggestions: true });
-		expect(config.flowSuggestions).toBe(true);
+	test("programmatic list opts into specific origins", () => {
+		const config = resolveConfig({
+			token: "tok",
+			suggestionOrigins: ["channel", "flow"],
+		});
+		expect(config.suggestionOrigins).toEqual(["channel", "flow"]);
 	});
 });
 
-describe("parseConfigFromScript — data-flow-suggestions", () => {
-	test("undefined when unspecified — no opt-in", async () => {
+describe("parseConfigFromScript — data-suggestion-origins", () => {
+	test("undefined when unspecified — no opt-in, defaults apply downstream", async () => {
 		const cfg = await parseWithAttrs({ "data-token": "tok" });
-		expect(cfg.flowSuggestions).toBeUndefined();
+		expect(cfg.suggestionOrigins).toBeUndefined();
 	});
 
-	test("'false' explicitly keeps flow-driven pills off", async () => {
+	test("comma-separated list parses to an array", async () => {
 		const cfg = await parseWithAttrs({
 			"data-token": "tok",
-			"data-flow-suggestions": "false",
+			"data-suggestion-origins": "channel,flow",
 		});
-		expect(cfg.flowSuggestions).toBe(false);
+		expect(cfg.suggestionOrigins).toEqual(["channel", "flow"]);
 	});
 
-	test("'true' parses as true", async () => {
+	test("whitespace around entries is trimmed", async () => {
 		const cfg = await parseWithAttrs({
 			"data-token": "tok",
-			"data-flow-suggestions": "true",
+			"data-suggestion-origins": " channel , flow ",
 		});
-		expect(cfg.flowSuggestions).toBe(true);
+		expect(cfg.suggestionOrigins).toEqual(["channel", "flow"]);
 	});
 
-	test("bare attribute (empty value) opts in like sibling boolean attrs", async () => {
+	test("unknown values are silently dropped", async () => {
 		const cfg = await parseWithAttrs({
 			"data-token": "tok",
-			"data-flow-suggestions": "",
+			"data-suggestion-origins": "channel,bogus,flow",
 		});
-		expect(cfg.flowSuggestions).toBe(true);
+		expect(cfg.suggestionOrigins).toEqual(["channel", "flow"]);
+	});
+
+	test("all four known origins parse", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-suggestion-origins": "channel,page,flow,followup",
+		});
+		expect(cfg.suggestionOrigins).toEqual([
+			"channel",
+			"page",
+			"flow",
+			"followup",
+		]);
+	});
+
+	test("attribute present but empty resolves to an empty array — a meaningful 'render nothing', not absent", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-suggestion-origins": "",
+		});
+		expect(cfg.suggestionOrigins).toEqual([]);
 	});
 });

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -477,50 +477,50 @@ describe("resolveConfig — assistantBubble precedence", () => {
 	});
 });
 
-describe("resolveConfig — dynamicSuggestions", () => {
+describe("resolveConfig — flowSuggestions", () => {
 	test("undefined when unspecified — flow pills stay off unless opted in", () => {
 		const config = resolveConfig({ token: "tok" });
-		expect(config.dynamicSuggestions).toBeUndefined();
+		expect(config.flowSuggestions).toBeUndefined();
 	});
 
 	test("programmatic false disables flow-driven pills", () => {
-		const config = resolveConfig({ token: "tok", dynamicSuggestions: false });
-		expect(config.dynamicSuggestions).toBe(false);
+		const config = resolveConfig({ token: "tok", flowSuggestions: false });
+		expect(config.flowSuggestions).toBe(false);
 	});
 
 	test("programmatic true opts into flow-driven pills", () => {
-		const config = resolveConfig({ token: "tok", dynamicSuggestions: true });
-		expect(config.dynamicSuggestions).toBe(true);
+		const config = resolveConfig({ token: "tok", flowSuggestions: true });
+		expect(config.flowSuggestions).toBe(true);
 	});
 });
 
-describe("parseConfigFromScript — data-dynamic-suggestions", () => {
+describe("parseConfigFromScript — data-flow-suggestions", () => {
 	test("undefined when unspecified — no opt-in", async () => {
 		const cfg = await parseWithAttrs({ "data-token": "tok" });
-		expect(cfg.dynamicSuggestions).toBeUndefined();
+		expect(cfg.flowSuggestions).toBeUndefined();
 	});
 
 	test("'false' explicitly keeps flow-driven pills off", async () => {
 		const cfg = await parseWithAttrs({
 			"data-token": "tok",
-			"data-dynamic-suggestions": "false",
+			"data-flow-suggestions": "false",
 		});
-		expect(cfg.dynamicSuggestions).toBe(false);
+		expect(cfg.flowSuggestions).toBe(false);
 	});
 
 	test("'true' parses as true", async () => {
 		const cfg = await parseWithAttrs({
 			"data-token": "tok",
-			"data-dynamic-suggestions": "true",
+			"data-flow-suggestions": "true",
 		});
-		expect(cfg.dynamicSuggestions).toBe(true);
+		expect(cfg.flowSuggestions).toBe(true);
 	});
 
 	test("bare attribute (empty value) opts in like sibling boolean attrs", async () => {
 		const cfg = await parseWithAttrs({
 			"data-token": "tok",
-			"data-dynamic-suggestions": "",
+			"data-flow-suggestions": "",
 		});
-		expect(cfg.dynamicSuggestions).toBe(true);
+		expect(cfg.flowSuggestions).toBe(true);
 	});
 });

--- a/src/chat/web/embed/__tests__/config.test.ts
+++ b/src/chat/web/embed/__tests__/config.test.ts
@@ -476,3 +476,51 @@ describe("resolveConfig — assistantBubble precedence", () => {
 		expect(config.appearance?.assistantBubble).toBe(false);
 	});
 });
+
+describe("resolveConfig — dynamicSuggestions", () => {
+	test("undefined when unspecified — consumers default to enabled", () => {
+		const config = resolveConfig({ token: "tok" });
+		expect(config.dynamicSuggestions).toBeUndefined();
+	});
+
+	test("programmatic false disables flow-driven pills", () => {
+		const config = resolveConfig({ token: "tok", dynamicSuggestions: false });
+		expect(config.dynamicSuggestions).toBe(false);
+	});
+
+	test("programmatic true keeps flow-driven pills enabled", () => {
+		const config = resolveConfig({ token: "tok", dynamicSuggestions: true });
+		expect(config.dynamicSuggestions).toBe(true);
+	});
+});
+
+describe("parseConfigFromScript — data-dynamic-suggestions", () => {
+	test("undefined when unspecified — pills stay enabled by default", async () => {
+		const cfg = await parseWithAttrs({ "data-token": "tok" });
+		expect(cfg.dynamicSuggestions).toBeUndefined();
+	});
+
+	test("'false' opts out of flow-driven pills", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-dynamic-suggestions": "false",
+		});
+		expect(cfg.dynamicSuggestions).toBe(false);
+	});
+
+	test("'true' parses as true", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-dynamic-suggestions": "true",
+		});
+		expect(cfg.dynamicSuggestions).toBe(true);
+	});
+
+	test("bare attribute (empty value) opts in like sibling boolean attrs", async () => {
+		const cfg = await parseWithAttrs({
+			"data-token": "tok",
+			"data-dynamic-suggestions": "",
+		});
+		expect(cfg.dynamicSuggestions).toBe(true);
+	});
+});

--- a/src/chat/web/embed/__tests__/widget-events.test.ts
+++ b/src/chat/web/embed/__tests__/widget-events.test.ts
@@ -162,7 +162,7 @@ describe("createWidgetEventEmitter", () => {
 
 		emitter.emit({
 			name: "suggestion.clicked",
-			properties: { text: "What are your prices?", index: 2, source: "flow" },
+			properties: { text: "What are your prices?", index: 2, origin: "flow" },
 		});
 		emitter.emit({
 			name: "link.clicked",
@@ -181,7 +181,7 @@ describe("createWidgetEventEmitter", () => {
 			expect(received[0].properties).toEqual({
 				text: "What are your prices?",
 				index: 2,
-				source: "flow",
+				origin: "flow",
 			});
 		}
 	});

--- a/src/chat/web/embed/__tests__/widget-events.test.ts
+++ b/src/chat/web/embed/__tests__/widget-events.test.ts
@@ -162,7 +162,7 @@ describe("createWidgetEventEmitter", () => {
 
 		emitter.emit({
 			name: "suggestion.clicked",
-			properties: { text: "What are your prices?", index: 2 },
+			properties: { text: "What are your prices?", index: 2, source: "flow" },
 		});
 		emitter.emit({
 			name: "link.clicked",
@@ -181,6 +181,7 @@ describe("createWidgetEventEmitter", () => {
 			expect(received[0].properties).toEqual({
 				text: "What are your prices?",
 				index: 2,
+				source: "flow",
 			});
 		}
 	});

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -3,6 +3,7 @@
 // ============================================================================
 
 import type { ChatTheme, SuggestionOrigin } from "../@types";
+import { SUGGESTION_ORIGINS } from "../@types";
 import type { Locale } from "../i18n";
 import type { VisitorIdInput } from "../lib/visitor-context";
 import type { VisibilityRules } from "./visibility";
@@ -236,13 +237,6 @@ const DEFAULTS = {
 	api: DEFAULT_API_URL,
 };
 
-const KNOWN_SUGGESTION_ORIGINS = new Set<SuggestionOrigin>([
-	"channel",
-	"page",
-	"flow",
-	"followup",
-]);
-
 // ---------------------------------------------------------------------------
 // Script tag detection
 // ---------------------------------------------------------------------------
@@ -384,9 +378,8 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 		config.suggestionOrigins = suggestionOriginsRaw
 			.split(",")
 			.map((s) => s.trim())
-			.filter(
-				(s): s is SuggestionOrigin =>
-					s !== "" && KNOWN_SUGGESTION_ORIGINS.has(s as SuggestionOrigin),
+			.filter((s): s is SuggestionOrigin =>
+				(SUGGESTION_ORIGINS as readonly string[]).includes(s),
 			);
 	}
 

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -2,7 +2,7 @@
 // Embed Config — types and resolution
 // ============================================================================
 
-import type { ChatTheme } from "../@types";
+import type { ChatTheme, SuggestionOrigin } from "../@types";
 import type { Locale } from "../i18n";
 import type { VisitorIdInput } from "../lib/visitor-context";
 import type { VisibilityRules } from "./visibility";
@@ -119,13 +119,15 @@ export interface EmbedConfig {
 	/** Initial suggestion chips displayed before the first message. */
 	suggestions?: string[];
 	/**
-	 * Opt-in for the per-turn pills a flow drives via
-	 * `interrupt({ suggestions })`. Disabled by default — set `true` (or
-	 * `data-flow-suggestions="true"` on the embed script tag) to render
-	 * them. Starter prompts (`suggestions`) are unaffected and show either
-	 * way.
+	 * Which providers may fill the per-turn pill row. Defaults to
+	 * `["channel", "page", "followup"]` when unset: starter prompts and
+	 * generated follow-ups render, flow-driven pills stay opt-in — include
+	 * `"flow"` (or `data-suggestion-origins="channel,page,flow,followup"` on
+	 * the embed script tag) to render the pills a flow drives via
+	 * `interrupt({ suggestions })`. Starter prompts (`suggestions`) are
+	 * unaffected by this field and show either way.
 	 */
-	flowSuggestions?: boolean;
+	suggestionOrigins?: SuggestionOrigin[];
 	/**
 	 * AI transparency notice rendered under the input (EU AI Act compliance).
 	 * String overrides the default wording; `false` hides it. Surfaced as
@@ -233,6 +235,13 @@ const DEFAULT_API_URL = "https://app.waniwani.ai/api/mcp/chat";
 const DEFAULTS = {
 	api: DEFAULT_API_URL,
 };
+
+const KNOWN_SUGGESTION_ORIGINS = new Set<SuggestionOrigin>([
+	"channel",
+	"page",
+	"flow",
+	"followup",
+]);
 
 // ---------------------------------------------------------------------------
 // Script tag detection
@@ -367,9 +376,18 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 		config.enableThreadHistory = enableThreadHistory;
 	}
 
-	const flowSuggestions = bool("data-flow-suggestions");
-	if (flowSuggestions !== undefined) {
-		config.flowSuggestions = flowSuggestions;
+	// An empty attribute (`data-suggestion-origins=""`) is a meaningful
+	// "render nothing" value, distinct from the attribute being absent —
+	// so this checks presence directly rather than going through `str()`.
+	const suggestionOriginsRaw = el.getAttribute("data-suggestion-origins");
+	if (suggestionOriginsRaw !== null) {
+		config.suggestionOrigins = suggestionOriginsRaw
+			.split(",")
+			.map((s) => s.trim())
+			.filter(
+				(s): s is SuggestionOrigin =>
+					s !== "" && KNOWN_SUGGESTION_ORIGINS.has(s as SuggestionOrigin),
+			);
 	}
 
 	const disablePageView = bool("data-disable-page-view");

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -119,12 +119,11 @@ export interface EmbedConfig {
 	/** Initial suggestion chips displayed before the first message. */
 	suggestions?: string[];
 	/**
-	 * Per-turn suggestion pills a flow drives via `interrupt({ suggestions })`.
-	 * Enabled by default — writing `suggestions` in a flow is itself the
-	 * opt-in, so most hosts never need to touch this. Set `false` to hide
-	 * flow-driven pills while still showing `suggestions` (the starter
-	 * prompts) at the start of the conversation. Surfaced as
-	 * `data-dynamic-suggestions` on the embed script tag.
+	 * Opt-in for the per-turn pills a flow drives via
+	 * `interrupt({ suggestions })`. Disabled by default — set `true` (or
+	 * `data-dynamic-suggestions="true"` on the embed script tag) to render
+	 * them. Starter prompts (`suggestions`) are unaffected and show either
+	 * way.
 	 */
 	dynamicSuggestions?: boolean;
 	/**

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -119,6 +119,15 @@ export interface EmbedConfig {
 	/** Initial suggestion chips displayed before the first message. */
 	suggestions?: string[];
 	/**
+	 * Per-turn suggestion pills a flow drives via `interrupt({ suggestions })`.
+	 * Enabled by default — writing `suggestions` in a flow is itself the
+	 * opt-in, so most hosts never need to touch this. Set `false` to hide
+	 * flow-driven pills while still showing `suggestions` (the starter
+	 * prompts) at the start of the conversation. Surfaced as
+	 * `data-dynamic-suggestions` on the embed script tag.
+	 */
+	dynamicSuggestions?: boolean;
+	/**
 	 * AI transparency notice rendered under the input (EU AI Act compliance).
 	 * String overrides the default wording; `false` hides it. Surfaced as
 	 * `data-disclaimer` on the embed script tag (use `data-disclaimer="false"`
@@ -357,6 +366,11 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 	const enableThreadHistory = bool("data-enable-thread-history");
 	if (enableThreadHistory !== undefined) {
 		config.enableThreadHistory = enableThreadHistory;
+	}
+
+	const dynamicSuggestions = bool("data-dynamic-suggestions");
+	if (dynamicSuggestions !== undefined) {
+		config.dynamicSuggestions = dynamicSuggestions;
 	}
 
 	const disablePageView = bool("data-disable-page-view");

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -121,11 +121,11 @@ export interface EmbedConfig {
 	/**
 	 * Opt-in for the per-turn pills a flow drives via
 	 * `interrupt({ suggestions })`. Disabled by default — set `true` (or
-	 * `data-dynamic-suggestions="true"` on the embed script tag) to render
+	 * `data-flow-suggestions="true"` on the embed script tag) to render
 	 * them. Starter prompts (`suggestions`) are unaffected and show either
 	 * way.
 	 */
-	dynamicSuggestions?: boolean;
+	flowSuggestions?: boolean;
 	/**
 	 * AI transparency notice rendered under the input (EU AI Act compliance).
 	 * String overrides the default wording; `false` hides it. Surfaced as
@@ -367,9 +367,9 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 		config.enableThreadHistory = enableThreadHistory;
 	}
 
-	const dynamicSuggestions = bool("data-dynamic-suggestions");
-	if (dynamicSuggestions !== undefined) {
-		config.dynamicSuggestions = dynamicSuggestions;
+	const flowSuggestions = bool("data-flow-suggestions");
+	if (flowSuggestions !== undefined) {
+		config.flowSuggestions = flowSuggestions;
 	}
 
 	const disablePageView = bool("data-disable-page-view");

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -469,6 +469,7 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 															properties: {
 																text,
 																index: suggestions.indexOf(text),
+																source: "initial",
 															},
 														});
 														openWith(text);

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -470,7 +470,7 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 															properties: {
 																text,
 																index: suggestions.indexOf(text),
-																source: "initial",
+																origin: "channel",
 															},
 														});
 														openWith(text);
@@ -568,7 +568,7 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 									placeholder={config.placeholder}
 									suggestions={toSuggestionsConfig({
 										suggestions: config.suggestions,
-										flowSuggestions: config.flowSuggestions,
+										suggestionOrigins: config.suggestionOrigins,
 									})}
 									enableThreadHistory={config.enableThreadHistory}
 									showToolCalls={config.showToolCalls}

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -30,6 +30,7 @@ import {
 import type { ChatHandle } from "../@types";
 import BorderGlow from "../components/border-glow";
 import { Suggestions } from "../components/suggestions";
+import { toSuggestionsConfig } from "../hooks/use-suggestions";
 import { useTypingPlaceholder } from "../hooks/use-typing-placeholder";
 import { I18nProvider, useTranslation } from "../i18n";
 import { ChatEmbed } from "../layouts/chat-embed";
@@ -565,11 +566,10 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 									hideHeader={false}
 									welcomeMessage={config.welcomeMessage}
 									placeholder={config.placeholder}
-									suggestions={
-										config.suggestions
-											? { initial: config.suggestions }
-											: undefined
-									}
+									suggestions={toSuggestionsConfig({
+										suggestions: config.suggestions,
+										dynamicSuggestions: config.dynamicSuggestions,
+									})}
 									enableThreadHistory={config.enableThreadHistory}
 									showToolCalls={config.showToolCalls}
 									locale={config.locale}

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -568,7 +568,7 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 									placeholder={config.placeholder}
 									suggestions={toSuggestionsConfig({
 										suggestions: config.suggestions,
-										dynamicSuggestions: config.dynamicSuggestions,
+										flowSuggestions: config.flowSuggestions,
 									})}
 									enableThreadHistory={config.enableThreadHistory}
 									showToolCalls={config.showToolCalls}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -135,7 +135,7 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 					placeholder={config.placeholder}
 					suggestions={toSuggestionsConfig({
 						suggestions: config.suggestions,
-						flowSuggestions: config.flowSuggestions,
+						suggestionOrigins: config.suggestionOrigins,
 					})}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -135,7 +135,7 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 					placeholder={config.placeholder}
 					suggestions={toSuggestionsConfig({
 						suggestions: config.suggestions,
-						dynamicSuggestions: config.dynamicSuggestions,
+						flowSuggestions: config.flowSuggestions,
 					})}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -14,6 +14,7 @@ import {
 	useRef,
 } from "react";
 import type { ChatHandle } from "../@types";
+import { toSuggestionsConfig } from "../hooks/use-suggestions";
 import { ChatEmbed } from "../layouts/chat-embed";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
@@ -132,9 +133,10 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 					hideHeader={config.hideHeader}
 					welcomeMessage={config.welcomeMessage}
 					placeholder={config.placeholder}
-					suggestions={
-						config.suggestions ? { initial: config.suggestions } : undefined
-					}
+					suggestions={toSuggestionsConfig({
+						suggestions: config.suggestions,
+						dynamicSuggestions: config.dynamicSuggestions,
+					})}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}
 					locale={config.locale}

--- a/src/chat/web/embed/widget-events.ts
+++ b/src/chat/web/embed/widget-events.ts
@@ -12,6 +12,8 @@
 // a message was exchanged, never what was said.
 // ============================================================================
 
+import type { SuggestionOrigin } from "../@types";
+
 /** Surface the widget is mounted on. */
 export type WidgetMode = "inline" | "floating";
 
@@ -48,8 +50,8 @@ export type WidgetEventDetail =
 			properties: {
 				text: string;
 				index: number;
-				/** `"flow"` when the MCP's flow drove these pills, `"initial"` for configured starter prompts. */
-				source: "flow" | "initial";
+				/** Which provider supplied the clicked pill: `"channel"` (starter prompts), `"page"` (per-URL starter prompts), `"flow"` (an MCP flow's `interrupt({ suggestions })`), or `"followup"` (generated from the conversation). */
+				origin: SuggestionOrigin;
 			};
 	  }
 	| { name: "link.clicked"; properties: { url: string } };

--- a/src/chat/web/embed/widget-events.ts
+++ b/src/chat/web/embed/widget-events.ts
@@ -43,7 +43,15 @@ export type WidgetEventDetail =
 	| { name: "session.started"; properties: { sessionId: string } }
 	| { name: "thread.changed"; properties: { threadId: string } }
 	| { name: "chat.error"; properties: { message: string } }
-	| { name: "suggestion.clicked"; properties: { text: string; index: number } }
+	| {
+			name: "suggestion.clicked";
+			properties: {
+				text: string;
+				index: number;
+				/** `"flow"` when the MCP's flow drove these pills, `"initial"` for configured starter prompts. */
+				source: "flow" | "initial";
+			};
+	  }
 	| { name: "link.clicked"; properties: { url: string } };
 
 /** Payload handed to `onEvent` subscribers. Discriminated on `name`. */

--- a/src/chat/web/hooks/__tests__/turn-suggestions.test.ts
+++ b/src/chat/web/hooks/__tests__/turn-suggestions.test.ts
@@ -204,4 +204,22 @@ describe("resolveTurnSuggestions", () => {
 
 		expect(resolveTurnSuggestions(message)).toBeNull();
 	});
+
+	test("ignores a flow entry when includeFlow is false", () => {
+		const message = assistantMessage([flowToolPart(["Oui", "Non"])]);
+
+		expect(resolveTurnSuggestions(message, { includeFlow: false })).toBeNull();
+	});
+
+	test("still returns the streamed part when includeFlow is false and both exist", () => {
+		const message = assistantMessage([
+			dataSuggestionsPart(["From", "Stream"]),
+			flowToolPart(["From", "Flow"]),
+		]);
+
+		expect(resolveTurnSuggestions(message, { includeFlow: false })).toEqual({
+			suggestions: ["From", "Stream"],
+			source: "streamed",
+		});
+	});
 });

--- a/src/chat/web/hooks/__tests__/turn-suggestions.test.ts
+++ b/src/chat/web/hooks/__tests__/turn-suggestions.test.ts
@@ -36,6 +36,19 @@ function dataSuggestionsPart(suggestions: string[]) {
 	return { type: "data-suggestions", data: { suggestions } };
 }
 
+/** A non-flow tool result (e.g. a KB search) — no `waniwani/suggestions` key at all. */
+function nonFlowToolPart(toolCallId = "call-kb") {
+	return {
+		type: "tool-kb_search",
+		toolCallId,
+		state: "output-available",
+		output: {
+			content: [{ type: "text", text: "{}" }],
+			_meta: { "waniwani/sessionId": "sess-1" },
+		},
+	};
+}
+
 describe("extractFlowSuggestions", () => {
 	test("returns the suggestions from a flow tool part", () => {
 		const message = assistantMessage([
@@ -114,6 +127,35 @@ describe("extractFlowSuggestions", () => {
 		expect(extractFlowSuggestions(message)).toBeNull();
 	});
 
+	// Regression test for the bug where a turn calling the flow twice — an
+	// interrupt-with-suggestions call followed by a complete/widget/error call
+	// carrying no `waniwani/suggestions` key — left the first call's pills on
+	// screen after the flow had moved on or finished. With the key made
+	// authoritative on every flow result (an empty array meaning "no pills for
+	// this step"), the second call's empty entry must win.
+	test("clears pills when a later flow call in the same turn carries an empty array", () => {
+		const message = assistantMessage([
+			flowToolPart(["Bronze", "Silver", "Gold"], "call-1"),
+			flowToolPart([], "call-2"),
+		]);
+
+		expect(extractFlowSuggestions(message)).toBeNull();
+		expect(resolveTurnSuggestions(message)).toBeNull();
+	});
+
+	test("does not let a non-flow tool part after a flow part clear the pills", () => {
+		const message = assistantMessage([
+			flowToolPart(["Bronze", "Silver", "Gold"], "call-1"),
+			nonFlowToolPart("call-2"),
+		]);
+
+		expect(extractFlowSuggestions(message)).toEqual([
+			"Bronze",
+			"Silver",
+			"Gold",
+		]);
+	});
+
 	test("ignores a tool part that has not produced output yet", () => {
 		const message = assistantMessage([
 			{ type: "tool-my_flow", toolCallId: "call-1", state: "input-streaming" },
@@ -153,7 +195,7 @@ describe("resolveTurnSuggestions", () => {
 
 		expect(resolveTurnSuggestions(message)).toEqual({
 			suggestions: ["From", "Stream"],
-			source: "initial",
+			source: "streamed",
 		});
 	});
 

--- a/src/chat/web/hooks/__tests__/turn-suggestions.test.ts
+++ b/src/chat/web/hooks/__tests__/turn-suggestions.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+import {
+	extractFlowSuggestions,
+	resolveTurnSuggestions,
+} from "../turn-suggestions";
+
+/** Build an assistant message from raw parts. */
+function assistantMessage(parts: unknown[]): UIMessage {
+	return {
+		id: "m1",
+		role: "assistant",
+		parts,
+	} as unknown as UIMessage;
+}
+
+/** A tool-result part carrying the flow engine's suggestions meta. */
+function flowToolPart(suggestions: string[], toolCallId = "call-1") {
+	return {
+		type: "tool-my_flow",
+		toolCallId,
+		state: "output-available",
+		output: {
+			content: [{ type: "text", text: "{}" }],
+			structuredContent: { status: "interrupt", suggestions },
+			_meta: {
+				"waniwani/sessionId": "sess-1",
+				"waniwani/suggestions": { suggestions },
+			},
+		},
+	};
+}
+
+/** The legacy streamed data part a bring-your-own-backend host may emit. */
+function dataSuggestionsPart(suggestions: string[]) {
+	return { type: "data-suggestions", data: { suggestions } };
+}
+
+describe("extractFlowSuggestions", () => {
+	test("returns the suggestions from a flow tool part", () => {
+		const message = assistantMessage([
+			{ type: "text", text: "Which plan fits you?" },
+			flowToolPart(["Bronze", "Silver", "Gold"]),
+		]);
+
+		expect(extractFlowSuggestions(message)).toEqual([
+			"Bronze",
+			"Silver",
+			"Gold",
+		]);
+	});
+
+	test("returns null when no part carries the key", () => {
+		const message = assistantMessage([
+			{ type: "text", text: "Here is what I found." },
+			{
+				type: "tool-search",
+				toolCallId: "call-9",
+				state: "output-available",
+				output: { content: [{ type: "text", text: "{}" }] },
+			},
+		]);
+
+		expect(extractFlowSuggestions(message)).toBeNull();
+	});
+
+	test("returns null for a message with no parts", () => {
+		expect(extractFlowSuggestions(assistantMessage([]))).toBeNull();
+	});
+
+	test("takes the last flow result when a turn calls the flow twice", () => {
+		const message = assistantMessage([
+			flowToolPart(["First", "Set"], "call-1"),
+			{ type: "text", text: "Got it." },
+			flowToolPart(["Second", "Set"], "call-2"),
+		]);
+
+		expect(extractFlowSuggestions(message)).toEqual(["Second", "Set"]);
+	});
+
+	test("ignores a tool part whose _meta entry is malformed", () => {
+		const message = assistantMessage([
+			{
+				type: "tool-my_flow",
+				toolCallId: "call-1",
+				state: "output-available",
+				output: {
+					_meta: { "waniwani/suggestions": { suggestions: "not-an-array" } },
+				},
+			},
+		]);
+
+		expect(extractFlowSuggestions(message)).toBeNull();
+	});
+
+	test("ignores a suggestions array containing non-strings", () => {
+		const message = assistantMessage([
+			{
+				type: "tool-my_flow",
+				toolCallId: "call-1",
+				state: "output-available",
+				output: {
+					_meta: { "waniwani/suggestions": { suggestions: ["ok", 42] } },
+				},
+			},
+		]);
+
+		expect(extractFlowSuggestions(message)).toBeNull();
+	});
+
+	test("ignores an empty suggestions array", () => {
+		const message = assistantMessage([flowToolPart([])]);
+
+		expect(extractFlowSuggestions(message)).toBeNull();
+	});
+
+	test("ignores a tool part that has not produced output yet", () => {
+		const message = assistantMessage([
+			{ type: "tool-my_flow", toolCallId: "call-1", state: "input-streaming" },
+		]);
+
+		expect(extractFlowSuggestions(message)).toBeNull();
+	});
+});
+
+describe("resolveTurnSuggestions", () => {
+	test("reports flow suggestions with source flow", () => {
+		const message = assistantMessage([flowToolPart(["Oui", "Non"])]);
+
+		expect(resolveTurnSuggestions(message)).toEqual({
+			suggestions: ["Oui", "Non"],
+			source: "flow",
+		});
+	});
+
+	test("flow suggestions win over a streamed data part", () => {
+		const message = assistantMessage([
+			dataSuggestionsPart(["From", "Stream"]),
+			flowToolPart(["From", "Flow"]),
+		]);
+
+		expect(resolveTurnSuggestions(message)).toEqual({
+			suggestions: ["From", "Flow"],
+			source: "flow",
+		});
+	});
+
+	test("falls back to a streamed data part when no flow result carries the key", () => {
+		const message = assistantMessage([
+			{ type: "text", text: "Here you go." },
+			dataSuggestionsPart(["From", "Stream"]),
+		]);
+
+		expect(resolveTurnSuggestions(message)).toEqual({
+			suggestions: ["From", "Stream"],
+			source: "initial",
+		});
+	});
+
+	test("returns null when the turn carries neither", () => {
+		const message = assistantMessage([{ type: "text", text: "All done." }]);
+
+		expect(resolveTurnSuggestions(message)).toBeNull();
+	});
+});

--- a/src/chat/web/hooks/__tests__/turn-suggestions.test.ts
+++ b/src/chat/web/hooks/__tests__/turn-suggestions.test.ts
@@ -195,7 +195,7 @@ describe("resolveTurnSuggestions", () => {
 
 		expect(resolveTurnSuggestions(message)).toEqual({
 			suggestions: ["From", "Stream"],
-			source: "streamed",
+			source: "followup",
 		});
 	});
 
@@ -219,7 +219,7 @@ describe("resolveTurnSuggestions", () => {
 
 		expect(resolveTurnSuggestions(message, { includeFlow: false })).toEqual({
 			suggestions: ["From", "Stream"],
-			source: "streamed",
+			source: "followup",
 		});
 	});
 });

--- a/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
+++ b/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
@@ -1,14 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
 	isDynamicSuggestionsEnabled,
+	isFlowSuggestionsEnabled,
 	toSuggestionsConfig,
 } from "../use-suggestions";
 
 describe("isDynamicSuggestionsEnabled", () => {
-	test("enabled when the host passes no suggestions config at all", () => {
-		// A channel with no starter prompts configured must still show the pills
-		// a flow drives. These two settings are unrelated.
-		expect(isDynamicSuggestionsEnabled(undefined)).toBe(true);
+	test("disabled when the host passes no suggestions config at all", () => {
+		expect(isDynamicSuggestionsEnabled(undefined)).toBe(false);
 	});
 
 	test("enabled for `true`", () => {
@@ -17,6 +16,14 @@ describe("isDynamicSuggestionsEnabled", () => {
 
 	test("enabled when only initial prompts are configured", () => {
 		expect(isDynamicSuggestionsEnabled({ initial: ["Hi"] })).toBe(true);
+	});
+
+	test("enabled for an empty config object", () => {
+		expect(isDynamicSuggestionsEnabled({})).toBe(true);
+	});
+
+	test("enabled for an explicit dynamic opt-in", () => {
+		expect(isDynamicSuggestionsEnabled({ dynamic: true })).toBe(true);
 	});
 
 	test("disabled for `false`", () => {
@@ -34,6 +41,38 @@ describe("isDynamicSuggestionsEnabled", () => {
 	});
 });
 
+describe("isFlowSuggestionsEnabled", () => {
+	test("disabled when the host passes no suggestions config at all", () => {
+		expect(isFlowSuggestionsEnabled(undefined)).toBe(false);
+	});
+
+	test("enabled for `true`", () => {
+		expect(isFlowSuggestionsEnabled(true)).toBe(true);
+	});
+
+	test("disabled for `false`", () => {
+		expect(isFlowSuggestionsEnabled(false)).toBe(false);
+	});
+
+	test("disabled when only initial prompts are configured", () => {
+		expect(isFlowSuggestionsEnabled({ initial: ["Hi"] })).toBe(false);
+	});
+
+	test("enabled for a dynamic-only opt-in", () => {
+		expect(isFlowSuggestionsEnabled({ dynamic: true })).toBe(true);
+	});
+
+	test("enabled when initial prompts and the opt-in are combined", () => {
+		expect(isFlowSuggestionsEnabled({ initial: ["Hi"], dynamic: true })).toBe(
+			true,
+		);
+	});
+
+	test("disabled when dynamic is explicitly turned off", () => {
+		expect(isFlowSuggestionsEnabled({ dynamic: false })).toBe(false);
+	});
+});
+
 describe("toSuggestionsConfig", () => {
 	test("returns undefined when neither field is set", () => {
 		expect(toSuggestionsConfig({})).toBeUndefined();
@@ -46,7 +85,7 @@ describe("toSuggestionsConfig", () => {
 		});
 	});
 
-	test("forwards the dynamic opt-out even without starter prompts", () => {
+	test("forwards a dynamic false even without starter prompts", () => {
 		expect(toSuggestionsConfig({ dynamicSuggestions: false })).toEqual({
 			initial: undefined,
 			dynamic: false,
@@ -59,11 +98,25 @@ describe("toSuggestionsConfig", () => {
 		).toEqual({ initial: ["Hi"], dynamic: false });
 	});
 
-	test("composes with the gate: opt-out without starter prompts disables pills", () => {
+	test("composes with the gate: dynamic false without starter prompts disables per-turn suggestions", () => {
 		expect(
 			isDynamicSuggestionsEnabled(
 				toSuggestionsConfig({ dynamicSuggestions: false }),
 			),
+		).toBe(false);
+	});
+
+	test("composes with the flow gate: the opt-in enables flow pills", () => {
+		expect(
+			isFlowSuggestionsEnabled(
+				toSuggestionsConfig({ dynamicSuggestions: true }),
+			),
+		).toBe(true);
+	});
+
+	test("composes with the flow gate: starter prompts alone leave flow pills off", () => {
+		expect(
+			isFlowSuggestionsEnabled(toSuggestionsConfig({ suggestions: ["Hi"] })),
 		).toBe(false);
 	});
 });

--- a/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
+++ b/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
@@ -86,7 +86,7 @@ describe("toSuggestionsConfig", () => {
 	});
 
 	test("forwards a dynamic false even without starter prompts", () => {
-		expect(toSuggestionsConfig({ dynamicSuggestions: false })).toEqual({
+		expect(toSuggestionsConfig({ flowSuggestions: false })).toEqual({
 			initial: undefined,
 			dynamic: false,
 		});
@@ -94,23 +94,21 @@ describe("toSuggestionsConfig", () => {
 
 	test("forwards both fields together", () => {
 		expect(
-			toSuggestionsConfig({ suggestions: ["Hi"], dynamicSuggestions: false }),
+			toSuggestionsConfig({ suggestions: ["Hi"], flowSuggestions: false }),
 		).toEqual({ initial: ["Hi"], dynamic: false });
 	});
 
 	test("composes with the gate: dynamic false without starter prompts disables per-turn suggestions", () => {
 		expect(
 			isDynamicSuggestionsEnabled(
-				toSuggestionsConfig({ dynamicSuggestions: false }),
+				toSuggestionsConfig({ flowSuggestions: false }),
 			),
 		).toBe(false);
 	});
 
 	test("composes with the flow gate: the opt-in enables flow pills", () => {
 		expect(
-			isFlowSuggestionsEnabled(
-				toSuggestionsConfig({ dynamicSuggestions: true }),
-			),
+			isFlowSuggestionsEnabled(toSuggestionsConfig({ flowSuggestions: true })),
 		).toBe(true);
 	});
 

--- a/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
+++ b/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { isDynamicSuggestionsEnabled } from "../use-suggestions";
+import {
+	isDynamicSuggestionsEnabled,
+	toSuggestionsConfig,
+} from "../use-suggestions";
 
 describe("isDynamicSuggestionsEnabled", () => {
 	test("enabled when the host passes no suggestions config at all", () => {
@@ -23,6 +26,44 @@ describe("isDynamicSuggestionsEnabled", () => {
 	test("disabled when dynamic is explicitly turned off", () => {
 		expect(
 			isDynamicSuggestionsEnabled({ initial: ["Hi"], dynamic: false }),
+		).toBe(false);
+	});
+
+	test("returns false for a dynamic-only config object", () => {
+		expect(isDynamicSuggestionsEnabled({ dynamic: false })).toBe(false);
+	});
+});
+
+describe("toSuggestionsConfig", () => {
+	test("returns undefined when neither field is set", () => {
+		expect(toSuggestionsConfig({})).toBeUndefined();
+	});
+
+	test("maps starter prompts to initial", () => {
+		expect(toSuggestionsConfig({ suggestions: ["Hi"] })).toEqual({
+			initial: ["Hi"],
+			dynamic: undefined,
+		});
+	});
+
+	test("forwards the dynamic opt-out even without starter prompts", () => {
+		expect(toSuggestionsConfig({ dynamicSuggestions: false })).toEqual({
+			initial: undefined,
+			dynamic: false,
+		});
+	});
+
+	test("forwards both fields together", () => {
+		expect(
+			toSuggestionsConfig({ suggestions: ["Hi"], dynamicSuggestions: false }),
+		).toEqual({ initial: ["Hi"], dynamic: false });
+	});
+
+	test("composes with the gate: opt-out without starter prompts disables pills", () => {
+		expect(
+			isDynamicSuggestionsEnabled(
+				toSuggestionsConfig({ dynamicSuggestions: false }),
+			),
 		).toBe(false);
 	});
 });

--- a/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
+++ b/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
@@ -1,75 +1,87 @@
 import { describe, expect, test } from "bun:test";
 import {
-	isDynamicSuggestionsEnabled,
-	isFlowSuggestionsEnabled,
+	DEFAULT_SUGGESTION_ORIGINS,
+	isOriginEnabled,
+	resolveSuggestionOrigins,
 	toSuggestionsConfig,
 } from "../use-suggestions";
 
-describe("isDynamicSuggestionsEnabled", () => {
-	test("disabled when the host passes no suggestions config at all", () => {
-		expect(isDynamicSuggestionsEnabled(undefined)).toBe(false);
+describe("resolveSuggestionOrigins", () => {
+	test("rule 1: `false` disables every origin", () => {
+		expect(resolveSuggestionOrigins(false)).toEqual([]);
 	});
 
-	test("enabled for `true`", () => {
-		expect(isDynamicSuggestionsEnabled(true)).toBe(true);
+	test("rule 2: `true` enables every origin", () => {
+		expect(resolveSuggestionOrigins(true)).toEqual([
+			"channel",
+			"page",
+			"flow",
+			"followup",
+		]);
 	});
 
-	test("enabled when only initial prompts are configured", () => {
-		expect(isDynamicSuggestionsEnabled({ initial: ["Hi"] })).toBe(true);
+	test("rule 3: an object's `origins` is used exactly as given", () => {
+		expect(resolveSuggestionOrigins({ origins: ["flow"] })).toEqual(["flow"]);
+		expect(resolveSuggestionOrigins({ origins: ["channel", "page"] })).toEqual([
+			"channel",
+			"page",
+		]);
 	});
 
-	test("enabled for an empty config object", () => {
-		expect(isDynamicSuggestionsEnabled({})).toBe(true);
+	test("rule 3: an empty `origins` array means nothing renders", () => {
+		expect(resolveSuggestionOrigins({ origins: [] })).toEqual([]);
 	});
 
-	test("enabled for an explicit dynamic opt-in", () => {
-		expect(isDynamicSuggestionsEnabled({ dynamic: true })).toBe(true);
-	});
-
-	test("disabled for `false`", () => {
-		expect(isDynamicSuggestionsEnabled(false)).toBe(false);
-	});
-
-	test("disabled when dynamic is explicitly turned off", () => {
+	test("rule 3 beats rule 4: `origins` wins even when legacy `dynamic` is also set", () => {
 		expect(
-			isDynamicSuggestionsEnabled({ initial: ["Hi"], dynamic: false }),
-		).toBe(false);
-	});
-
-	test("returns false for a dynamic-only config object", () => {
-		expect(isDynamicSuggestionsEnabled({ dynamic: false })).toBe(false);
-	});
-});
-
-describe("isFlowSuggestionsEnabled", () => {
-	test("disabled when the host passes no suggestions config at all", () => {
-		expect(isFlowSuggestionsEnabled(undefined)).toBe(false);
-	});
-
-	test("enabled for `true`", () => {
-		expect(isFlowSuggestionsEnabled(true)).toBe(true);
-	});
-
-	test("disabled for `false`", () => {
-		expect(isFlowSuggestionsEnabled(false)).toBe(false);
-	});
-
-	test("disabled when only initial prompts are configured", () => {
-		expect(isFlowSuggestionsEnabled({ initial: ["Hi"] })).toBe(false);
-	});
-
-	test("enabled for a dynamic-only opt-in", () => {
-		expect(isFlowSuggestionsEnabled({ dynamic: true })).toBe(true);
-	});
-
-	test("enabled when initial prompts and the opt-in are combined", () => {
-		expect(isFlowSuggestionsEnabled({ initial: ["Hi"], dynamic: true })).toBe(
-			true,
+			resolveSuggestionOrigins({ origins: ["flow"], dynamic: false }),
+		).toEqual(["flow"]);
+		expect(resolveSuggestionOrigins({ origins: [], dynamic: true })).toEqual(
+			[],
 		);
 	});
 
-	test("disabled when dynamic is explicitly turned off", () => {
-		expect(isFlowSuggestionsEnabled({ dynamic: false })).toBe(false);
+	test("rule 4: legacy `dynamic: true` enables every origin", () => {
+		expect(resolveSuggestionOrigins({ dynamic: true })).toEqual([
+			"channel",
+			"page",
+			"flow",
+			"followup",
+		]);
+	});
+
+	test("rule 5: legacy `dynamic: false` disables every origin", () => {
+		expect(resolveSuggestionOrigins({ dynamic: false })).toEqual([]);
+	});
+
+	test("rule 6: `undefined` falls back to the default origins", () => {
+		expect(resolveSuggestionOrigins(undefined)).toEqual([
+			...DEFAULT_SUGGESTION_ORIGINS,
+		]);
+	});
+
+	test("rule 6: an object with neither `origins` nor `dynamic` falls back to the default origins", () => {
+		expect(resolveSuggestionOrigins({ initial: ["Hi"] })).toEqual([
+			...DEFAULT_SUGGESTION_ORIGINS,
+		]);
+		expect(resolveSuggestionOrigins({})).toEqual([
+			...DEFAULT_SUGGESTION_ORIGINS,
+		]);
+	});
+
+	test("default origins are channel, page, and followup — flow stays opt-in", () => {
+		expect(DEFAULT_SUGGESTION_ORIGINS).toEqual(["channel", "page", "followup"]);
+	});
+});
+
+describe("isOriginEnabled", () => {
+	test("reflects the resolved origin list", () => {
+		expect(isOriginEnabled(undefined, "channel")).toBe(true);
+		expect(isOriginEnabled(undefined, "flow")).toBe(false);
+		expect(isOriginEnabled(true, "flow")).toBe(true);
+		expect(isOriginEnabled(false, "channel")).toBe(false);
+		expect(isOriginEnabled({ origins: ["flow"] }, "flow")).toBe(true);
+		expect(isOriginEnabled({ origins: ["flow"] }, "channel")).toBe(false);
 	});
 });
 
@@ -81,40 +93,44 @@ describe("toSuggestionsConfig", () => {
 	test("maps starter prompts to initial", () => {
 		expect(toSuggestionsConfig({ suggestions: ["Hi"] })).toEqual({
 			initial: ["Hi"],
-			dynamic: undefined,
+			origins: undefined,
 		});
 	});
 
-	test("forwards a dynamic false even without starter prompts", () => {
-		expect(toSuggestionsConfig({ flowSuggestions: false })).toEqual({
+	test("forwards suggestionOrigins even without starter prompts", () => {
+		expect(toSuggestionsConfig({ suggestionOrigins: ["flow"] })).toEqual({
 			initial: undefined,
-			dynamic: false,
+			origins: ["flow"],
 		});
 	});
 
 	test("forwards both fields together", () => {
 		expect(
-			toSuggestionsConfig({ suggestions: ["Hi"], flowSuggestions: false }),
-		).toEqual({ initial: ["Hi"], dynamic: false });
+			toSuggestionsConfig({
+				suggestions: ["Hi"],
+				suggestionOrigins: ["channel", "flow"],
+			}),
+		).toEqual({ initial: ["Hi"], origins: ["channel", "flow"] });
 	});
 
-	test("composes with the gate: dynamic false without starter prompts disables per-turn suggestions", () => {
+	test("composes with the gate: an empty suggestionOrigins disables per-turn suggestions", () => {
 		expect(
-			isDynamicSuggestionsEnabled(
-				toSuggestionsConfig({ flowSuggestions: false }),
+			resolveSuggestionOrigins(toSuggestionsConfig({ suggestionOrigins: [] })),
+		).toEqual([]);
+	});
+
+	test("composes with the gate: `flow` in suggestionOrigins enables flow pills", () => {
+		expect(
+			isOriginEnabled(
+				toSuggestionsConfig({ suggestionOrigins: ["flow"] }),
+				"flow",
 			),
-		).toBe(false);
-	});
-
-	test("composes with the flow gate: the opt-in enables flow pills", () => {
-		expect(
-			isFlowSuggestionsEnabled(toSuggestionsConfig({ flowSuggestions: true })),
 		).toBe(true);
 	});
 
-	test("composes with the flow gate: starter prompts alone leave flow pills off", () => {
+	test("composes with the gate: starter prompts alone leave flow pills off (falls back to defaults)", () => {
 		expect(
-			isFlowSuggestionsEnabled(toSuggestionsConfig({ suggestions: ["Hi"] })),
+			isOriginEnabled(toSuggestionsConfig({ suggestions: ["Hi"] }), "flow"),
 		).toBe(false);
 	});
 });

--- a/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
+++ b/src/chat/web/hooks/__tests__/use-suggestions-gate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { isDynamicSuggestionsEnabled } from "../use-suggestions";
+
+describe("isDynamicSuggestionsEnabled", () => {
+	test("enabled when the host passes no suggestions config at all", () => {
+		// A channel with no starter prompts configured must still show the pills
+		// a flow drives. These two settings are unrelated.
+		expect(isDynamicSuggestionsEnabled(undefined)).toBe(true);
+	});
+
+	test("enabled for `true`", () => {
+		expect(isDynamicSuggestionsEnabled(true)).toBe(true);
+	});
+
+	test("enabled when only initial prompts are configured", () => {
+		expect(isDynamicSuggestionsEnabled({ initial: ["Hi"] })).toBe(true);
+	});
+
+	test("disabled for `false`", () => {
+		expect(isDynamicSuggestionsEnabled(false)).toBe(false);
+	});
+
+	test("disabled when dynamic is explicitly turned off", () => {
+		expect(
+			isDynamicSuggestionsEnabled({ initial: ["Hi"], dynamic: false }),
+		).toBe(false);
+	});
+});

--- a/src/chat/web/hooks/__tests__/use-suggestions.test.tsx
+++ b/src/chat/web/hooks/__tests__/use-suggestions.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Window } from "happy-dom";
+import type { SuggestionOrigin } from "../../@types";
 
 // ---------------------------------------------------------------------------
 // Minimal DOM globals so react-dom/client can mount a hook harness. Unlike
@@ -111,10 +112,10 @@ function assistantMessageWithFlowSuggestions(suggestions: string[]) {
 	};
 }
 
-/** An assistant message carrying a streamed `data-suggestions` part. */
-function assistantMessageWithStreamedSuggestions(
+/** An assistant message carrying a streamed `data-suggestions` (followup) part. */
+function assistantMessageWithFollowupSuggestions(
 	suggestions: string[],
-	id = "a-streamed",
+	id = "a-followup",
 ) {
 	return {
 		id,
@@ -137,8 +138,12 @@ describe("useSuggestions — conversation reset clears stale pills", () => {
 	test("clears flow-driven pills once messages go back to empty, with no `initial` configured", () => {
 		// Mount mid-flight so the streaming -> ready transition below fires the
 		// hook's recompute effect. Flow pills are opt-in, so the host passes
-		// `dynamic: true`.
-		render({ messages: [], status: "streaming", config: { dynamic: true } });
+		// `origins: ["flow"]`.
+		render({
+			messages: [],
+			status: "streaming",
+			config: { origins: ["flow"] },
+		});
 
 		const turnMessages: Msg[] = [
 			userMessage("Which plan?"),
@@ -147,24 +152,24 @@ describe("useSuggestions — conversation reset clears stale pills", () => {
 		render({
 			messages: turnMessages,
 			status: "ready",
-			config: { dynamic: true },
+			config: { origins: ["flow"] },
 		});
 
 		expect(hookRef.current?.suggestions).toEqual(["Bronze", "Silver", "Gold"]);
 
 		// Simulate `reset()` / `startNewThread()`: messages go back to empty
 		// while status stays "ready". No `initial` was ever configured.
-		render({ messages: [], status: "ready", config: { dynamic: true } });
+		render({ messages: [], status: "ready", config: { origins: ["flow"] } });
 
 		expect(hookRef.current?.suggestions).toEqual([]);
-		expect(hookRef.current?.source).toBe("initial");
+		expect(hookRef.current?.source).toBe("channel");
 	});
 
 	test("resets to the configured `initial` pills (not last flow pills) once messages go back to empty", () => {
 		render({
 			messages: [],
 			status: "streaming",
-			config: { initial: ["Book a demo"], dynamic: true },
+			config: { initial: ["Book a demo"], origins: ["flow"] },
 		});
 
 		const turnMessages: Msg[] = [
@@ -174,7 +179,7 @@ describe("useSuggestions — conversation reset clears stale pills", () => {
 		render({
 			messages: turnMessages,
 			status: "ready",
-			config: { initial: ["Book a demo"], dynamic: true },
+			config: { initial: ["Book a demo"], origins: ["flow"] },
 		});
 
 		expect(hookRef.current?.suggestions).toEqual(["Bronze", "Silver", "Gold"]);
@@ -183,11 +188,11 @@ describe("useSuggestions — conversation reset clears stale pills", () => {
 		render({
 			messages: [],
 			status: "ready",
-			config: { initial: ["Book a demo"], dynamic: true },
+			config: { initial: ["Book a demo"], origins: ["flow"] },
 		});
 
 		expect(hookRef.current?.suggestions).toEqual(["Book a demo"]);
-		expect(hookRef.current?.source).toBe("initial");
+		expect(hookRef.current?.source).toBe("channel");
 	});
 });
 
@@ -202,21 +207,21 @@ describe("useSuggestions — flow pills are opt-in", () => {
 		render({ messages: turnMessages, status: "ready" });
 
 		expect(hookRef.current?.suggestions).toEqual([]);
-		expect(hookRef.current?.source).toBe("initial");
+		expect(hookRef.current?.source).toBe("channel");
 	});
 
-	test("with only `initial` configured, streamed pills render while flow pills do not", () => {
+	test("with only `initial` configured, followup pills render (default origins) while flow pills do not", () => {
 		const config = { initial: ["Hi"] };
 		render({ messages: [], status: "streaming", config });
 
-		const streamedTurn: Msg[] = [
+		const followupTurn: Msg[] = [
 			userMessage("Anything else?"),
-			assistantMessageWithStreamedSuggestions(["From", "Stream"]),
+			assistantMessageWithFollowupSuggestions(["From", "Followup"]),
 		];
-		render({ messages: streamedTurn, status: "ready", config });
+		render({ messages: followupTurn, status: "ready", config });
 
-		expect(hookRef.current?.suggestions).toEqual(["From", "Stream"]);
-		expect(hookRef.current?.source).toBe("initial");
+		expect(hookRef.current?.suggestions).toEqual(["From", "Followup"]);
+		expect(hookRef.current?.source).toBe("followup");
 
 		const secondUser: Msg = {
 			id: "u2",
@@ -224,19 +229,49 @@ describe("useSuggestions — flow pills are opt-in", () => {
 			parts: [{ type: "text", text: "Which plan?" }],
 		};
 		render({
-			messages: [...streamedTurn, secondUser],
+			messages: [...followupTurn, secondUser],
 			status: "streaming",
 			config,
 		});
 
 		const flowTurn: Msg[] = [
-			...streamedTurn,
+			...followupTurn,
 			secondUser,
 			assistantMessageWithFlowSuggestions(["Bronze", "Silver", "Gold"]),
 		];
 		render({ messages: flowTurn, status: "ready", config });
 
 		expect(hookRef.current?.suggestions).toEqual([]);
-		expect(hookRef.current?.source).toBe("initial");
+		expect(hookRef.current?.source).toBe("channel");
+	});
+});
+
+describe("useSuggestions — origin filtering", () => {
+	test("filters out a followup result when only `flow` is enabled", () => {
+		const config: { origins: SuggestionOrigin[] } = { origins: ["flow"] };
+		render({ messages: [], status: "streaming", config });
+
+		const turnMessages: Msg[] = [
+			userMessage("Anything else?"),
+			assistantMessageWithFollowupSuggestions(["From", "Followup"]),
+		];
+		render({ messages: turnMessages, status: "ready", config });
+
+		expect(hookRef.current?.suggestions).toEqual([]);
+		expect(hookRef.current?.source).toBe("channel");
+	});
+
+	test("filters out a flow result when only `followup` is enabled", () => {
+		const config: { origins: SuggestionOrigin[] } = { origins: ["followup"] };
+		render({ messages: [], status: "streaming", config });
+
+		const turnMessages: Msg[] = [
+			userMessage("Which plan?"),
+			assistantMessageWithFlowSuggestions(["Bronze", "Silver", "Gold"]),
+		];
+		render({ messages: turnMessages, status: "ready", config });
+
+		expect(hookRef.current?.suggestions).toEqual([]);
+		expect(hookRef.current?.source).toBe("channel");
 	});
 });

--- a/src/chat/web/hooks/__tests__/use-suggestions.test.tsx
+++ b/src/chat/web/hooks/__tests__/use-suggestions.test.tsx
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+
+// ---------------------------------------------------------------------------
+// Minimal DOM globals so react-dom/client can mount a hook harness. Unlike
+// `use-chat-engine.test.tsx`, `useSuggestions` has no dependency on
+// `@ai-sdk/react`, IndexedDB, or the transport layer, so none of that mocking
+// is needed here — just enough DOM for `createRoot` + `act`.
+// ---------------------------------------------------------------------------
+
+const win = new Window({ url: "https://localhost" });
+for (const key of [
+	"document",
+	"navigator",
+	"HTMLElement",
+	"HTMLDivElement",
+	"MutationObserver",
+	"customElements",
+	"Element",
+	"Node",
+	"Text",
+	"Comment",
+	"DocumentFragment",
+	"Event",
+	"CustomEvent",
+	"requestAnimationFrame",
+	"cancelAnimationFrame",
+	"getComputedStyle",
+] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any)[key] = (win as any)[key];
+}
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).window = win;
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { act, createElement } = await import("react");
+const { createRoot } = await import("react-dom/client");
+type Root = ReturnType<typeof createRoot>;
+
+const { useSuggestions } = await import("../use-suggestions");
+type UseSuggestionsOptions = Parameters<typeof useSuggestions>[0];
+type UseSuggestionsReturn = ReturnType<typeof useSuggestions>;
+
+const { SUGGESTIONS_META_KEY } = await import("../../../../shared/meta-keys");
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function Harness({
+	resultRef,
+	options,
+}: {
+	resultRef: { current: UseSuggestionsReturn | null };
+	options: UseSuggestionsOptions;
+}) {
+	resultRef.current = useSuggestions(options);
+	return null;
+}
+
+let root: Root;
+let container: HTMLElement;
+let hookRef: { current: UseSuggestionsReturn | null };
+
+function render(options: UseSuggestionsOptions) {
+	act(() => {
+		root.render(createElement(Harness, { resultRef: hookRef, options }));
+	});
+}
+
+beforeEach(() => {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	hookRef = { current: null };
+});
+
+afterEach(() => {
+	act(() => {
+		root.unmount();
+	});
+	container.remove();
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function userMessage(text: string) {
+	return { id: "u1", role: "user", parts: [{ type: "text", text }] };
+}
+
+/** An assistant message carrying flow-driven suggestion pills. */
+function assistantMessageWithFlowSuggestions(suggestions: string[]) {
+	return {
+		id: "a1",
+		role: "assistant",
+		parts: [
+			{
+				type: "tool-my_flow",
+				toolCallId: "call-1",
+				state: "output-available",
+				output: {
+					content: [{ type: "text", text: "{}" }],
+					_meta: { [SUGGESTIONS_META_KEY]: { suggestions } },
+				},
+			},
+		],
+	};
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: fixtures stand in for `UIMessage`
+type Msg = any;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useSuggestions — conversation reset clears stale pills", () => {
+	test("clears flow-driven pills once messages go back to empty, with no `initial` configured", () => {
+		// Mount mid-flight so the streaming -> ready transition below fires the
+		// hook's recompute effect.
+		render({ messages: [], status: "streaming" });
+
+		const turnMessages: Msg[] = [
+			userMessage("Which plan?"),
+			assistantMessageWithFlowSuggestions(["Bronze", "Silver", "Gold"]),
+		];
+		render({ messages: turnMessages, status: "ready" });
+
+		expect(hookRef.current?.suggestions).toEqual(["Bronze", "Silver", "Gold"]);
+
+		// Simulate `reset()` / `startNewThread()`: messages go back to empty
+		// while status stays "ready". No `initial` was ever configured — this
+		// is the common case, since dynamic pills are enabled by default.
+		render({ messages: [], status: "ready" });
+
+		expect(hookRef.current?.suggestions).toEqual([]);
+		expect(hookRef.current?.source).toBe("initial");
+	});
+
+	test("resets to the configured `initial` pills (not last flow pills) once messages go back to empty", () => {
+		render({
+			messages: [],
+			status: "streaming",
+			config: { initial: ["Book a demo"] },
+		});
+
+		const turnMessages: Msg[] = [
+			userMessage("Which plan?"),
+			assistantMessageWithFlowSuggestions(["Bronze", "Silver", "Gold"]),
+		];
+		render({
+			messages: turnMessages,
+			status: "ready",
+			config: { initial: ["Book a demo"] },
+		});
+
+		expect(hookRef.current?.suggestions).toEqual(["Bronze", "Silver", "Gold"]);
+		expect(hookRef.current?.source).toBe("flow");
+
+		render({
+			messages: [],
+			status: "ready",
+			config: { initial: ["Book a demo"] },
+		});
+
+		expect(hookRef.current?.suggestions).toEqual(["Book a demo"]);
+		expect(hookRef.current?.source).toBe("initial");
+	});
+});

--- a/src/chat/web/hooks/__tests__/use-suggestions.test.tsx
+++ b/src/chat/web/hooks/__tests__/use-suggestions.test.tsx
@@ -111,6 +111,21 @@ function assistantMessageWithFlowSuggestions(suggestions: string[]) {
 	};
 }
 
+/** An assistant message carrying a streamed `data-suggestions` part. */
+function assistantMessageWithStreamedSuggestions(
+	suggestions: string[],
+	id = "a-streamed",
+) {
+	return {
+		id,
+		role: "assistant",
+		parts: [
+			{ type: "text", text: "Here you go." },
+			{ type: "data-suggestions", data: { suggestions } },
+		],
+	};
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: fixtures stand in for `UIMessage`
 type Msg = any;
 
@@ -121,21 +136,25 @@ type Msg = any;
 describe("useSuggestions — conversation reset clears stale pills", () => {
 	test("clears flow-driven pills once messages go back to empty, with no `initial` configured", () => {
 		// Mount mid-flight so the streaming -> ready transition below fires the
-		// hook's recompute effect.
-		render({ messages: [], status: "streaming" });
+		// hook's recompute effect. Flow pills are opt-in, so the host passes
+		// `dynamic: true`.
+		render({ messages: [], status: "streaming", config: { dynamic: true } });
 
 		const turnMessages: Msg[] = [
 			userMessage("Which plan?"),
 			assistantMessageWithFlowSuggestions(["Bronze", "Silver", "Gold"]),
 		];
-		render({ messages: turnMessages, status: "ready" });
+		render({
+			messages: turnMessages,
+			status: "ready",
+			config: { dynamic: true },
+		});
 
 		expect(hookRef.current?.suggestions).toEqual(["Bronze", "Silver", "Gold"]);
 
 		// Simulate `reset()` / `startNewThread()`: messages go back to empty
-		// while status stays "ready". No `initial` was ever configured — this
-		// is the common case, since dynamic pills are enabled by default.
-		render({ messages: [], status: "ready" });
+		// while status stays "ready". No `initial` was ever configured.
+		render({ messages: [], status: "ready", config: { dynamic: true } });
 
 		expect(hookRef.current?.suggestions).toEqual([]);
 		expect(hookRef.current?.source).toBe("initial");
@@ -145,7 +164,7 @@ describe("useSuggestions — conversation reset clears stale pills", () => {
 		render({
 			messages: [],
 			status: "streaming",
-			config: { initial: ["Book a demo"] },
+			config: { initial: ["Book a demo"], dynamic: true },
 		});
 
 		const turnMessages: Msg[] = [
@@ -155,7 +174,7 @@ describe("useSuggestions — conversation reset clears stale pills", () => {
 		render({
 			messages: turnMessages,
 			status: "ready",
-			config: { initial: ["Book a demo"] },
+			config: { initial: ["Book a demo"], dynamic: true },
 		});
 
 		expect(hookRef.current?.suggestions).toEqual(["Bronze", "Silver", "Gold"]);
@@ -164,10 +183,60 @@ describe("useSuggestions — conversation reset clears stale pills", () => {
 		render({
 			messages: [],
 			status: "ready",
-			config: { initial: ["Book a demo"] },
+			config: { initial: ["Book a demo"], dynamic: true },
 		});
 
 		expect(hookRef.current?.suggestions).toEqual(["Book a demo"]);
+		expect(hookRef.current?.source).toBe("initial");
+	});
+});
+
+describe("useSuggestions — flow pills are opt-in", () => {
+	test("renders no pills from a flow `_meta` entry when no config is passed", () => {
+		render({ messages: [], status: "streaming" });
+
+		const turnMessages: Msg[] = [
+			userMessage("Which plan?"),
+			assistantMessageWithFlowSuggestions(["Bronze", "Silver", "Gold"]),
+		];
+		render({ messages: turnMessages, status: "ready" });
+
+		expect(hookRef.current?.suggestions).toEqual([]);
+		expect(hookRef.current?.source).toBe("initial");
+	});
+
+	test("with only `initial` configured, streamed pills render while flow pills do not", () => {
+		const config = { initial: ["Hi"] };
+		render({ messages: [], status: "streaming", config });
+
+		const streamedTurn: Msg[] = [
+			userMessage("Anything else?"),
+			assistantMessageWithStreamedSuggestions(["From", "Stream"]),
+		];
+		render({ messages: streamedTurn, status: "ready", config });
+
+		expect(hookRef.current?.suggestions).toEqual(["From", "Stream"]);
+		expect(hookRef.current?.source).toBe("initial");
+
+		const secondUser: Msg = {
+			id: "u2",
+			role: "user",
+			parts: [{ type: "text", text: "Which plan?" }],
+		};
+		render({
+			messages: [...streamedTurn, secondUser],
+			status: "streaming",
+			config,
+		});
+
+		const flowTurn: Msg[] = [
+			...streamedTurn,
+			secondUser,
+			assistantMessageWithFlowSuggestions(["Bronze", "Silver", "Gold"]),
+		];
+		render({ messages: flowTurn, status: "ready", config });
+
+		expect(hookRef.current?.suggestions).toEqual([]);
 		expect(hookRef.current?.source).toBe("initial");
 	});
 });

--- a/src/chat/web/hooks/turn-suggestions.ts
+++ b/src/chat/web/hooks/turn-suggestions.ts
@@ -102,12 +102,17 @@ function extractStreamedSuggestions(message: UIMessage): string[] | null {
  * streamed data part, which is reachable only from a self-hosted chat backend
  * and is therefore attributed like operator-authored config.
  *
+ * When `includeFlow` is `false`, the flow's `_meta` entries are ignored
+ * entirely and only the streamed `data-suggestions` part is considered.
+ *
  * @returns the pills and their origin, or `null` when the turn carried none.
  */
 export function resolveTurnSuggestions(
 	message: UIMessage,
+	options: { includeFlow?: boolean } = {},
 ): TurnSuggestions | null {
-	const fromFlow = extractFlowSuggestions(message);
+	const { includeFlow = true } = options;
+	const fromFlow = includeFlow ? extractFlowSuggestions(message) : null;
 	if (fromFlow) {
 		return { suggestions: fromFlow, source: "flow" };
 	}

--- a/src/chat/web/hooks/turn-suggestions.ts
+++ b/src/chat/web/hooks/turn-suggestions.ts
@@ -2,11 +2,11 @@ import type { UIMessage } from "ai";
 import { SUGGESTIONS_META_KEY } from "../../../shared/meta-keys";
 
 /** Where the pills currently on screen came from. */
-export type SuggestionsSource = "flow" | "initial";
+export type TurnSuggestionsSource = "flow" | "streamed";
 
 export type TurnSuggestions = {
 	suggestions: string[];
-	source: SuggestionsSource;
+	source: TurnSuggestionsSource;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -20,36 +20,53 @@ function isStringArray(value: unknown): value is string[] {
 }
 
 /**
+ * Read a well-formed `waniwani/suggestions` entry off a tool part's `_meta`,
+ * or `null` when the part carries no flow result or a malformed one.
+ * Malformed entries (non-array `suggestions`, non-string items, a non-object
+ * `_meta` entry) are never authoritative — they are garbage, not a clear.
+ */
+function readSuggestionsEntry(part: unknown): string[] | null {
+	if (!isRecord(part) || !("toolCallId" in part) || !("output" in part)) {
+		return null;
+	}
+	const output = part.output;
+	if (!isRecord(output) || !isRecord(output._meta)) {
+		return null;
+	}
+	const entry = output._meta[SUGGESTIONS_META_KEY];
+	if (!isRecord(entry) || !isStringArray(entry.suggestions)) {
+		return null;
+	}
+	return entry.suggestions;
+}
+
+/**
  * Read the suggestion pills the flow engine attached to a tool result.
  *
- * Tool parts are identified the way the renderer identifies them — by the
- * presence of `toolCallId` and `output` — rather than by a `tool-*` type
- * string, so this survives AI SDK part-type renames.
+ * Every flow tool result carries the `waniwani/suggestions` key — an empty
+ * array means "no pills for this step". Tool parts are identified the way
+ * the renderer identifies them — by the presence of `toolCallId` and
+ * `output` — rather than by a `tool-*` type string, so this survives AI SDK
+ * part-type renames. Non-flow tool parts (e.g. a KB search) carry no key at
+ * all and are skipped, leaving whatever the last flow part decided in place.
  *
  * A single turn can call the flow more than once (a `continue` that advances
- * through an action node into the next interrupt), so the last result wins:
- * it describes the step the visitor is now on.
+ * through an action node into the next interrupt), so the last well-formed
+ * flow entry wins — including an empty one — since it describes the step
+ * the visitor is now on.
  *
- * @returns the suggestions, or `null` when this turn carried none.
+ * @returns the suggestions, or `null` when the last flow entry was empty (or
+ * no part carried the key at all).
  */
 export function extractFlowSuggestions(message: UIMessage): string[] | null {
 	let found: string[] | null = null;
 
 	for (const part of message.parts) {
-		if (!isRecord(part) || !("toolCallId" in part) || !("output" in part)) {
+		const suggestions = readSuggestionsEntry(part);
+		if (suggestions === null) {
 			continue;
 		}
-		const output = part.output;
-		if (!isRecord(output) || !isRecord(output._meta)) {
-			continue;
-		}
-		const entry = output._meta[SUGGESTIONS_META_KEY];
-		if (!isRecord(entry)) {
-			continue;
-		}
-		if (isStringArray(entry.suggestions) && entry.suggestions.length > 0) {
-			found = entry.suggestions;
-		}
+		found = suggestions.length > 0 ? suggestions : null;
 	}
 
 	return found;
@@ -97,7 +114,7 @@ export function resolveTurnSuggestions(
 
 	const streamed = extractStreamedSuggestions(message);
 	if (streamed) {
-		return { suggestions: streamed, source: "initial" };
+		return { suggestions: streamed, source: "streamed" };
 	}
 
 	return null;

--- a/src/chat/web/hooks/turn-suggestions.ts
+++ b/src/chat/web/hooks/turn-suggestions.ts
@@ -1,12 +1,10 @@
 import type { UIMessage } from "ai";
 import { SUGGESTIONS_META_KEY } from "../../../shared/meta-keys";
-
-/** Where the pills currently on screen came from. */
-export type TurnSuggestionOrigin = "flow" | "streamed";
+import type { SuggestionOrigin } from "../@types";
 
 export type TurnSuggestions = {
 	suggestions: string[];
-	source: TurnSuggestionOrigin;
+	source: SuggestionOrigin;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -77,7 +75,7 @@ export function extractFlowSuggestions(message: UIMessage): string[] | null {
  * `{ type: "data-suggestions", data: { suggestions: string[] } }`.
  * Only a bring-your-own-backend host emits this; the Waniwani chat API does not.
  */
-function extractStreamedSuggestions(message: UIMessage): string[] | null {
+function extractFollowupSuggestions(message: UIMessage): string[] | null {
 	for (const part of message.parts) {
 		if (!isRecord(part)) {
 			continue;
@@ -100,7 +98,7 @@ function extractStreamedSuggestions(message: UIMessage): string[] | null {
 /**
  * Resolve the pills for a completed turn. Flow-driven suggestions win over the
  * streamed data part, which is reachable only from a self-hosted chat backend
- * and is therefore attributed like operator-authored config.
+ * and is therefore attributed as a generated follow-up.
  *
  * When `includeFlow` is `false`, the flow's `_meta` entries are ignored
  * entirely and only the streamed `data-suggestions` part is considered.
@@ -117,9 +115,9 @@ export function resolveTurnSuggestions(
 		return { suggestions: fromFlow, source: "flow" };
 	}
 
-	const streamed = extractStreamedSuggestions(message);
-	if (streamed) {
-		return { suggestions: streamed, source: "streamed" };
+	const followup = extractFollowupSuggestions(message);
+	if (followup) {
+		return { suggestions: followup, source: "followup" };
 	}
 
 	return null;

--- a/src/chat/web/hooks/turn-suggestions.ts
+++ b/src/chat/web/hooks/turn-suggestions.ts
@@ -1,0 +1,104 @@
+import type { UIMessage } from "ai";
+import { SUGGESTIONS_META_KEY } from "../../../shared/meta-keys";
+
+/** Where the pills currently on screen came from. */
+export type SuggestionsSource = "flow" | "initial";
+
+export type TurnSuggestions = {
+	suggestions: string[];
+	source: SuggestionsSource;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return (
+		Array.isArray(value) && value.every((item) => typeof item === "string")
+	);
+}
+
+/**
+ * Read the suggestion pills the flow engine attached to a tool result.
+ *
+ * Tool parts are identified the way the renderer identifies them — by the
+ * presence of `toolCallId` and `output` — rather than by a `tool-*` type
+ * string, so this survives AI SDK part-type renames.
+ *
+ * A single turn can call the flow more than once (a `continue` that advances
+ * through an action node into the next interrupt), so the last result wins:
+ * it describes the step the visitor is now on.
+ *
+ * @returns the suggestions, or `null` when this turn carried none.
+ */
+export function extractFlowSuggestions(message: UIMessage): string[] | null {
+	let found: string[] | null = null;
+
+	for (const part of message.parts) {
+		if (!isRecord(part) || !("toolCallId" in part) || !("output" in part)) {
+			continue;
+		}
+		const output = part.output;
+		if (!isRecord(output) || !isRecord(output._meta)) {
+			continue;
+		}
+		const entry = output._meta[SUGGESTIONS_META_KEY];
+		if (!isRecord(entry)) {
+			continue;
+		}
+		if (isStringArray(entry.suggestions) && entry.suggestions.length > 0) {
+			found = entry.suggestions;
+		}
+	}
+
+	return found;
+}
+
+/**
+ * Read suggestions from a streamed data part:
+ * `{ type: "data-suggestions", data: { suggestions: string[] } }`.
+ * Only a bring-your-own-backend host emits this; the Waniwani chat API does not.
+ */
+function extractStreamedSuggestions(message: UIMessage): string[] | null {
+	for (const part of message.parts) {
+		if (!isRecord(part)) {
+			continue;
+		}
+		if (part.type !== "data-suggestions") {
+			continue;
+		}
+		const data = part.data;
+		if (
+			isRecord(data) &&
+			isStringArray(data.suggestions) &&
+			data.suggestions.length > 0
+		) {
+			return data.suggestions;
+		}
+	}
+	return null;
+}
+
+/**
+ * Resolve the pills for a completed turn. Flow-driven suggestions win over the
+ * streamed data part, which is reachable only from a self-hosted chat backend
+ * and is therefore attributed like operator-authored config.
+ *
+ * @returns the pills and their origin, or `null` when the turn carried none.
+ */
+export function resolveTurnSuggestions(
+	message: UIMessage,
+): TurnSuggestions | null {
+	const fromFlow = extractFlowSuggestions(message);
+	if (fromFlow) {
+		return { suggestions: fromFlow, source: "flow" };
+	}
+
+	const streamed = extractStreamedSuggestions(message);
+	if (streamed) {
+		return { suggestions: streamed, source: "initial" };
+	}
+
+	return null;
+}

--- a/src/chat/web/hooks/turn-suggestions.ts
+++ b/src/chat/web/hooks/turn-suggestions.ts
@@ -2,11 +2,11 @@ import type { UIMessage } from "ai";
 import { SUGGESTIONS_META_KEY } from "../../../shared/meta-keys";
 
 /** Where the pills currently on screen came from. */
-export type TurnSuggestionsSource = "flow" | "streamed";
+export type TurnSuggestionOrigin = "flow" | "streamed";
 
 export type TurnSuggestions = {
 	suggestions: string[];
-	source: TurnSuggestionsSource;
+	source: TurnSuggestionOrigin;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/chat/web/hooks/use-suggestions.ts
+++ b/src/chat/web/hooks/use-suggestions.ts
@@ -21,27 +21,36 @@ function isConfigObject(
 }
 
 /**
- * Whether per-turn suggestions may render.
- *
- * Enabled unless the host explicitly turns them off, so a channel with no
- * configured starter prompts still shows the pills a flow drives. Writing
- * `suggestions` in a flow is itself the opt-in — nothing renders otherwise.
+ * Whether per-turn suggestion recomputation runs at all (the streamed
+ * `data-suggestions` path). Enabled when the host passes `true` or any config
+ * object not setting `dynamic: false`.
  */
 export function isDynamicSuggestionsEnabled(
 	config: boolean | SuggestionsConfig | undefined,
 ): boolean {
-	if (config === false) {
-		return false;
-	}
-	return !(isConfigObject(config) && config.dynamic === false);
+	return (
+		config === true || (isConfigObject(config) && config.dynamic !== false)
+	);
+}
+
+/**
+ * Whether flow-driven pills (a flow's `interrupt({ suggestions })`) may
+ * render. Opt-in: the host must pass `suggestions={true}` or an object with
+ * `dynamic: true`. Streamed `data-suggestions` parts are governed by
+ * `isDynamicSuggestionsEnabled` instead and keep working without this.
+ */
+export function isFlowSuggestionsEnabled(
+	config: boolean | SuggestionsConfig | undefined,
+): boolean {
+	return config === true || (isConfigObject(config) && config.dynamic === true);
 }
 
 /**
  * Map host-level config fields — `suggestions` (starter prompts) and
- * `dynamicSuggestions` (flow-pill opt-out) — to the `SuggestionsConfig`
+ * `dynamicSuggestions` (flow-pill opt-in) — to the `SuggestionsConfig`
  * consumed by `useSuggestions`. Every mount point (WaniwaniChat, the inline
  * and floating script embeds) must build its `ChatEmbed` suggestions prop
- * through this helper so the opt-out is never silently dropped.
+ * through this helper so the opt-in is never silently dropped.
  */
 export function toSuggestionsConfig(options: {
 	suggestions?: string[];
@@ -65,6 +74,7 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 	const prevStatusRef = useRef<ChatStatus>(status);
 
 	const isDynamicEnabled = isDynamicSuggestionsEnabled(config);
+	const isFlowEnabled = isFlowSuggestionsEnabled(config);
 
 	const clear = useCallback(() => {
 		setSuggestions([]);
@@ -108,13 +118,15 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 				return;
 			}
 
-			const resolved = resolveTurnSuggestions(lastAssistant);
+			const resolved = resolveTurnSuggestions(lastAssistant, {
+				includeFlow: isFlowEnabled,
+			});
 			setSuggestions(resolved?.suggestions ?? []);
 			// A streamed data part is reachable only from a self-hosted backend, so
 			// it is attributed alongside operator-authored prompts, not the flow.
 			setSource(resolved?.source === "flow" ? "flow" : "initial");
 		}
-	}, [status, isDynamicEnabled, messages]);
+	}, [status, isDynamicEnabled, isFlowEnabled, messages]);
 
 	return { suggestions, source, isLoading: false, clear };
 }

--- a/src/chat/web/hooks/use-suggestions.ts
+++ b/src/chat/web/hooks/use-suggestions.ts
@@ -3,6 +3,7 @@
 import type { ChatStatus, UIMessage } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SuggestionOrigin, SuggestionsConfig } from "../@types";
+import { SUGGESTION_ORIGINS } from "../@types";
 import { resolveTurnSuggestions } from "./turn-suggestions";
 
 export interface UseSuggestionsOptions {
@@ -28,13 +29,6 @@ export const DEFAULT_SUGGESTION_ORIGINS: readonly SuggestionOrigin[] = [
 	"followup",
 ];
 
-const ALL_SUGGESTION_ORIGINS: readonly SuggestionOrigin[] = [
-	"channel",
-	"page",
-	"flow",
-	"followup",
-];
-
 /**
  * Resolve which origins may fill the pill row for a given host config.
  *
@@ -50,14 +44,14 @@ export function resolveSuggestionOrigins(
 		return [];
 	}
 	if (config === true) {
-		return [...ALL_SUGGESTION_ORIGINS];
+		return [...SUGGESTION_ORIGINS];
 	}
 	if (isConfigObject(config)) {
 		if (config.origins !== undefined) {
 			return config.origins;
 		}
 		if (config.dynamic === true) {
-			return [...ALL_SUGGESTION_ORIGINS];
+			return [...SUGGESTION_ORIGINS];
 		}
 		if (config.dynamic === false) {
 			return [];

--- a/src/chat/web/hooks/use-suggestions.ts
+++ b/src/chat/web/hooks/use-suggestions.ts
@@ -52,13 +52,17 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 		setSuggestions([]);
 	}, []);
 
-	// Sync initial suggestions when the remote config arrives post-mount.
-	// Only applied while the conversation is empty; once the user has sent
-	// a message, suggestions are driven by streaming responses (or cleared).
+	// Sync initial suggestions when the remote config arrives post-mount, and
+	// clear whatever is on screen whenever the conversation goes back to
+	// empty — a `reset()` or `startNewThread()` clears `messages` without
+	// unmounting this hook, and a flow's pills from the previous conversation
+	// must not survive into the new one (they'd otherwise stay clickable and
+	// misattribute a click as `source: "flow"` for a flow that was never
+	// invoked in this conversation).
 	const hasMessages = messages.length > 0;
 	useEffect(() => {
-		if (!hasMessages && initial && initial.length > 0) {
-			setSuggestions(initial);
+		if (!hasMessages) {
+			setSuggestions(initial ?? []);
 			setSource("initial");
 		}
 	}, [initial, hasMessages]);

--- a/src/chat/web/hooks/use-suggestions.ts
+++ b/src/chat/web/hooks/use-suggestions.ts
@@ -2,7 +2,7 @@
 
 import type { ChatStatus, UIMessage } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { SuggestionsConfig } from "../@types";
+import type { SuggestionOrigin, SuggestionsConfig } from "../@types";
 import { resolveTurnSuggestions } from "./turn-suggestions";
 
 export interface UseSuggestionsOptions {
@@ -11,9 +11,6 @@ export interface UseSuggestionsOptions {
 	config?: boolean | SuggestionsConfig;
 }
 
-/** Which pill row the visitor is looking at. */
-export type SuggestionsSource = "flow" | "initial";
-
 function isConfigObject(
 	config: boolean | SuggestionsConfig | undefined,
 ): config is SuggestionsConfig {
@@ -21,46 +18,79 @@ function isConfigObject(
 }
 
 /**
- * Whether per-turn suggestion recomputation runs at all (the streamed
- * `data-suggestions` path). Enabled when the host passes `true` or any config
- * object not setting `dynamic: false`.
+ * Default origins allowed to fill the pill row when the host passes no
+ * config at all: starter prompts and generated follow-ups render, flow-driven
+ * pills stay opt-in.
  */
-export function isDynamicSuggestionsEnabled(
-	config: boolean | SuggestionsConfig | undefined,
-): boolean {
-	return (
-		config === true || (isConfigObject(config) && config.dynamic !== false)
-	);
-}
+export const DEFAULT_SUGGESTION_ORIGINS: readonly SuggestionOrigin[] = [
+	"channel",
+	"page",
+	"followup",
+];
+
+const ALL_SUGGESTION_ORIGINS: readonly SuggestionOrigin[] = [
+	"channel",
+	"page",
+	"flow",
+	"followup",
+];
 
 /**
- * Whether flow-driven pills (a flow's `interrupt({ suggestions })`) may
- * render. Opt-in: the host must pass `suggestions={true}` or an object with
- * `dynamic: true`. Streamed `data-suggestions` parts are governed by
- * `isDynamicSuggestionsEnabled` instead and keep working without this.
+ * Resolve which origins may fill the pill row for a given host config.
+ *
+ * Priority: `false` → none; `true` → every origin; an object's `origins`
+ * (when present, even empty) wins outright; otherwise the legacy `dynamic`
+ * boolean (`true` → every origin, `false` → none); anything else (including
+ * `undefined`) falls back to {@link DEFAULT_SUGGESTION_ORIGINS}.
  */
-export function isFlowSuggestionsEnabled(
+export function resolveSuggestionOrigins(
 	config: boolean | SuggestionsConfig | undefined,
+): SuggestionOrigin[] {
+	if (config === false) {
+		return [];
+	}
+	if (config === true) {
+		return [...ALL_SUGGESTION_ORIGINS];
+	}
+	if (isConfigObject(config)) {
+		if (config.origins !== undefined) {
+			return config.origins;
+		}
+		if (config.dynamic === true) {
+			return [...ALL_SUGGESTION_ORIGINS];
+		}
+		if (config.dynamic === false) {
+			return [];
+		}
+	}
+	return [...DEFAULT_SUGGESTION_ORIGINS];
+}
+
+/** Whether a given origin may fill the pill row for a given host config. */
+export function isOriginEnabled(
+	config: boolean | SuggestionsConfig | undefined,
+	origin: SuggestionOrigin,
 ): boolean {
-	return config === true || (isConfigObject(config) && config.dynamic === true);
+	return resolveSuggestionOrigins(config).includes(origin);
 }
 
 /**
  * Map host-level config fields — `suggestions` (starter prompts) and
- * `flowSuggestions` (flow-pill opt-in) — to the `SuggestionsConfig`
- * consumed by `useSuggestions`. Every mount point (WaniwaniChat, the inline
- * and floating script embeds) must build its `ChatEmbed` suggestions prop
- * through this helper so the opt-in is never silently dropped.
+ * `suggestionOrigins` (which providers may fill the per-turn pill row) — to
+ * the `SuggestionsConfig` consumed by `useSuggestions`. Every mount point
+ * (WaniwaniChat, the inline and floating script embeds) must build its
+ * `ChatEmbed` suggestions prop through this helper so the origin config is
+ * never silently dropped.
  */
 export function toSuggestionsConfig(options: {
 	suggestions?: string[];
-	flowSuggestions?: boolean;
+	suggestionOrigins?: SuggestionOrigin[];
 }): SuggestionsConfig | undefined {
-	const { suggestions, flowSuggestions } = options;
-	if (!suggestions && flowSuggestions === undefined) {
+	const { suggestions, suggestionOrigins } = options;
+	if (!suggestions && suggestionOrigins === undefined) {
 		return undefined;
 	}
-	return { initial: suggestions, dynamic: flowSuggestions };
+	return { initial: suggestions, origins: suggestionOrigins };
 }
 
 export function useSuggestions(options: UseSuggestionsOptions) {
@@ -70,11 +100,12 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 		isConfigObject(config) && config.initial ? config.initial : undefined;
 
 	const [suggestions, setSuggestions] = useState<string[]>(initial ?? []);
-	const [source, setSource] = useState<SuggestionsSource>("initial");
+	const [source, setSource] = useState<SuggestionOrigin>("channel");
 	const prevStatusRef = useRef<ChatStatus>(status);
 
-	const isDynamicEnabled = isDynamicSuggestionsEnabled(config);
-	const isFlowEnabled = isFlowSuggestionsEnabled(config);
+	const origins = resolveSuggestionOrigins(config);
+	const isFlowEnabled = origins.includes("flow");
+	const isFollowupEnabled = origins.includes("followup");
 
 	const clear = useCallback(() => {
 		setSuggestions([]);
@@ -85,13 +116,13 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 	// empty — a `reset()` or `startNewThread()` clears `messages` without
 	// unmounting this hook, and a flow's pills from the previous conversation
 	// must not survive into the new one (they'd otherwise stay clickable and
-	// misattribute a click as `source: "flow"` for a flow that was never
+	// misattribute a click as origin `"flow"` for a flow that was never
 	// invoked in this conversation).
 	const hasMessages = messages.length > 0;
 	useEffect(() => {
 		if (!hasMessages) {
 			setSuggestions(initial ?? []);
-			setSource("initial");
+			setSource("channel");
 		}
 	}, [initial, hasMessages]);
 
@@ -110,7 +141,11 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 		const prevStatus = prevStatusRef.current;
 		prevStatusRef.current = status;
 
-		if (prevStatus === "streaming" && status === "ready" && isDynamicEnabled) {
+		if (
+			prevStatus === "streaming" &&
+			status === "ready" &&
+			(isFlowEnabled || isFollowupEnabled)
+		) {
 			const lastAssistant = [...messages]
 				.reverse()
 				.find((m) => m.role === "assistant");
@@ -121,12 +156,16 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 			const resolved = resolveTurnSuggestions(lastAssistant, {
 				includeFlow: isFlowEnabled,
 			});
-			setSuggestions(resolved?.suggestions ?? []);
-			// A streamed data part is reachable only from a self-hosted backend, so
-			// it is attributed alongside operator-authored prompts, not the flow.
-			setSource(resolved?.source === "flow" ? "flow" : "initial");
+			// A resolved origin not enabled for this host (e.g. a flow result
+			// when only `followup` is enabled) is treated as no suggestions.
+			const enabled =
+				resolved &&
+				((resolved.source === "flow" && isFlowEnabled) ||
+					(resolved.source === "followup" && isFollowupEnabled));
+			setSuggestions(enabled ? resolved.suggestions : []);
+			setSource(enabled ? resolved.source : "channel");
 		}
-	}, [status, isDynamicEnabled, isFlowEnabled, messages]);
+	}, [status, isFlowEnabled, isFollowupEnabled, messages]);
 
 	return { suggestions, source, isLoading: false, clear };
 }

--- a/src/chat/web/hooks/use-suggestions.ts
+++ b/src/chat/web/hooks/use-suggestions.ts
@@ -3,6 +3,7 @@
 import type { ChatStatus, UIMessage } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SuggestionsConfig } from "../@types";
+import { resolveTurnSuggestions } from "./turn-suggestions";
 
 export interface UseSuggestionsOptions {
 	messages: UIMessage[];
@@ -10,29 +11,29 @@ export interface UseSuggestionsOptions {
 	config?: boolean | SuggestionsConfig;
 }
 
-/**
- * Extract suggestions from the last assistant message's data part.
- * The API streams a `data-suggestions` part at the end of the response:
- * `{ type: "data-suggestions", data: { suggestions: string[] } }`
- */
-function extractSuggestions(message: UIMessage): string[] | null {
-	for (const part of message.parts) {
-		const p = part as Record<string, unknown>;
-		// Handle both "data-suggestions" and generic "data" part types
-		if (p.type === "data" || p.type === "data-suggestions") {
-			const data = p.data as Record<string, unknown> | undefined;
-			if (data && Array.isArray(data.suggestions)) {
-				return data.suggestions as string[];
-			}
-		}
-	}
-	return null;
-}
+/** Which pill row the visitor is looking at. */
+export type SuggestionsSource = "flow" | "initial";
 
 function isConfigObject(
 	config: boolean | SuggestionsConfig | undefined,
 ): config is SuggestionsConfig {
 	return typeof config === "object" && config !== null && "initial" in config;
+}
+
+/**
+ * Whether per-turn suggestions may render.
+ *
+ * Enabled unless the host explicitly turns them off, so a channel with no
+ * configured starter prompts still shows the pills a flow drives. Writing
+ * `suggestions` in a flow is itself the opt-in — nothing renders otherwise.
+ */
+export function isDynamicSuggestionsEnabled(
+	config: boolean | SuggestionsConfig | undefined,
+): boolean {
+	if (config === false) {
+		return false;
+	}
+	return !(isConfigObject(config) && config.dynamic === false);
 }
 
 export function useSuggestions(options: UseSuggestionsOptions) {
@@ -42,10 +43,10 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 		isConfigObject(config) && config.initial ? config.initial : undefined;
 
 	const [suggestions, setSuggestions] = useState<string[]>(initial ?? []);
+	const [source, setSource] = useState<SuggestionsSource>("initial");
 	const prevStatusRef = useRef<ChatStatus>(status);
 
-	const isDynamicEnabled =
-		config === true || (isConfigObject(config) && config.dynamic !== false);
+	const isDynamicEnabled = isDynamicSuggestionsEnabled(config);
 
 	const clear = useCallback(() => {
 		setSuggestions([]);
@@ -58,6 +59,7 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 	useEffect(() => {
 		if (!hasMessages && initial && initial.length > 0) {
 			setSuggestions(initial);
+			setSource("initial");
 		}
 	}, [initial, hasMessages]);
 
@@ -69,7 +71,9 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 		}
 	}, [lastMessage, clear]);
 
-	// Extract suggestions from message parts on streaming -> ready transition
+	// Recompute on every streaming -> ready transition. The pills always
+	// describe the reply the visitor just received, so a turn that carries no
+	// suggestions clears the row rather than leaving stale options on screen.
 	useEffect(() => {
 		const prevStatus = prevStatusRef.current;
 		prevStatusRef.current = status;
@@ -82,12 +86,13 @@ export function useSuggestions(options: UseSuggestionsOptions) {
 				return;
 			}
 
-			const extracted = extractSuggestions(lastAssistant);
-			if (extracted) {
-				setSuggestions(extracted);
-			}
+			const resolved = resolveTurnSuggestions(lastAssistant);
+			setSuggestions(resolved?.suggestions ?? []);
+			// A streamed data part is reachable only from a self-hosted backend, so
+			// it is attributed alongside operator-authored prompts, not the flow.
+			setSource(resolved?.source === "flow" ? "flow" : "initial");
 		}
 	}, [status, isDynamicEnabled, messages]);
 
-	return { suggestions, isLoading: false, clear };
+	return { suggestions, source, isLoading: false, clear };
 }

--- a/src/chat/web/hooks/use-suggestions.ts
+++ b/src/chat/web/hooks/use-suggestions.ts
@@ -17,7 +17,7 @@ export type SuggestionsSource = "flow" | "initial";
 function isConfigObject(
 	config: boolean | SuggestionsConfig | undefined,
 ): config is SuggestionsConfig {
-	return typeof config === "object" && config !== null && "initial" in config;
+	return typeof config === "object" && config !== null;
 }
 
 /**
@@ -34,6 +34,24 @@ export function isDynamicSuggestionsEnabled(
 		return false;
 	}
 	return !(isConfigObject(config) && config.dynamic === false);
+}
+
+/**
+ * Map host-level config fields — `suggestions` (starter prompts) and
+ * `dynamicSuggestions` (flow-pill opt-out) — to the `SuggestionsConfig`
+ * consumed by `useSuggestions`. Every mount point (WaniwaniChat, the inline
+ * and floating script embeds) must build its `ChatEmbed` suggestions prop
+ * through this helper so the opt-out is never silently dropped.
+ */
+export function toSuggestionsConfig(options: {
+	suggestions?: string[];
+	dynamicSuggestions?: boolean;
+}): SuggestionsConfig | undefined {
+	const { suggestions, dynamicSuggestions } = options;
+	if (!suggestions && dynamicSuggestions === undefined) {
+		return undefined;
+	}
+	return { initial: suggestions, dynamic: dynamicSuggestions };
 }
 
 export function useSuggestions(options: UseSuggestionsOptions) {

--- a/src/chat/web/hooks/use-suggestions.ts
+++ b/src/chat/web/hooks/use-suggestions.ts
@@ -47,20 +47,20 @@ export function isFlowSuggestionsEnabled(
 
 /**
  * Map host-level config fields — `suggestions` (starter prompts) and
- * `dynamicSuggestions` (flow-pill opt-in) — to the `SuggestionsConfig`
+ * `flowSuggestions` (flow-pill opt-in) — to the `SuggestionsConfig`
  * consumed by `useSuggestions`. Every mount point (WaniwaniChat, the inline
  * and floating script embeds) must build its `ChatEmbed` suggestions prop
  * through this helper so the opt-in is never silently dropped.
  */
 export function toSuggestionsConfig(options: {
 	suggestions?: string[];
-	dynamicSuggestions?: boolean;
+	flowSuggestions?: boolean;
 }): SuggestionsConfig | undefined {
-	const { suggestions, dynamicSuggestions } = options;
-	if (!suggestions && dynamicSuggestions === undefined) {
+	const { suggestions, flowSuggestions } = options;
+	if (!suggestions && flowSuggestions === undefined) {
 		return undefined;
 	}
-	return { initial: suggestions, dynamic: dynamicSuggestions };
+	return { initial: suggestions, dynamic: flowSuggestions };
 }
 
 export function useSuggestions(options: UseSuggestionsOptions) {

--- a/src/chat/web/layouts/__tests__/chat-embed-widget-events.test.tsx
+++ b/src/chat/web/layouts/__tests__/chat-embed-widget-events.test.tsx
@@ -167,7 +167,11 @@ describe("ChatEmbed widget events", () => {
 		expect(clicks[0]).toMatchObject({
 			name: "suggestion.clicked",
 			mode: "inline",
-			properties: { text: "Second suggestion", index: 1 },
+			properties: {
+				text: "Second suggestion",
+				index: 1,
+				source: "initial",
+			},
 		});
 	});
 

--- a/src/chat/web/layouts/__tests__/chat-embed-widget-events.test.tsx
+++ b/src/chat/web/layouts/__tests__/chat-embed-widget-events.test.tsx
@@ -170,7 +170,7 @@ describe("ChatEmbed widget events", () => {
 			properties: {
 				text: "Second suggestion",
 				index: 1,
-				source: "initial",
+				origin: "channel",
 			},
 		});
 	});

--- a/src/chat/web/layouts/chat-embed.stories.tsx
+++ b/src/chat/web/layouts/chat-embed.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type { ChatAppearance } from "../@types";
+import type { ChatAppearance, SuggestionsConfig } from "../@types";
 import { ChatEmbed } from "./chat-embed";
 
 // ============================================================================
@@ -256,6 +256,8 @@ interface EmbedArgs {
 	hideHeader: boolean;
 	/** Which widget the iframe loads. Swapped by the auto-fullscreen story. */
 	resourceEndpoint: string;
+	/** Suggestion pill config. The flow story opts into flow-driven pills. */
+	suggestions?: boolean | SuggestionsConfig;
 }
 
 // The embed itself, shared across every story's render so only the wrapping
@@ -271,6 +273,7 @@ function Embed(args: EmbedArgs) {
 			hideHeader={args.hideHeader}
 			welcomeMessage={args.welcomeMessage}
 			placeholder={args.placeholder}
+			suggestions={args.suggestions}
 		/>
 	);
 }
@@ -368,8 +371,10 @@ export const UnboundedParent: Story = {
  * tool result whose `_meta` carries the step's suggested answers, and the embed
  * renders them as pills above the composer. Clicking one sends it as the reply.
  *
- * The embed is given no `suggestions` prop at all, which is the case a channel
- * with no configured starter prompts produces. Pills must still appear.
+ * Flow-driven pills are opt-in: this story passes
+ * `suggestions={{ dynamic: true }}` (the `WaniwaniChat` / script-embed
+ * spellings are `dynamicSuggestions: true` / `data-dynamic-suggestions="true"`).
+ * Without the opt-in, the flow's suggestions render nothing.
  */
 export const FlowDrivenSuggestions: Story = {
 	render: (args) => {
@@ -382,6 +387,7 @@ export const FlowDrivenSuggestions: Story = {
 	},
 	args: {
 		welcomeMessage: "Hi! Ask me about plans to see the flow suggest answers.",
+		suggestions: { dynamic: true },
 	},
 };
 

--- a/src/chat/web/layouts/chat-embed.stories.tsx
+++ b/src/chat/web/layouts/chat-embed.stories.tsx
@@ -372,9 +372,10 @@ export const UnboundedParent: Story = {
  * renders them as pills above the composer. Clicking one sends it as the reply.
  *
  * Flow-driven pills are opt-in: this story passes
- * `suggestions={{ dynamic: true }}` (the `WaniwaniChat` / script-embed
- * spellings are `flowSuggestions: true` / `data-flow-suggestions="true"`).
- * Without the opt-in, the flow's suggestions render nothing.
+ * `suggestions={{ origins: ["flow"] }}` (the `WaniwaniChat` / script-embed
+ * spellings are `overrides={{ suggestionOrigins: ["flow"] }}` /
+ * `data-suggestion-origins="flow"`). Without the opt-in, the flow's
+ * suggestions render nothing.
  */
 export const FlowDrivenSuggestions: Story = {
 	render: (args) => {
@@ -387,7 +388,7 @@ export const FlowDrivenSuggestions: Story = {
 	},
 	args: {
 		welcomeMessage: "Hi! Ask me about plans to see the flow suggest answers.",
-		suggestions: { dynamic: true },
+		suggestions: { origins: ["flow"] },
 	},
 };
 

--- a/src/chat/web/layouts/chat-embed.stories.tsx
+++ b/src/chat/web/layouts/chat-embed.stories.tsx
@@ -41,10 +41,24 @@ interface ReplyOptions {
 	autoHeight?: boolean;
 	/** Stream a reasoning part first (2+ activity parts → chain-of-thought). */
 	withReasoning?: boolean;
+	/**
+	 * Stream a flow tool result carrying these as the step's suggested answers,
+	 * so the embed renders them as pills above the composer.
+	 */
+	flowSuggestions?: string[];
 }
 
 const WIDGET_TOOL = "showActivity";
 const WIDGET_URI = "ui://widget/activity";
+const FLOW_TOOL = "plan_qualification";
+
+// The fetch shim is installed once at module scope and cannot read story args,
+// so the flow story flips this and every other story's render clears it.
+let flowSuggestions: string[] | null = null;
+
+export function setFlowSuggestions(next: string[] | null): void {
+	flowSuggestions = next;
+}
 
 // A fresh id per streamed turn, so multiple tool calls in one conversation
 // don't collide (a shared id would make the fullscreen match hit every turn's
@@ -114,6 +128,43 @@ function mockChatResponse(opts: ReplyOptions): Response {
 				});
 			}
 
+			if (opts.flowSuggestions) {
+				const flowCallId = `flow_${turnCounter}`;
+				send({
+					type: "tool-input-start",
+					toolCallId: flowCallId,
+					toolName: FLOW_TOOL,
+					dynamic: true,
+				});
+				send({
+					type: "tool-input-available",
+					toolCallId: flowCallId,
+					toolName: FLOW_TOOL,
+					dynamic: true,
+					input: { action: "continue" },
+				});
+				// Mirrors what the flow engine returns: the suggested answers ride on
+				// `_meta`, while `structuredContent` stays the LLM-facing contract.
+				send({
+					type: "tool-output-available",
+					toolCallId: flowCallId,
+					dynamic: true,
+					output: {
+						content: [{ type: "text", text: "Which plan fits you?" }],
+						structuredContent: {
+							status: "interrupt",
+							question: "Which plan fits you?",
+							field: "plan",
+							suggestions: opts.flowSuggestions,
+						},
+						_meta: {
+							"waniwani/sessionId": "story-session",
+							"waniwani/suggestions": { suggestions: opts.flowSuggestions },
+						},
+					},
+				});
+			}
+
 			send({ type: "finish" });
 			controller.enqueue(encoder.encode("data: [DONE]\n\n"));
 			controller.close();
@@ -150,6 +201,11 @@ function installMockBackend(): void {
 			// Every mocked chat turn streams a widget so any story that opens
 			// the chat can reach the fullscreen path. Reasoning is streamed too
 			// so the tool sits inside a chain-of-thought (the realistic shape).
+			if (flowSuggestions) {
+				return Promise.resolve(
+					mockChatResponse({ withReasoning: true, flowSuggestions }),
+				);
+			}
 			return Promise.resolve(
 				mockChatResponse({ withWidget: true, withReasoning: true }),
 			);
@@ -225,11 +281,14 @@ const meta: Meta<EmbedArgs> = {
 	// channel page places it (`<div class="h-dvh">`), which is the realistic
 	// deployment. The chat scrolls internally. `FixedSize` is the one story
 	// that puts it in a bounded card instead.
-	render: (args) => (
-		<div style={{ height: "100dvh", width: "100%" }}>
-			<Embed {...args} />
-		</div>
-	),
+	render: (args) => {
+		setFlowSuggestions(null);
+		return (
+			<div style={{ height: "100dvh", width: "100%" }}>
+				<Embed {...args} />
+			</div>
+		);
+	},
 	args: {
 		title: "Support Assistant",
 		welcomeMessage: "Hi! Ask me anything, or say “show me the widget”.",
@@ -294,11 +353,36 @@ export const AutoFullscreenWidget: Story = {
  * to nothing.
  */
 export const UnboundedParent: Story = {
-	render: (args) => (
-		<div style={{ maxWidth: 560, margin: "0 auto" }}>
-			<Embed {...args} />
-		</div>
-	),
+	render: (args) => {
+		setFlowSuggestions(null);
+		return (
+			<div style={{ maxWidth: 560, margin: "0 auto" }}>
+				<Embed {...args} />
+			</div>
+		);
+	},
+};
+
+/**
+ * Flow-driven suggestion pills. Send any message: the mocked turn streams a flow
+ * tool result whose `_meta` carries the step's suggested answers, and the embed
+ * renders them as pills above the composer. Clicking one sends it as the reply.
+ *
+ * The embed is given no `suggestions` prop at all, which is the case a channel
+ * with no configured starter prompts produces. Pills must still appear.
+ */
+export const FlowDrivenSuggestions: Story = {
+	render: (args) => {
+		setFlowSuggestions(["Bronze", "Silver", "Gold"]);
+		return (
+			<div style={{ height: "100dvh", width: "100%" }}>
+				<Embed {...args} />
+			</div>
+		);
+	},
+	args: {
+		welcomeMessage: "Hi! Ask me about plans to see the flow suggest answers.",
+	},
 };
 
 /**
@@ -307,18 +391,21 @@ export const UnboundedParent: Story = {
  * within the card and a fullscreen widget fills just the card, not the page.
  */
 export const FixedSize: Story = {
-	render: (args) => (
-		<div
-			style={{
-				height: 640,
-				width: 400,
-				margin: "24px auto",
-				border: "1px solid var(--ww-color-border)",
-				borderRadius: 12,
-				overflow: "hidden",
-			}}
-		>
-			<Embed {...args} />
-		</div>
-	),
+	render: (args) => {
+		setFlowSuggestions(null);
+		return (
+			<div
+				style={{
+					height: 640,
+					width: 400,
+					margin: "24px auto",
+					border: "1px solid var(--ww-color-border)",
+					borderRadius: 12,
+					overflow: "hidden",
+				}}
+			>
+				<Embed {...args} />
+			</div>
+		);
+	},
 };

--- a/src/chat/web/layouts/chat-embed.stories.tsx
+++ b/src/chat/web/layouts/chat-embed.stories.tsx
@@ -373,7 +373,7 @@ export const UnboundedParent: Story = {
  *
  * Flow-driven pills are opt-in: this story passes
  * `suggestions={{ dynamic: true }}` (the `WaniwaniChat` / script-embed
- * spellings are `dynamicSuggestions: true` / `data-dynamic-suggestions="true"`).
+ * spellings are `flowSuggestions: true` / `data-flow-suggestions="true"`).
  * Without the opt-in, the flow's suggestions render nothing.
  */
 export const FlowDrivenSuggestions: Story = {

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -334,15 +334,19 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 					dynamicIndex >= 0
 						? dynamicIndex
 						: (welcome?.suggestions?.indexOf(suggestion) ?? -1);
+				// Welcome-screen cards are always operator-authored; only the live
+				// pill row can be flow-driven.
+				const source = dynamicIndex >= 0 ? suggestionsState.source : "initial";
 				widgetEvents.emit({
 					name: "suggestion.clicked",
-					properties: { text: suggestion, index },
+					properties: { text: suggestion, index, source },
 				});
 				suggestionsState.clear();
 				engine.handleSubmit({ text: suggestion, files: [] });
 			},
 			[
 				suggestionsState.suggestions,
+				suggestionsState.source,
 				suggestionsState.clear,
 				engine.handleSubmit,
 				welcome,

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -334,12 +334,12 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 					dynamicIndex >= 0
 						? dynamicIndex
 						: (welcome?.suggestions?.indexOf(suggestion) ?? -1);
-				// Welcome-screen cards are always operator-authored; only the live
-				// pill row can be flow-driven.
-				const source = dynamicIndex >= 0 ? suggestionsState.source : "initial";
+				// Welcome-screen cards are always operator-authored starter prompts;
+				// only the live pill row can carry another origin.
+				const origin = dynamicIndex >= 0 ? suggestionsState.source : "channel";
 				widgetEvents.emit({
 					name: "suggestion.clicked",
-					properties: { text: suggestion, index, source },
+					properties: { text: suggestion, index, origin },
 				});
 				suggestionsState.clear();
 				engine.handleSubmit({ text: suggestion, files: [] });

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -14,6 +14,7 @@ import type {
 	ChatClassNames,
 	ChatHandle,
 	ShowToolCalls,
+	SuggestionOrigin,
 	VisitorIdInput,
 	WelcomeConfig,
 } from "../@types";
@@ -69,12 +70,14 @@ export interface WaniwaniChatOverrides {
 	/** Initial suggestion chips. */
 	suggestions?: string[];
 	/**
-	 * Opt-in for the per-turn pills a flow drives via
-	 * `interrupt({ suggestions })`. Disabled by default — set `true` to render
-	 * them. Starter prompts (`suggestions`) are unaffected and show either
-	 * way.
+	 * Which providers may fill the per-turn pill row. Defaults to
+	 * `["channel", "page", "followup"]` when unset: starter prompts and
+	 * generated follow-ups render, flow-driven pills stay opt-in — include
+	 * `"flow"` to render the pills a flow drives via
+	 * `interrupt({ suggestions })`. Starter prompts (`suggestions`) are
+	 * unaffected by this field and show either way.
 	 */
-	flowSuggestions?: boolean;
+	suggestionOrigins?: SuggestionOrigin[];
 	/** Persist conversations across reloads in IndexedDB. */
 	enableThreadHistory?: boolean;
 	/**
@@ -248,7 +251,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 				welcomeMessage: overrides?.welcomeMessage,
 				placeholder: overrides?.placeholder,
 				suggestions: overrides?.suggestions,
-				flowSuggestions: overrides?.flowSuggestions,
+				suggestionOrigins: overrides?.suggestionOrigins,
 				enableThreadHistory: overrides?.enableThreadHistory,
 				showToolCalls: overrides?.showToolCalls,
 				appearance: overrides?.appearance,
@@ -265,7 +268,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 				overrides?.welcomeMessage,
 				overrides?.placeholder,
 				overrides?.suggestions,
-				overrides?.flowSuggestions,
+				overrides?.suggestionOrigins,
 				overrides?.enableThreadHistory,
 				overrides?.showToolCalls,
 				overrides?.appearance,
@@ -465,7 +468,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 					placeholder={config.placeholder}
 					suggestions={toSuggestionsConfig({
 						suggestions: config.suggestions,
-						flowSuggestions: config.flowSuggestions,
+						suggestionOrigins: config.suggestionOrigins,
 					})}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -69,11 +69,10 @@ export interface WaniwaniChatOverrides {
 	/** Initial suggestion chips. */
 	suggestions?: string[];
 	/**
-	 * Per-turn suggestion pills a flow drives via `interrupt({ suggestions })`.
-	 * Enabled by default — writing `suggestions` in a flow is itself the
-	 * opt-in, so most hosts never need to touch this. Set `false` to hide
-	 * flow-driven pills while still showing `suggestions` (the starter
-	 * prompts) at the start of the conversation.
+	 * Opt-in for the per-turn pills a flow drives via
+	 * `interrupt({ suggestions })`. Disabled by default — set `true` to render
+	 * them. Starter prompts (`suggestions`) are unaffected and show either
+	 * way.
 	 */
 	dynamicSuggestions?: boolean;
 	/** Persist conversations across reloads in IndexedDB. */

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -74,7 +74,7 @@ export interface WaniwaniChatOverrides {
 	 * them. Starter prompts (`suggestions`) are unaffected and show either
 	 * way.
 	 */
-	dynamicSuggestions?: boolean;
+	flowSuggestions?: boolean;
 	/** Persist conversations across reloads in IndexedDB. */
 	enableThreadHistory?: boolean;
 	/**
@@ -248,7 +248,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 				welcomeMessage: overrides?.welcomeMessage,
 				placeholder: overrides?.placeholder,
 				suggestions: overrides?.suggestions,
-				dynamicSuggestions: overrides?.dynamicSuggestions,
+				flowSuggestions: overrides?.flowSuggestions,
 				enableThreadHistory: overrides?.enableThreadHistory,
 				showToolCalls: overrides?.showToolCalls,
 				appearance: overrides?.appearance,
@@ -265,7 +265,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 				overrides?.welcomeMessage,
 				overrides?.placeholder,
 				overrides?.suggestions,
-				overrides?.dynamicSuggestions,
+				overrides?.flowSuggestions,
 				overrides?.enableThreadHistory,
 				overrides?.showToolCalls,
 				overrides?.appearance,
@@ -465,7 +465,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 					placeholder={config.placeholder}
 					suggestions={toSuggestionsConfig({
 						suggestions: config.suggestions,
-						dynamicSuggestions: config.dynamicSuggestions,
+						flowSuggestions: config.flowSuggestions,
 					})}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -67,6 +67,14 @@ export interface WaniwaniChatOverrides {
 	placeholder?: string;
 	/** Initial suggestion chips. */
 	suggestions?: string[];
+	/**
+	 * Per-turn suggestion pills a flow drives via `interrupt({ suggestions })`.
+	 * Enabled by default — writing `suggestions` in a flow is itself the
+	 * opt-in, so most hosts never need to touch this. Set `false` to hide
+	 * flow-driven pills while still showing `suggestions` (the starter
+	 * prompts) at the start of the conversation.
+	 */
+	dynamicSuggestions?: boolean;
 	/** Persist conversations across reloads in IndexedDB. */
 	enableThreadHistory?: boolean;
 	/**
@@ -240,6 +248,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 				welcomeMessage: overrides?.welcomeMessage,
 				placeholder: overrides?.placeholder,
 				suggestions: overrides?.suggestions,
+				dynamicSuggestions: overrides?.dynamicSuggestions,
 				enableThreadHistory: overrides?.enableThreadHistory,
 				showToolCalls: overrides?.showToolCalls,
 				appearance: overrides?.appearance,
@@ -256,6 +265,7 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 				overrides?.welcomeMessage,
 				overrides?.placeholder,
 				overrides?.suggestions,
+				overrides?.dynamicSuggestions,
 				overrides?.enableThreadHistory,
 				overrides?.showToolCalls,
 				overrides?.appearance,
@@ -454,7 +464,12 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 					welcome={overrides?.welcome}
 					placeholder={config.placeholder}
 					suggestions={
-						config.suggestions ? { initial: config.suggestions } : undefined
+						config.suggestions || config.dynamicSuggestions !== undefined
+							? {
+									initial: config.suggestions,
+									dynamic: config.dynamicSuggestions,
+								}
+							: undefined
 					}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -28,6 +28,7 @@ import { useVisibilityGate } from "../embed/use-pathname";
 import type { WidgetEvent } from "../embed/widget-events";
 import { createWidgetEventEmitter } from "../embed/widget-events";
 import { WidgetEventsProvider } from "../embed/widget-events-context";
+import { toSuggestionsConfig } from "../hooks/use-suggestions";
 import type { Locale, MessageOverrides } from "../i18n";
 import {
 	createChatTrackClient,
@@ -463,14 +464,10 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 					welcomeMessage={config.welcomeMessage}
 					welcome={overrides?.welcome}
 					placeholder={config.placeholder}
-					suggestions={
-						config.suggestions || config.dynamicSuggestions !== undefined
-							? {
-									initial: config.suggestions,
-									dynamic: config.dynamicSuggestions,
-								}
-							: undefined
-					}
+					suggestions={toSuggestionsConfig({
+						suggestions: config.suggestions,
+						dynamicSuggestions: config.dynamicSuggestions,
+					})}
 					enableThreadHistory={config.enableThreadHistory}
 					showToolCalls={config.showToolCalls}
 					disclaimer={config.disclaimer}

--- a/src/mcp/server/flows/__tests__/suggestions-meta.test.ts
+++ b/src/mcp/server/flows/__tests__/suggestions-meta.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { RegisteredTool } from "../../../../legacy/mcp/tools/types";
+import { SUGGESTIONS_META_KEY } from "../../utils";
+import type { FlowTokenContent, McpServer, RegisteredFlow } from "../@types";
+import { END, START } from "../@types";
+import { createFlow } from "../create-flow";
+
+class TestFlowStateStore {
+	private readonly map = new Map<string, FlowTokenContent>();
+	async get(key: string): Promise<FlowTokenContent | null> {
+		return this.map.get(key) ?? null;
+	}
+	async set(key: string, value: FlowTokenContent): Promise<void> {
+		this.map.set(key, value);
+	}
+	async delete(key: string): Promise<void> {
+		this.map.delete(key);
+	}
+}
+
+const mockPlanPickerTool: RegisteredTool = {
+	id: "plan_picker",
+	title: "Plan Picker",
+	description: "Show plan picker widget",
+	register: async () => {},
+};
+
+type Handler = (input: unknown, extra: unknown) => Promise<unknown>;
+type RegisterToolArgs = [string, Record<string, unknown>, Handler];
+
+const TEST_SESSION_ID = "test-session-suggestions";
+const TEST_INTENT = "Qualify the user for this flow.";
+
+function startInput(stateUpdates?: Record<string, unknown>) {
+	return {
+		action: "start" as const,
+		intent: TEST_INTENT,
+		...(stateUpdates ? { stateUpdates } : {}),
+	};
+}
+
+function mockServer() {
+	const registered: RegisterToolArgs[] = [];
+	const server = {
+		registerTool: (...args: unknown[]) => {
+			registered.push(args as RegisterToolArgs);
+		},
+	};
+	return { server: server as unknown as McpServer, registered };
+}
+
+/** Register a compiled flow and run one `start` call, returning the raw result. */
+async function runStart(
+	flow: RegisteredFlow,
+	stateUpdates?: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const mock = mockServer();
+	await flow.register(mock.server);
+	const handler = mock.registered[0]?.[2];
+	// A fresh `_meta` object per call — `compile.ts` mutates it in place, and a
+	// shared object here would leak one test's suggestions into the next.
+	return (await handler?.(startInput(stateUpdates), {
+		_meta: { sessionId: TEST_SESSION_ID },
+	})) as Record<string, unknown>;
+}
+
+function metaOf(result: Record<string, unknown>): Record<string, unknown> {
+	return (result._meta ?? {}) as Record<string, unknown>;
+}
+
+describe("flow result _meta suggestions", () => {
+	test("emits the key for a single open question with suggestions", async () => {
+		const flow = createFlow({
+			id: "single_question_flow",
+			title: "Single question",
+			description: "Asks one question",
+			state: {
+				plan: z.enum(["Bronze", "Silver", "Gold"]).describe("Chosen plan"),
+			},
+		})
+			.addNode({
+				id: "ask_plan",
+				label: "Ask plan",
+				run: ({ interrupt }) =>
+					interrupt({
+						plan: {
+							question: "Which plan fits you?",
+							suggestions: ["Bronze", "Silver", "Gold"],
+						},
+					}),
+			})
+			.addEdge(START, "ask_plan")
+			.addEdge("ask_plan", END)
+			.compile({ store: new TestFlowStateStore() });
+
+		const result = await runStart(flow);
+
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toEqual({
+			suggestions: ["Bronze", "Silver", "Gold"],
+		});
+	});
+
+	test("leaves structuredContent unchanged", async () => {
+		const flow = createFlow({
+			id: "structured_content_flow",
+			title: "Structured content",
+			description: "Asks one question",
+			state: { plan: z.enum(["Bronze", "Gold"]).describe("Chosen plan") },
+		})
+			.addNode({
+				id: "ask_plan",
+				label: "Ask plan",
+				run: ({ interrupt }) =>
+					interrupt({
+						plan: {
+							question: "Which plan fits you?",
+							suggestions: ["Bronze", "Gold"],
+						},
+					}),
+			})
+			.addEdge(START, "ask_plan")
+			.addEdge("ask_plan", END)
+			.compile({ store: new TestFlowStateStore() });
+
+		const result = await runStart(flow);
+		const structured = result.structuredContent as Record<string, unknown>;
+
+		expect(structured.status).toBe("interrupt");
+		expect(structured.suggestions).toEqual(["Bronze", "Gold"]);
+	});
+
+	test("omits the key when the single question declares no suggestions", async () => {
+		const flow = createFlow({
+			id: "no_suggestions_flow",
+			title: "No suggestions",
+			description: "Asks one open question",
+			state: { breed: z.string().describe("Pet breed") },
+		})
+			.addNode({
+				id: "ask_breed",
+				label: "Ask breed",
+				run: ({ interrupt }) =>
+					interrupt({ breed: { question: "What breed is your pet?" } }),
+			})
+			.addEdge(START, "ask_breed")
+			.addEdge("ask_breed", END)
+			.compile({ store: new TestFlowStateStore() });
+
+		const result = await runStart(flow);
+
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toBeUndefined();
+	});
+
+	test("omits the key when more than one question is open", async () => {
+		const flow = createFlow({
+			id: "multi_question_flow",
+			title: "Multi question",
+			description: "Asks two questions at once",
+			state: {
+				petName: z.string().describe("Pet name"),
+				petType: z.enum(["dog", "cat"]).describe("Pet type"),
+			},
+		})
+			.addNode({
+				id: "ask_pet",
+				label: "Ask pet",
+				run: ({ interrupt }) =>
+					interrupt({
+						petName: { question: "What's your pet's name?" },
+						petType: {
+							question: "What type of pet do you have?",
+							suggestions: ["dog", "cat"],
+						},
+					}),
+			})
+			.addEdge(START, "ask_pet")
+			.addEdge("ask_pet", END)
+			.compile({ store: new TestFlowStateStore() });
+
+		const result = await runStart(flow);
+
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toBeUndefined();
+	});
+
+	test("emits the key once a multi-question interrupt has one question left", async () => {
+		const flow = createFlow({
+			id: "partially_filled_flow",
+			title: "Partially filled",
+			description: "Asks two questions at once",
+			state: {
+				petName: z.string().describe("Pet name"),
+				petType: z.enum(["dog", "cat"]).describe("Pet type"),
+			},
+		})
+			.addNode({
+				id: "ask_pet",
+				label: "Ask pet",
+				run: ({ interrupt }) =>
+					interrupt({
+						petName: { question: "What's your pet's name?" },
+						petType: {
+							question: "What type of pet do you have?",
+							suggestions: ["dog", "cat"],
+						},
+					}),
+			})
+			.addEdge(START, "ask_pet")
+			.addEdge("ask_pet", END)
+			.compile({ store: new TestFlowStateStore() });
+
+		// `petName` arrives pre-filled, so only `petType` is still open and the
+		// engine collapses to the single-question shorthand.
+		const result = await runStart(flow, { petName: "Rex" });
+
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toEqual({
+			suggestions: ["dog", "cat"],
+		});
+	});
+
+	test("omits the key for a widget step", async () => {
+		const flow = createFlow({
+			id: "widget_flow",
+			title: "Widget",
+			description: "Shows a widget",
+			state: { plan: z.string().describe("Chosen plan") },
+		})
+			.addNode({
+				id: "show_plans",
+				label: "Show plans",
+				run: ({ showWidget }) =>
+					showWidget({ tool: mockPlanPickerTool, field: "plan" }),
+			})
+			.addEdge(START, "show_plans")
+			.addEdge("show_plans", END)
+			.compile({ store: new TestFlowStateStore() });
+
+		const result = await runStart(flow);
+
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toBeUndefined();
+	});
+
+	test("omits the key when the flow completes", async () => {
+		const flow = createFlow({
+			id: "complete_flow",
+			title: "Complete",
+			description: "Completes immediately",
+			state: { done: z.boolean().describe("Whether the flow finished") },
+		})
+			.addNode({
+				id: "finish",
+				label: "Finish",
+				run: () => ({ done: true }),
+			})
+			.addEdge(START, "finish")
+			.addEdge("finish", END)
+			.compile({ store: new TestFlowStateStore() });
+
+		const result = await runStart(flow);
+		const structured = result.structuredContent as Record<string, unknown>;
+
+		expect(structured.status).toBe("complete");
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toBeUndefined();
+	});
+});

--- a/src/mcp/server/flows/__tests__/suggestions-meta.test.ts
+++ b/src/mcp/server/flows/__tests__/suggestions-meta.test.ts
@@ -130,7 +130,7 @@ describe("flow result _meta suggestions", () => {
 		expect(structured.suggestions).toEqual(["Bronze", "Gold"]);
 	});
 
-	test("omits the key when the single question declares no suggestions", async () => {
+	test("emits an empty array when the single question declares no suggestions", async () => {
 		const flow = createFlow({
 			id: "no_suggestions_flow",
 			title: "No suggestions",
@@ -149,10 +149,10 @@ describe("flow result _meta suggestions", () => {
 
 		const result = await runStart(flow);
 
-		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toBeUndefined();
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toEqual({ suggestions: [] });
 	});
 
-	test("omits the key when more than one question is open", async () => {
+	test("emits an empty array when more than one question is open", async () => {
 		const flow = createFlow({
 			id: "multi_question_flow",
 			title: "Multi question",
@@ -180,7 +180,7 @@ describe("flow result _meta suggestions", () => {
 
 		const result = await runStart(flow);
 
-		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toBeUndefined();
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toEqual({ suggestions: [] });
 	});
 
 	test("emits the key once a multi-question interrupt has one question left", async () => {
@@ -218,7 +218,7 @@ describe("flow result _meta suggestions", () => {
 		});
 	});
 
-	test("omits the key for a widget step", async () => {
+	test("emits an empty array for a widget step", async () => {
 		const flow = createFlow({
 			id: "widget_flow",
 			title: "Widget",
@@ -237,10 +237,10 @@ describe("flow result _meta suggestions", () => {
 
 		const result = await runStart(flow);
 
-		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toBeUndefined();
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toEqual({ suggestions: [] });
 	});
 
-	test("omits the key when the flow completes", async () => {
+	test("emits an empty array when the flow completes", async () => {
 		const flow = createFlow({
 			id: "complete_flow",
 			title: "Complete",
@@ -260,6 +260,61 @@ describe("flow result _meta suggestions", () => {
 		const structured = result.structuredContent as Record<string, unknown>;
 
 		expect(structured.status).toBe("complete");
-		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toBeUndefined();
+		expect(metaOf(result)[SUGGESTIONS_META_KEY]).toEqual({ suggestions: [] });
+	});
+
+	test("always carries the suggestions key on a flow result, regardless of status", async () => {
+		const flows = [
+			createFlow({
+				id: "invariant_interrupt_flow",
+				title: "Invariant interrupt",
+				description: "Asks one open question",
+				state: { breed: z.string().describe("Pet breed") },
+			})
+				.addNode({
+					id: "ask_breed",
+					label: "Ask breed",
+					run: ({ interrupt }) =>
+						interrupt({ breed: { question: "What breed is your pet?" } }),
+				})
+				.addEdge(START, "ask_breed")
+				.addEdge("ask_breed", END)
+				.compile({ store: new TestFlowStateStore() }),
+			createFlow({
+				id: "invariant_complete_flow",
+				title: "Invariant complete",
+				description: "Completes immediately",
+				state: { done: z.boolean().describe("Whether the flow finished") },
+			})
+				.addNode({ id: "finish", label: "Finish", run: () => ({ done: true }) })
+				.addEdge(START, "finish")
+				.addEdge("finish", END)
+				.compile({ store: new TestFlowStateStore() }),
+			createFlow({
+				id: "invariant_widget_flow",
+				title: "Invariant widget",
+				description: "Shows a widget",
+				state: { plan: z.string().describe("Chosen plan") },
+			})
+				.addNode({
+					id: "show_plans",
+					label: "Show plans",
+					run: ({ showWidget }) =>
+						showWidget({ tool: mockPlanPickerTool, field: "plan" }),
+				})
+				.addEdge(START, "show_plans")
+				.addEdge("show_plans", END)
+				.compile({ store: new TestFlowStateStore() }),
+		];
+
+		for (const flow of flows) {
+			const result = await runStart(flow);
+			const meta = metaOf(result)[SUGGESTIONS_META_KEY];
+
+			expect(meta).toBeDefined();
+			expect(
+				Array.isArray((meta as { suggestions: unknown }).suggestions),
+			).toBe(true);
+		}
 	});
 });

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -390,6 +390,22 @@ export function compileFlow<TState extends Record<string, unknown>>(
 
 		const result = await handleToolCall(args, sessionId, _meta, waniwani);
 
+		// Echo sessionId in response when not sourced from _meta (client must pass it back)
+		const contentObj =
+			!metaSessionId && sessionId
+				? { ...result.content, sessionId }
+				: result.content;
+
+		// Authoritative for the turn: an empty array clears pills an earlier flow
+		// call in the same turn set. Only the single-open-question shorthand
+		// carries a top-level `suggestions`. Set before both return paths below
+		// so every flow tool result — including the state-persistence failure —
+		// carries the key.
+		_meta[SUGGESTIONS_META_KEY] = {
+			suggestions:
+				contentObj.status === "interrupt" ? (contentObj.suggestions ?? []) : [],
+		} satisfies SuggestionsMeta;
+
 		// Persist flow state under session ID. On completion we store the final
 		// `{ state }` (no `step`) so customers can read the final state until
 		// the KV TTL expires; a stale `continue` falls into the "already
@@ -422,12 +438,6 @@ export function compileFlow<TState extends Record<string, unknown>>(
 			}
 		}
 
-		// Echo sessionId in response when not sourced from _meta (client must pass it back)
-		const contentObj =
-			!metaSessionId && sessionId
-				? { ...result.content, sessionId }
-				: result.content;
-
 		const content = [
 			{
 				type: "text" as const,
@@ -441,13 +451,6 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				flowId: config.id,
 				nodesVisited: result.nodesVisited,
 			};
-		}
-
-		// Top-level `suggestions` only exists for the single-open-question shorthand.
-		if (contentObj.status === "interrupt" && contentObj.suggestions?.length) {
-			_meta[SUGGESTIONS_META_KEY] = {
-				suggestions: contentObj.suggestions,
-			} satisfies SuggestionsMeta;
 		}
 
 		return {

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -7,7 +7,12 @@ import type {
 import { z } from "zod";
 import type { ScopedWaniWaniClient } from "../scoped-client";
 import { extractScopedClient } from "../scoped-client";
-import { extractSessionId, FLOW_META_KEY } from "../utils";
+import {
+	extractSessionId,
+	FLOW_META_KEY,
+	SUGGESTIONS_META_KEY,
+	type SuggestionsMeta,
+} from "../utils";
 import type {
 	CompileInput,
 	FlowToolHandler,
@@ -436,6 +441,13 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				flowId: config.id,
 				nodesVisited: result.nodesVisited,
 			};
+		}
+
+		// Top-level `suggestions` only exists for the single-open-question shorthand.
+		if (contentObj.status === "interrupt" && contentObj.suggestions?.length) {
+			_meta[SUGGESTIONS_META_KEY] = {
+				suggestions: contentObj.suggestions,
+			} satisfies SuggestionsMeta;
 		}
 
 		return {

--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -60,6 +60,9 @@ const TURN_COUNT_KEYS = ["waniwani/turnCount"] as const;
 /** Meta key for flow execution path (nodesVisited, flowId). */
 export const FLOW_META_KEY = "waniwani/flow" as const;
 
+export type { SuggestionsMeta } from "../../shared/meta-keys";
+export { SUGGESTIONS_META_KEY } from "../../shared/meta-keys";
+
 /**
  * Meta key under which `withWaniwani` injects the widget tracking config
  * (`{ endpoint, token, sessionId, source, geoLocation }`) into tool response

--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -965,4 +965,31 @@ describe("withWaniwani", () => {
 			stateUpdates: { ages: "35,32" },
 		});
 	});
+
+	test("preserves unknown namespaced _meta keys on the tool result", async () => {
+		const { client } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, { client });
+
+		mock.registerTool(
+			"flow_like",
+			{ description: "Returns _meta" },
+			async () => ({
+				content: [{ type: "text", text: "{}" }],
+				_meta: {
+					"waniwani/suggestions": { suggestions: ["Bronze", "Gold"] },
+				},
+			}),
+		);
+
+		const handler = mock.registered[0]?.[2];
+		const result = (await handler?.({}, { _meta: { requestId: "req-1" } })) as {
+			_meta?: Record<string, unknown>;
+		};
+
+		expect(result._meta?.["waniwani/suggestions"]).toEqual({
+			suggestions: ["Bronze", "Gold"],
+		});
+	});
 });

--- a/src/shared/meta-keys.ts
+++ b/src/shared/meta-keys.ts
@@ -5,10 +5,12 @@
  */
 
 /**
- * Suggested answers for the flow's current step. Present only when the step
- * has exactly one open question, which is the only case where a single pill
- * is an unambiguous answer. The chat widget renders these as pills; other MCP
- * hosts ignore the key.
+ * Suggested answers for the flow's current step. Every flow tool result
+ * carries this key — a non-empty array only when the step has exactly one
+ * open question (the only case where a single pill is an unambiguous
+ * answer), an empty array otherwise. The chat widget renders a non-empty
+ * array as pills and treats the key's presence, empty or not, as
+ * authoritative for the turn; other MCP hosts ignore the key.
  */
 export const SUGGESTIONS_META_KEY = "waniwani/suggestions" as const;
 

--- a/src/shared/meta-keys.ts
+++ b/src/shared/meta-keys.ts
@@ -1,0 +1,18 @@
+/**
+ * `_meta` keys shared between the MCP server surface and the browser chat
+ * bundle. Kept in `shared/` so both import the same string literal instead of
+ * duplicating it, without the chat bundle pulling in server code.
+ */
+
+/**
+ * Suggested answers for the flow's current step. Present only when the step
+ * has exactly one open question, which is the only case where a single pill
+ * is an unambiguous answer. The chat widget renders these as pills; other MCP
+ * hosts ignore the key.
+ */
+export const SUGGESTIONS_META_KEY = "waniwani/suggestions" as const;
+
+/** Shape stored under {@link SUGGESTIONS_META_KEY}. */
+export type SuggestionsMeta = {
+	suggestions: string[];
+};


### PR DESCRIPTION
Flow-declared `interrupt({ suggestions })` can now render as clickable pills in the WaniWani chat widget. Previously those suggestions only ever reached the LLM.

## How it works

The flow engine writes the current step's suggested answers onto the tool result's `_meta` under `waniwani/suggestions`. The chat widget reads that off the last assistant turn's tool parts and fills the pill row. Clicking a pill sends it as the visitor's answer.

Pills appear only when a step has **exactly one question still open**. That is evaluated at runtime, not from how the call was written: a four-question `interrupt()` with three fields already filled has one open question, so it gets pills. Two or more open questions get none, since no single pill could answer them all.

`structuredContent` and `outputSchema` are untouched, so ChatGPT and Claude behave exactly as before.

## Opt-in, zero behavior change by default

Flow-driven pills are **opt-in per chat surface**. Without the opt-in, behavior is byte-for-byte identical to 0.18 (the pre-existing streamed `data-suggestions` path keeps its exact 0.18 gating). Enable with:

- `<WaniwaniChat>`: `overrides={{ dynamicSuggestions: true }}`
- `<script>` embed: `data-dynamic-suggestions="true"`
- bare `<ChatEmbed>`: `suggestions={{ dynamic: true }}` (or `suggestions={true}`)

All three surfaces route through a shared, unit-tested `toSuggestionsConfig` helper, so the flag cannot silently drop on any mount point. `interrupt({ field: { question, suggestions } })` itself already existed — no new flow API.

## How to see it working

```
bun run storybook
```

Open **Chat / ChatEmbed → FlowDrivenSuggestions** and send any message. The story opts in via `suggestions={{ dynamic: true }}`; the mocked turn streams a flow tool result whose `_meta` carries the suggestions, and Bronze / Silver / Gold render above the composer. Clicking one sends it and the row recomputes. Without the opt-in, the same turn renders nothing.

## Verified

| Link | Evidence |
|---|---|
| Engine writes the key | Unit tests over interrupt / widget / complete / error / multi-question |
| `withWaniwani` preserves it | Characterization test, proven non-vacuous |
| Real MCP over HTTP | Live run: `[]` on a widget step, populated on a single-open-question step |
| AI SDK MCP client preserves `_meta` | `ResultSchema` declares it as `.loose()` |
| App chat route delivers it to the browser | Captured a production playground `tool-output-available` part carrying result `_meta` |
| Widget renders pills | Storybook, real browser, click-to-advance |
| Opt-in gating on every surface | Gate unit matrix + hook-level parity tests (0.18 streamed path unchanged, no pills without opt-in) |

## Bugs found in review and fixed here

- Stale pills when one turn calls the flow twice and ends non-interrupt (fixed by making the `_meta` key authoritative: an empty array clears)
- Stale pills surviving `reset()` / new thread, mis-reporting `source: "flow"` in a conversation that never called the flow
- The script embed parsed `data-dynamic-suggestions` but never forwarded it to the chat on either mount (inline and floating), and a `{ dynamic: ... }`-only `suggestions` config was silently ignored by `ChatEmbed` — both fixed via the shared `toSuggestionsConfig` helper and a relaxed config guard, pinned by unit tests

## Known gaps

- Version-stamped release artifacts (changelog section, `upgrading.md` entry, `migrate-waniwani-sdk-<from>-to-<to>` skill) are intentionally NOT in this PR: the next version number is undecided and the release may bundle other changes. The release that ships this must produce them via `.claude/skills/release-migration/` — the `suggestion.clicked` required `source` field remains a compile-breaking change for code that constructs event literals, even though runtime behavior is now purely additive. A pre-written changelog draft is preserved on the `docs` repo branch `gabriel/wan-708-docs-correct-chat-widget-pages` (its PR #5 was closed in favor of the release flow; the draft predates the opt-in flip and needs updating at release time).
- `/config` does not carry `dynamicSuggestions`, so channels cannot opt in from the dashboard — enabling pills requires a host code change. Dashboard-level enablement is the natural app-side follow-up.
- Not exercised in ChatGPT itself. Safety there rests on `structuredContent` being unchanged plus the same `_meta` mechanism already shipping to ChatGPT in production.

## Blast radius on release

None by default. No client widget changes appearance on SDK upgrade; BPI Conseil, Offre MRH Jeunes, Tuio, and BPI all keep their current behavior until a surface explicitly opts in with `dynamicSuggestions: true` (BPI Conseil and Offre MRH Jeunes have single-open-question interrupts and would show pills once enabled; Tuio and BPI group their questions, so they would show none until one question remains open).
