### PR TITLE
docs(sdk): point the 0.19 migration docs at 0.19.1

### DIFF
--- a/skills/migrate-waniwani-sdk-0.18-to-0.19/SKILL.md
+++ b/skills/migrate-waniwani-sdk-0.18-to-0.19/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: migrate-waniwani-sdk-0.18-to-0.19
-description: "Migrate a project from @waniwani/sdk 0.18.x to 0.19.0 and auto-apply its breaking change: suggestion.clicked (WidgetEvent / WidgetEventDetail from @waniwani/sdk/chat) gained a required properties.origin field (channel | page | flow | followup). Reading events through onEvent needs no changes; only code constructing a suggestion.clicked event literal must add origin. Also covers the SuggestionsConfig.dynamic deprecation (use origins) and how to opt in to flow-driven suggestion pills. Trigger when the user is on @waniwani/sdk 0.18.x and wants to move to 0.19, asks to migrate to 0.19, or hits type errors on suggestion.clicked literals after bumping @waniwani/sdk."
+description: "Migrate a project from @waniwani/sdk 0.18.x to 0.19.x (first published: 0.19.1) and auto-apply its breaking change: suggestion.clicked (WidgetEvent / WidgetEventDetail from @waniwani/sdk/chat) gained a required properties.origin field (channel | page | flow | followup). Reading events through onEvent needs no changes; only code constructing a suggestion.clicked event literal must add origin. Also covers the SuggestionsConfig.dynamic deprecation (use origins) and how to opt in to flow-driven suggestion pills. Trigger when the user is on @waniwani/sdk 0.18.x and wants to move to 0.19, asks to migrate to 0.19, or hits type errors on suggestion.clicked literals after bumping @waniwani/sdk."
 metadata:
   author: Waniwani
 ---
 
 # Migrate `@waniwani/sdk` 0.18 → 0.19
 
-A self-contained migration for the single hop from `0.18.x` to `0.19.0`. Apply it when a project on 0.18 is moving to 0.19. It covers only that jump; for other version boundaries use the matching `migrate-waniwani-sdk-<from>-to-<to>` skill, or the general procedure in the SDK's [changelog](https://docs.waniwani.ai/sdk/changelog).
+A self-contained migration for the single hop from `0.18.x` to `0.19.x` (the first published 0.19 release is `0.19.1`; `0.19.0` was never published to npm). Apply it when a project on 0.18 is moving to 0.19. It covers only that jump; for other version boundaries use the matching `migrate-waniwani-sdk-<from>-to-<to>` skill, or the general procedure in the SDK's [changelog](https://docs.waniwani.ai/sdk/changelog).
 
 **Precondition:** the project is on `@waniwani/sdk@0.18.x`. If it is on an older version, migrate up to 0.18 first (each jump ships its own migration skill); if it is already on 0.19+, there is nothing to do here.
 
@@ -31,7 +31,7 @@ This break **is** visible to `tsc`: every hand-constructed `suggestion.clicked` 
 
 1. **Bump the dependency.**
    ```bash
-   bun add @waniwani/sdk@^0.19.0
+   bun add @waniwani/sdk@^0.19.1
    ```
 2. **Collect the call sites.** Run the type checker and/or grep:
    ```bash

--- a/skills/waniwani-sdk/references/upgrading.md
+++ b/skills/waniwani-sdk/references/upgrading.md
@@ -31,7 +31,7 @@ One behavioral note (not a break): `messageBorderRadius` / `--ww-msg-radius` is 
 
 This list mirrors the changelog so you can apply migrations without a network fetch. Always cross-check against the live changelog for anything newer than this file.
 
-### 0.19.0: `suggestion.clicked` requires a `properties.origin` field
+### 0.19.1: `suggestion.clicked` requires a `properties.origin` field
 
 `suggestion.clicked` (part of `WidgetEventDetail` / `WidgetEvent` from `@waniwani/sdk/chat`) gained a required `properties.origin: "channel" | "page" | "flow" | "followup"` field, reporting which provider supplied the clicked pill. On 0.18.x the payload was `{ text, index }`. Consumers who only *read* the event through `onEvent` (the overwhelmingly common case) need no changes: it is a new, always-populated field. Only code that *constructs* a `suggestion.clicked` event literal (test fixtures, a custom adapter) needs updating.
 


### PR DESCRIPTION
0.19.0 was never published to npm (the release shipped as 0.19.1), so the upgrading guide and migration skill point at 0.19.1. Ref WAN-723