### PR TITLE
fix(flows): extraction on start, self-heal interrupts, idempotent start (0.19.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.19.4",
+  "version": "0.19.3",
   "description": "MCP distribution SDK. Build sales funnels, lead generation, booking, and quote apps on top of your MCP server. Event tracking, flows, widgets, knowledge base.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "MCP distribution SDK. Build sales funnels, lead generation, booking, and quote apps on top of your MCP server. Event tracking, flows, widgets, knowledge base.",
   "type": "module",
   "exports": {

--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -101,8 +101,11 @@ independently by `suggestionOrigins`:
 - **`"page"`**: per-URL starter prompts configured in the dashboard for the
   current page.
 - **`"flow"`**: a connected MCP's flow declaring `suggestions` on a step with
-  one open question. These refresh after each reply and describe the question
-  the agent just asked.
+  one open question. These refresh after each reply and describe the flow's
+  pending step. When an agent answers a pending question in prose without
+  advancing the flow, the pills can lag one step behind the message; the flow
+  engine self-heals this on `start` interrupts by instructing the agent to
+  advance in the same turn.
 - **`"followup"`**: pills generated from the conversation and streamed as a
   `data-suggestions` part (self-hosted backends only).
 

--- a/skills/waniwani-sdk/references/flows-api-reference.md
+++ b/skills/waniwani-sdk/references/flows-api-reference.md
@@ -154,8 +154,13 @@ type FlowTokenContent = {
   state: Record<string, unknown>;
   field?: string;
   widgetId?: string;
+  flowId?: string;
 };
 ```
+
+The engine stamps `flowId` on every write; a `start` on a parked session
+resumes only records carrying the same flow's id. Custom stores should
+persist it like any other field.
 
 ### WaniwaniFlowStore
 

--- a/skills/waniwani-sdk/references/flows.md
+++ b/skills/waniwani-sdk/references/flows.md
@@ -198,8 +198,10 @@ the interrupt carries a hidden instruction telling the assistant to advance
 the flow with `continue` in the same turn instead of re-asking.
 
 A `start` for a session that is already parked mid-flow executes as a
-`continue`: state merges instead of resetting, and a parked widget re-emits
-its display instruction. After a flow completes, `start` begins a fresh run.
+`continue`, provided the parked record was written by the same flow: state
+merges instead of resetting, and a parked widget re-emits its display
+instruction. A different flow's `start` on the same session always begins
+fresh. After a flow completes, `start` begins a fresh run.
 
 ### Multiple Questions
 

--- a/skills/waniwani-sdk/references/flows.md
+++ b/skills/waniwani-sdk/references/flows.md
@@ -186,6 +186,21 @@ step with two or more open questions gets none, because no single pill could
 answer them all. Other MCP hosts (ChatGPT, Claude) are unaffected either way:
 they have no pill row, and what they receive is unchanged.
 
+### Extraction on `start` and self-healing
+
+The generated tool schema requires the assistant to pass `stateUpdates` on
+every call (`{}` when the message answers nothing). On `start`, answers the
+visitor's opening message already contains are extracted into `stateUpdates`,
+and the engine auto-skips every question whose field is filled — so a flow
+whose first question the visitor answers up front opens on the first
+*unanswered* step. When a `start` still parks on an already-answered question,
+the interrupt carries a hidden instruction telling the assistant to advance
+the flow with `continue` in the same turn instead of re-asking.
+
+A `start` for a session that is already parked mid-flow executes as a
+`continue`: state merges instead of resetting, and a parked widget re-emits
+its display instruction. After a flow completes, `start` begins a fresh run.
+
 ### Multiple Questions
 
 ```ts

--- a/skills/waniwani-sdk/references/upgrading.md
+++ b/skills/waniwani-sdk/references/upgrading.md
@@ -21,7 +21,7 @@ Deprecations (struck-through signatures, `@deprecated` JSDoc) are **not** breaki
 
 These entries add capability without changing existing behavior — listed so the surface is discoverable, not because an upgrade needs action.
 
-### 0.20.0: first-turn extraction and idempotent `start` (flow engine)
+### 0.19.4: first-turn extraction and idempotent `start` (flow engine)
 
 No code changes required. The generated flow tool schema now demands
 `stateUpdates` extraction on every call (`{}` when there is nothing to

--- a/skills/waniwani-sdk/references/upgrading.md
+++ b/skills/waniwani-sdk/references/upgrading.md
@@ -29,8 +29,10 @@ extract), start-interrupts carry a self-heal instruction when the opening
 message already answers the parked question, and a `start` on a session
 parked mid-flow executes as a `continue` instead of restarting with fresh
 state, provided the parked record belongs to the same flow (a different
-flow's `start` on a shared session begins fresh). Flows that relied on `start` to wipe a live session mid-conversation
-must use `reset` (corrections) or let the flow complete (fresh run).
+flow's `start` on a shared session begins fresh). This changes
+conversational behavior only, with no code impact: a live session is
+corrected with `reset` (answers not corrected are kept) and a fresh run
+begins after the flow completes.
 
 ### Chat widget customization tokens + escape hatch
 

--- a/skills/waniwani-sdk/references/upgrading.md
+++ b/skills/waniwani-sdk/references/upgrading.md
@@ -21,6 +21,16 @@ Deprecations (struck-through signatures, `@deprecated` JSDoc) are **not** breaki
 
 These entries add capability without changing existing behavior — listed so the surface is discoverable, not because an upgrade needs action.
 
+### 0.20.0: first-turn extraction and idempotent `start` (flow engine)
+
+No code changes required. The generated flow tool schema now demands
+`stateUpdates` extraction on every call (`{}` when there is nothing to
+extract), start-interrupts carry a self-heal instruction when the opening
+message already answers the parked question, and a `start` on a session
+parked mid-flow executes as a `continue` instead of restarting with fresh
+state. Flows that relied on `start` to wipe a live session mid-conversation
+must use `reset` (corrections) or let the flow complete (fresh run).
+
 ### Chat widget customization tokens + escape hatch
 
 New `ChatTheme` tokens on `appearance.variables`: `userBubbleTextColor`, `assistantBubbleTextColor`, `messagePaddingX`, `messagePaddingY`, `messageMaxWidth`, `fontSize`, `lineHeight`. New `appearance.assistantBubble` flag (opt-in filled assistant bubble; default `false`). New React `classNames` prop (`ChatClassNames`: `root`, `header`, `message`, `userBubble`, `assistantBubble`, `input`) and stable Shadow-DOM-reachable classes for `data-css` (`.ww-message`, `.ww-message-user`, `.ww-message-assistant`, `.ww-bubble`, `.ww-header`, `.ww-input`). See `references/chat-widget.md`.

--- a/skills/waniwani-sdk/references/upgrading.md
+++ b/skills/waniwani-sdk/references/upgrading.md
@@ -28,7 +28,8 @@ No code changes required. The generated flow tool schema now demands
 extract), start-interrupts carry a self-heal instruction when the opening
 message already answers the parked question, and a `start` on a session
 parked mid-flow executes as a `continue` instead of restarting with fresh
-state. Flows that relied on `start` to wipe a live session mid-conversation
+state, provided the parked record belongs to the same flow (a different
+flow's `start` on a shared session begins fresh). Flows that relied on `start` to wipe a live session mid-conversation
 must use `reset` (corrections) or let the flow complete (fresh run).
 
 ### Chat widget customization tokens + escape hatch

--- a/src/chat/web/hooks/__tests__/use-suggestions.test.tsx
+++ b/src/chat/web/hooks/__tests__/use-suggestions.test.tsx
@@ -275,3 +275,61 @@ describe("useSuggestions — origin filtering", () => {
 		expect(hookRef.current?.source).toBe("channel");
 	});
 });
+
+describe("useSuggestions — full origin set (regression)", () => {
+	const OPENER = ["Option A", "Option B", "Option C"];
+	const NEXT_STEP = ["Choice X", "Choice Y"];
+	const config = {
+		initial: ["Starter 1", "Starter 2"],
+		origins: ["channel", "page", "flow", "followup"] as SuggestionOrigin[],
+	};
+
+	function assistantWithTwoFlowResults(id: string) {
+		const first = assistantMessageWithFlowSuggestions(OPENER);
+		const second = assistantMessageWithFlowSuggestions(NEXT_STEP);
+		return {
+			id,
+			role: "assistant" as const,
+			parts: [...first.parts, ...second.parts],
+		} as Msg;
+	}
+
+	test("starter prompts do not survive the first user message", () => {
+		render({ messages: [], status: "ready", config });
+		expect(hookRef.current?.suggestions).toEqual(["Starter 1", "Starter 2"]);
+		const turn: Msg[] = [userMessage("hello")];
+		render({ messages: turn, status: "streaming", config });
+		expect(hookRef.current?.suggestions).toEqual([]);
+	});
+
+	test("flow pills win over starters when every origin is enabled", () => {
+		render({ messages: [], status: "streaming", config });
+		const turn: Msg[] = [
+			userMessage("hello"),
+			assistantMessageWithFlowSuggestions(OPENER),
+		];
+		render({ messages: turn, status: "ready", config });
+		expect(hookRef.current?.suggestions).toEqual(OPENER);
+		expect(hookRef.current?.source).toBe("flow");
+	});
+
+	test("the last flow result of the turn drives the pills", () => {
+		render({ messages: [], status: "streaming", config });
+		const turn: Msg[] = [
+			userMessage("hello"),
+			assistantWithTwoFlowResults("a1"),
+		];
+		render({ messages: turn, status: "ready", config });
+		expect(hookRef.current?.suggestions).toEqual(NEXT_STEP);
+	});
+
+	test("an un-advanced start keeps its step's pills (residual the engine self-heal addresses)", () => {
+		render({ messages: [], status: "streaming", config });
+		const turn1: Msg[] = [
+			userMessage("I just did the thing"),
+			assistantMessageWithFlowSuggestions(OPENER),
+		];
+		render({ messages: turn1, status: "ready", config });
+		expect(hookRef.current?.suggestions).toEqual(OPENER);
+	});
+});

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -568,10 +568,7 @@ export type FlowTokenContent = {
 	state: Record<string, unknown>;
 	field?: string;
 	widgetId?: string;
-	/**
-	 * Identifies the flow that wrote this record; a start redirect resumes
-	 * only records written by the same flow.
-	 */
+	/** Flow that wrote this record; a start redirects only into records carrying this flow's id. */
 	flowId?: string;
 };
 

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -568,6 +568,11 @@ export type FlowTokenContent = {
 	state: Record<string, unknown>;
 	field?: string;
 	widgetId?: string;
+	/**
+	 * Identifies the flow that wrote this record; a start redirect resumes
+	 * only records written by the same flow.
+	 */
+	flowId?: string;
 };
 
 export type InterruptQuestionData = {
@@ -643,6 +648,6 @@ export type ExecutionResult = {
 	flowTokenContent?: FlowTokenContent;
 	/** Nodes visited during this execution (excludes nodes with hideFromFunnel). */
 	nodesVisited?: NodeVisit[];
-	/** Set when a start on a live session was executed as a continue. */
+	/** True when a start redirected into a live session's current step instead of restarting. */
 	redirected?: boolean;
 };

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -643,4 +643,6 @@ export type ExecutionResult = {
 	flowTokenContent?: FlowTokenContent;
 	/** Nodes visited during this execution (excludes nodes with hideFromFunnel). */
 	nodesVisited?: NodeVisit[];
+	/** Set when a start on a live session was executed as a continue. */
+	redirected?: boolean;
 };

--- a/src/mcp/server/flows/__tests__/compile.test.ts
+++ b/src/mcp/server/flows/__tests__/compile.test.ts
@@ -947,9 +947,8 @@ describe("validate on interrupt", () => {
 });
 
 describe("isError on error responses", () => {
-	const store = new TestFlowStateStore();
-
 	test("error responses have isError: true", async () => {
+		const store = new TestFlowStateStore();
 		const flow = createFlow({
 			id: "error_flow",
 			title: "Error Flow",
@@ -981,6 +980,7 @@ describe("isError on error responses", () => {
 	});
 
 	test("non-error responses do not have isError", async () => {
+		const store = new TestFlowStateStore();
 		const flow = createFlow({
 			id: "success_flow",
 			title: "Success Flow",

--- a/src/mcp/server/flows/__tests__/idempotent-start.test.ts
+++ b/src/mcp/server/flows/__tests__/idempotent-start.test.ts
@@ -148,6 +148,44 @@ describe("idempotent start on a live session", () => {
 		assertInterruptResult(r);
 		expect(r.field).toBe("color");
 	});
+
+	test("a legacy record without flowId still redirects via the node-name fallback", async () => {
+		const store = new TestFlowStateStore();
+		const sessionId = "legacy-session-without-flow-id";
+
+		// Seed the store with a legacy record (no flowId field)
+		await store.set(sessionId, { step: "ask_size", state: { color: "Red" } });
+
+		const flow = buildTwoStepFlow(store);
+		const mock = mockServer();
+		await flow.register(mock.server);
+		const handler = mock.registered[0]?.[2];
+		if (!handler) {
+			throw new Error('flow "idempotent_probe" did not register a handler');
+		}
+
+		// Call start with the seeded sessionId
+		const resultPayload = (await handler(
+			{ action: "start", intent: "resume session" },
+			{ _meta: { sessionId } },
+		)) as Record<string, unknown>;
+
+		const parsed = parsePayload(resultPayload);
+		expect(parsed.status).toBe("interrupt");
+		if (parsed.status !== "interrupt") {
+			throw new Error(
+				`expected interrupt result, got status "${parsed.status}"`,
+			);
+		}
+		expect(parsed.field).toBe("size");
+		expect(parsed.context ?? "").toContain(
+			"already in progress; resumed at the current step",
+		);
+
+		// Verify the stored record now has flowId stamped
+		const updated = await store.get(sessionId);
+		expect(updated?.flowId).toBe("idempotent_probe");
+	});
 });
 
 const mockPlanPickerTool: RegisteredTool = {

--- a/src/mcp/server/flows/__tests__/idempotent-start.test.ts
+++ b/src/mcp/server/flows/__tests__/idempotent-start.test.ts
@@ -271,4 +271,83 @@ describe("idempotent start across flows sharing a session id", () => {
 		);
 		expect(resultB.isError).toBeUndefined();
 	});
+
+	test("a start with a session id parked by another flow's same-named step still runs fresh with no state bleed", async () => {
+		const store = new TestFlowStateStore();
+		const extra = { _meta: { sessionId: "shared-session-same-node-name" } };
+
+		// Both flows name their first (and only) node "confirm", so a guard
+		// keyed on node-name presence alone would treat flow A's record as
+		// belonging to flow B too.
+		const flowA = createFlow({
+			id: "idempotent_same_name_a",
+			title: "p",
+			description: "d",
+			state: { topic: z.string().optional(), note: z.string().optional() },
+		})
+			.addNode("confirm", ({ interrupt }) =>
+				interrupt({ topic: { question: "What's the topic?" } }),
+			)
+			.addEdge(START, "confirm")
+			.addEdge("confirm", END)
+			.compile({ store });
+
+		const mockA = mockServer();
+		await flowA.register(mockA.server);
+		const handlerA = mockA.registered[0]?.[2];
+		if (!handlerA) {
+			throw new Error(
+				'flow "idempotent_same_name_a" did not register a handler',
+			);
+		}
+
+		// Park flow A on "confirm" carrying a field ("note") flow B never
+		// declares, without answering "topic" (so the flow stays parked there).
+		await handlerA(
+			{
+				action: "start",
+				intent: "park flow A",
+				stateUpdates: { note: "A's private note" },
+			},
+			extra,
+		);
+
+		const flowB = createFlow({
+			id: "idempotent_same_name_b",
+			title: "p",
+			description: "d",
+			state: { nickname: z.string().optional() },
+		})
+			.addNode("confirm", ({ interrupt }) =>
+				interrupt({ nickname: { question: "What should we call you?" } }),
+			)
+			.addEdge(START, "confirm")
+			.addEdge("confirm", END)
+			.compile({ store });
+
+		const mockB = mockServer();
+		await flowB.register(mockB.server);
+		const handlerB = mockB.registered[0]?.[2];
+		if (!handlerB) {
+			throw new Error(
+				'flow "idempotent_same_name_b" did not register a handler',
+			);
+		}
+
+		const resultB = (await handlerB(
+			{ action: "start", intent: "start flow B" },
+			extra,
+		)) as Record<string, unknown>;
+		const parsedB = parsePayload(resultB);
+
+		expect(parsedB.status).toBe("interrupt");
+		expect(parsedB.field).toBe("nickname");
+		expect((parsedB.context as string | undefined) ?? "").not.toContain(
+			"already in progress",
+		);
+		expect(resultB.isError).toBeUndefined();
+
+		const decoded = await store.get("shared-session-same-node-name");
+		expect(decoded?.state).not.toHaveProperty("note");
+	});
 });

--- a/src/mcp/server/flows/__tests__/idempotent-start.test.ts
+++ b/src/mcp/server/flows/__tests__/idempotent-start.test.ts
@@ -21,10 +21,8 @@ class TestFlowStateStore {
 }
 
 /**
- * Fails the first read (the redirect probe made by a "start" call) and
- * succeeds afterward. The later, successful reads let the test harness's own
- * `decodedState` bookkeeping fetch (see `toResult` in `test-utils.ts`) resolve
- * normally, so only the redirect probe's catch-and-fall-through is under test.
+ * Fails only the first read (the start call's redirect probe) so the
+ * harness's own bookkeeping reads still resolve.
  */
 class ThrowingReadStore extends TestFlowStateStore {
 	private reads = 0;
@@ -37,11 +35,6 @@ class ThrowingReadStore extends TestFlowStateStore {
 	}
 }
 
-/**
- * `FlowTestResult` is a union of the four flow content shapes plus a decoded
- * state. These narrow to the member under test so assertions can read
- * `field`/`context`/`tool`, properties the other members don't declare.
- */
 function assertInterruptResult(
 	result: FlowTestResult,
 ): asserts result is Extract<FlowTestResult, { status: "interrupt" }> {
@@ -106,6 +99,7 @@ describe("idempotent start on a live session", () => {
 			"already in progress; resumed at the current step",
 		);
 		expect(r.context).toContain('Use action "reset"');
+		expect(r.context).toContain("answers not corrected are kept");
 		expect(r.context ?? "").not.toContain("BEFORE asking");
 	});
 
@@ -149,11 +143,12 @@ describe("idempotent start on a live session", () => {
 		expect(r.field).toBe("color");
 	});
 
-	test("a legacy record without flowId still redirects via the node-name fallback", async () => {
+	test("a record without flowId runs fresh instead of redirecting", async () => {
 		const store = new TestFlowStateStore();
 		const sessionId = "legacy-session-without-flow-id";
 
-		// Seed the store with a legacy record (no flowId field)
+		// A record without flowId must not redirect, even when its step name
+		// exists in this flow's graph.
 		await store.set(sessionId, { step: "ask_size", state: { color: "Red" } });
 
 		const flow = buildTwoStepFlow(store);
@@ -164,7 +159,6 @@ describe("idempotent start on a live session", () => {
 			throw new Error('flow "idempotent_probe" did not register a handler');
 		}
 
-		// Call start with the seeded sessionId
 		const resultPayload = (await handler(
 			{ action: "start", intent: "resume session" },
 			{ _meta: { sessionId } },
@@ -177,14 +171,12 @@ describe("idempotent start on a live session", () => {
 				`expected interrupt result, got status "${parsed.status}"`,
 			);
 		}
-		expect(parsed.field).toBe("size");
-		expect(parsed.context ?? "").toContain(
-			"already in progress; resumed at the current step",
-		);
+		expect(parsed.field).toBe("color");
+		expect(parsed.context ?? "").not.toContain("already in progress");
 
-		// Verify the stored record now has flowId stamped
 		const updated = await store.get(sessionId);
 		expect(updated?.flowId).toBe("idempotent_probe");
+		expect(updated?.step).toBe("ask_color");
 	});
 });
 
@@ -265,15 +257,13 @@ describe("idempotent start across flows sharing a session id", () => {
 			throw new Error('flow "idempotent_probe" did not register a handler');
 		}
 
-		// Park flow A mid-flow under the shared session id.
 		await handlerA({ action: "start", intent: "park flow A" }, extra);
 		await handlerA(
 			{ action: "continue", stateUpdates: { color: "Red" } },
 			extra,
 		);
 
-		// Flow B has its own id and its own node names, but shares the store and,
-		// via the shared session id, sees flow A's parked step on a start.
+		// Flow B shares the store and session id but not the flow id.
 		const flowB = createFlow({
 			id: "idempotent_other_flow",
 			title: "p",
@@ -314,9 +304,7 @@ describe("idempotent start across flows sharing a session id", () => {
 		const store = new TestFlowStateStore();
 		const extra = { _meta: { sessionId: "shared-session-same-node-name" } };
 
-		// Both flows name their first (and only) node "confirm", so a guard
-		// keyed on node-name presence alone would treat flow A's record as
-		// belonging to flow B too.
+		// Both flows name their only node "confirm".
 		const flowA = createFlow({
 			id: "idempotent_same_name_a",
 			title: "p",
@@ -339,8 +327,7 @@ describe("idempotent start across flows sharing a session id", () => {
 			);
 		}
 
-		// Park flow A on "confirm" carrying a field ("note") flow B never
-		// declares, without answering "topic" (so the flow stays parked there).
+		// Park flow A on "confirm" carrying a field flow B never declares.
 		await handlerA(
 			{
 				action: "start",

--- a/src/mcp/server/flows/__tests__/idempotent-start.test.ts
+++ b/src/mcp/server/flows/__tests__/idempotent-start.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { z } from "zod";
 import type { RegisteredTool } from "../../../../legacy/mcp/tools/types";
-import type { FlowTokenContent } from "../@types";
+import type { FlowTokenContent, McpServer } from "../@types";
 import { END, START } from "../@types";
 import { createFlow } from "../create-flow";
 import type { FlowTestResult } from "../test-utils";
@@ -191,5 +191,84 @@ describe("idempotent start while parked on a widget", () => {
 		const r = await h.start("spurious second start");
 		assertWidgetResult(r);
 		expect(r.tool).toBe(first.tool);
+	});
+});
+
+type Handler = (input: unknown, extra: unknown) => Promise<unknown>;
+type RegisterToolArgs = [string, Record<string, unknown>, Handler];
+
+function mockServer() {
+	const registered: RegisterToolArgs[] = [];
+	const server = {
+		registerTool: (...args: unknown[]) => {
+			registered.push(args as RegisterToolArgs);
+		},
+	};
+	return { server: server as unknown as McpServer, registered };
+}
+
+function parsePayload(
+	result: Record<string, unknown>,
+): Record<string, unknown> {
+	const content = result.content as Array<{ type: string; text?: string }>;
+	return JSON.parse(content[0]?.text ?? "") as Record<string, unknown>;
+}
+
+describe("idempotent start across flows sharing a session id", () => {
+	test("a start with a session id parked by another flow runs fresh instead of redirecting into it", async () => {
+		const store = new TestFlowStateStore();
+		const extra = { _meta: { sessionId: "shared-session-cross-flow" } };
+
+		const flowA = buildTwoStepFlow(store);
+		const mockA = mockServer();
+		await flowA.register(mockA.server);
+		const handlerA = mockA.registered[0]?.[2];
+		if (!handlerA) {
+			throw new Error('flow "idempotent_probe" did not register a handler');
+		}
+
+		// Park flow A mid-flow under the shared session id.
+		await handlerA({ action: "start", intent: "park flow A" }, extra);
+		await handlerA(
+			{ action: "continue", stateUpdates: { color: "Red" } },
+			extra,
+		);
+
+		// Flow B has its own id and its own node names, but shares the store and,
+		// via the shared session id, sees flow A's parked step on a start.
+		const flowB = createFlow({
+			id: "idempotent_other_flow",
+			title: "p",
+			description: "d",
+			state: { nickname: z.string().optional() },
+		})
+			.addNode("ask_nickname", ({ interrupt }) =>
+				interrupt({ nickname: { question: "What should we call you?" } }),
+			)
+			.addEdge(START, "ask_nickname")
+			.addEdge("ask_nickname", END)
+			.compile({ store });
+
+		const mockB = mockServer();
+		await flowB.register(mockB.server);
+		const handlerB = mockB.registered[0]?.[2];
+		if (!handlerB) {
+			throw new Error(
+				'flow "idempotent_other_flow" did not register a handler',
+			);
+		}
+
+		const resultB = (await handlerB(
+			{ action: "start", intent: "start flow B" },
+			extra,
+		)) as Record<string, unknown>;
+		const parsedB = parsePayload(resultB);
+
+		expect(parsedB.status).toBe("interrupt");
+		expect(parsedB.field).toBe("nickname");
+		expect((parsedB.context as string | undefined) ?? "").not.toContain(
+			"already in progress",
+		);
+		expect(resultB.isError).toBeUndefined();
 	});
 });

--- a/src/mcp/server/flows/__tests__/idempotent-start.test.ts
+++ b/src/mcp/server/flows/__tests__/idempotent-start.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { RegisteredTool } from "../../../../legacy/mcp/tools/types";
+import type { FlowTokenContent } from "../@types";
+import { END, START } from "../@types";
+import { createFlow } from "../create-flow";
+import type { FlowTestResult } from "../test-utils";
+import { createFlowTestHarness } from "../test-utils";
+
+class TestFlowStateStore {
+	private readonly map = new Map<string, FlowTokenContent>();
+	async get(key: string): Promise<FlowTokenContent | null> {
+		return this.map.get(key) ?? null;
+	}
+	async set(key: string, value: FlowTokenContent): Promise<void> {
+		this.map.set(key, value);
+	}
+	async delete(key: string): Promise<void> {
+		this.map.delete(key);
+	}
+}
+
+/**
+ * Fails the first read (the redirect probe made by a "start" call) and
+ * succeeds afterward. The later, successful reads let the test harness's own
+ * `decodedState` bookkeeping fetch (see `toResult` in `test-utils.ts`) resolve
+ * normally, so only the redirect probe's catch-and-fall-through is under test.
+ */
+class ThrowingReadStore extends TestFlowStateStore {
+	private reads = 0;
+	override async get(key: string): Promise<FlowTokenContent | null> {
+		this.reads += 1;
+		if (this.reads === 1) {
+			throw new Error("kv unavailable");
+		}
+		return super.get(key);
+	}
+}
+
+/**
+ * `FlowTestResult` is a union of the four flow content shapes plus a decoded
+ * state. These narrow to the member under test so assertions can read
+ * `field`/`context`/`tool`, properties the other members don't declare.
+ */
+function assertInterruptResult(
+	result: FlowTestResult,
+): asserts result is Extract<FlowTestResult, { status: "interrupt" }> {
+	if (result.status !== "interrupt") {
+		throw new Error(`expected interrupt result, got status "${result.status}"`);
+	}
+}
+
+function assertWidgetResult(
+	result: FlowTestResult,
+): asserts result is Extract<FlowTestResult, { status: "widget" }> {
+	if (result.status !== "widget") {
+		throw new Error(`expected widget result, got status "${result.status}"`);
+	}
+}
+
+function buildTwoStepFlow(store: TestFlowStateStore) {
+	return createFlow({
+		id: "idempotent_probe",
+		title: "p",
+		description: "d",
+		state: { color: z.string().optional(), size: z.string().optional() },
+	})
+		.addNode("ask_color", ({ interrupt }) =>
+			interrupt({
+				color: { question: "Favorite color?", suggestions: ["Red", "Blue"] },
+			}),
+		)
+		.addNode("ask_size", ({ interrupt }) =>
+			interrupt({ size: { question: "Which size?", suggestions: ["S", "M"] } }),
+		)
+		.addEdge(START, "ask_color")
+		.addEdge("ask_color", "ask_size")
+		.addEdge("ask_size", END)
+		.compile({ store });
+}
+
+describe("idempotent start on a live session", () => {
+	test("a second start resumes the parked step instead of restarting", async () => {
+		const store = new TestFlowStateStore();
+		const h = await createFlowTestHarness(buildTwoStepFlow(store), {
+			stateStore: store,
+		});
+		await h.start("first start");
+		await h.continueWith({ color: "Red" });
+		const r = await h.start("spurious second start");
+		expect(r.status).toBe("interrupt");
+		assertInterruptResult(r);
+		expect(r.field).toBe("size");
+		expect(r.decodedState?.state).toMatchObject({ color: "Red" });
+	});
+
+	test("the redirected result explains itself and points at reset", async () => {
+		const store = new TestFlowStateStore();
+		const h = await createFlowTestHarness(buildTwoStepFlow(store), {
+			stateStore: store,
+		});
+		await h.start("first start");
+		const r = await h.start("spurious second start");
+		assertInterruptResult(r);
+		expect(r.context).toContain(
+			"already in progress; resumed at the current step",
+		);
+		expect(r.context).toContain('Use action "reset"');
+		expect(r.context ?? "").not.toContain("BEFORE asking");
+	});
+
+	test("a redirected start merges its stateUpdates like a continue", async () => {
+		const store = new TestFlowStateStore();
+		const h = await createFlowTestHarness(buildTwoStepFlow(store), {
+			stateStore: store,
+		});
+		await h.start("first start");
+		const r = await h.start("second start carrying the answer", {
+			color: "Blue",
+		});
+		expect(r.status).toBe("interrupt");
+		assertInterruptResult(r);
+		expect(r.field).toBe("size");
+		expect(r.decodedState?.state).toMatchObject({ color: "Blue" });
+	});
+
+	test("a start after completion runs fresh (restart path preserved)", async () => {
+		const store = new TestFlowStateStore();
+		const h = await createFlowTestHarness(buildTwoStepFlow(store), {
+			stateStore: store,
+		});
+		await h.start("first start");
+		await h.continueWith({ color: "Red" });
+		await h.continueWith({ size: "M" });
+		const r = await h.start("brand new run");
+		expect(r.status).toBe("interrupt");
+		assertInterruptResult(r);
+		expect(r.field).toBe("color");
+	});
+
+	test("an unreadable store falls through to a fresh start", async () => {
+		const store = new ThrowingReadStore();
+		const h = await createFlowTestHarness(buildTwoStepFlow(store), {
+			stateStore: store,
+		});
+		const r = await h.start("first start on a flaky store");
+		expect(r.status).toBe("interrupt");
+		assertInterruptResult(r);
+		expect(r.field).toBe("color");
+	});
+});
+
+const mockPlanPickerTool: RegisteredTool = {
+	id: "plan_picker",
+	title: "Plan Picker",
+	description: "Show plan picker widget",
+	register: async () => {},
+};
+
+function buildWidgetFlow(store: TestFlowStateStore) {
+	return createFlow({
+		id: "idempotent_widget_probe",
+		title: "p",
+		description: "d",
+		state: { color: z.string().optional(), plan: z.string().optional() },
+	})
+		.addNode("ask_color", ({ interrupt }) =>
+			interrupt({
+				color: { question: "Favorite color?", suggestions: ["Red", "Blue"] },
+			}),
+		)
+		.addNode("show_plan", ({ showWidget }) =>
+			showWidget({ tool: mockPlanPickerTool, field: "plan" }),
+		)
+		.addEdge(START, "ask_color")
+		.addEdge("ask_color", "show_plan")
+		.addEdge("show_plan", END)
+		.compile({ store });
+}
+
+describe("idempotent start while parked on a widget", () => {
+	test("a start while parked on a widget re-emits the widget instead of skipping it", async () => {
+		const store = new TestFlowStateStore();
+		const h = await createFlowTestHarness(buildWidgetFlow(store), {
+			stateStore: store,
+		});
+		await h.start("first start");
+		const first = await h.continueWith({ color: "Red" });
+		assertWidgetResult(first);
+
+		const r = await h.start("spurious second start");
+		assertWidgetResult(r);
+		expect(r.tool).toBe(first.tool);
+	});
+});

--- a/src/mcp/server/flows/__tests__/input-schema.test.ts
+++ b/src/mcp/server/flows/__tests__/input-schema.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { FlowTokenContent, McpServer } from "../@types";
+import { END, START } from "../@types";
+import { createFlow } from "../create-flow";
+
+class TestFlowStateStore {
+	private readonly map = new Map<string, FlowTokenContent>();
+	async get(key: string): Promise<FlowTokenContent | null> {
+		return this.map.get(key) ?? null;
+	}
+	async set(key: string, value: FlowTokenContent): Promise<void> {
+		this.map.set(key, value);
+	}
+	async delete(key: string): Promise<void> {
+		this.map.delete(key);
+	}
+}
+
+type RegisterToolArgs = [
+	string,
+	{ inputSchema: Record<string, z.ZodTypeAny> },
+	unknown,
+];
+
+function registeredSchema(): Record<string, z.ZodTypeAny> {
+	const registered: RegisterToolArgs[] = [];
+	const server = {
+		registerTool: (...args: unknown[]) => {
+			registered.push(args as RegisterToolArgs);
+		},
+	};
+	const flow = createFlow({
+		id: "schema_probe",
+		title: "Schema probe",
+		description: "d",
+		state: { color: z.string().optional() },
+	})
+		.addNode("ask_color", ({ interrupt }) =>
+			interrupt({ color: { question: "Favorite color?" } }),
+		)
+		.addEdge(START, "ask_color")
+		.addEdge("ask_color", END)
+		.compile({ store: new TestFlowStateStore() });
+	void flow.register(server as unknown as McpServer);
+	const schema = registered[0]?.[1]?.inputSchema;
+	if (!schema) {
+		throw new Error("flow did not register an input schema");
+	}
+	return schema;
+}
+
+describe("generated flow tool input schema", () => {
+	test("stateUpdates precedes intent and context", () => {
+		expect(Object.keys(registeredSchema())).toEqual([
+			"action",
+			"stateUpdates",
+			"intent",
+			"context",
+			"sessionId",
+		]);
+	});
+
+	test("stateUpdates description demands extraction with the {} escape hatch", () => {
+		const description = registeredSchema().stateUpdates?.description ?? "";
+		expect(description).toContain("REQUIRED on every call ({} is valid)");
+		expect(description).toContain("The only channel that fills flow fields");
+		expect(description).toContain(
+			"each answer it contains MUST be extracted here or the flow will re-ask it",
+		);
+		expect(description).toContain("Pass {} when it answers none");
+		expect(description).toContain("never infer or derive");
+	});
+
+	test("intent description states the engine never reads it", () => {
+		const description = registeredSchema().intent?.description ?? "";
+		expect(description).toContain("The flow engine never reads intent");
+		expect(description).toContain(
+			"every concrete answer must also go in stateUpdates",
+		);
+	});
+
+	test("stateUpdates stays optional in the Zod schema (no new error paths)", () => {
+		expect(registeredSchema().stateUpdates?.isOptional()).toBe(true);
+	});
+});

--- a/src/mcp/server/flows/__tests__/input-schema.test.ts
+++ b/src/mcp/server/flows/__tests__/input-schema.test.ts
@@ -83,4 +83,11 @@ describe("generated flow tool input schema", () => {
 	test("stateUpdates stays optional in the Zod schema (no new error paths)", () => {
 		expect(registeredSchema().stateUpdates?.isOptional()).toBe(true);
 	});
+
+	test("action description scopes start to a not-yet-started flow", () => {
+		const description = registeredSchema().action?.description ?? "";
+		expect(description).toContain(
+			"only if this flow has not already been started",
+		);
+	});
 });

--- a/src/mcp/server/flows/__tests__/start-self-heal.test.ts
+++ b/src/mcp/server/flows/__tests__/start-self-heal.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type {
+	FlowContent,
+	FlowInterruptContent,
+	FlowTokenContent,
+} from "../@types";
+import { END, START } from "../@types";
+import { createFlow } from "../create-flow";
+import { withStartSelfHeal } from "../start-self-heal";
+import type { FlowTestResult } from "../test-utils";
+import { createFlowTestHarness } from "../test-utils";
+
+class TestFlowStateStore {
+	private readonly map = new Map<string, FlowTokenContent>();
+	async get(key: string): Promise<FlowTokenContent | null> {
+		return this.map.get(key) ?? null;
+	}
+	async set(key: string, value: FlowTokenContent): Promise<void> {
+		this.map.set(key, value);
+	}
+	async delete(key: string): Promise<void> {
+		this.map.delete(key);
+	}
+}
+
+/**
+ * `withStartSelfHeal` returns the `FlowContent` union, and `createFlowTestHarness`
+ * results carry the same union shape. These narrow to the interrupt member so
+ * the assertions below can read `context`/`field`/`suggestions`, properties
+ * the other members (widget/complete/error) don't declare.
+ */
+function assertInterruptContent(
+	content: FlowContent,
+): asserts content is FlowInterruptContent {
+	if (content.status !== "interrupt") {
+		throw new Error(
+			`expected interrupt content, got status "${content.status}"`,
+		);
+	}
+}
+
+function assertInterruptResult(
+	result: FlowTestResult,
+): asserts result is Extract<FlowTestResult, { status: "interrupt" }> {
+	if (result.status !== "interrupt") {
+		throw new Error(`expected interrupt result, got status "${result.status}"`);
+	}
+}
+
+const single = {
+	status: "interrupt" as const,
+	question: "Favorite color?",
+	field: "color",
+};
+
+const multi = {
+	status: "interrupt" as const,
+	questions: [
+		{ question: "Name?", field: "name" },
+		{ question: "Email?", field: "email" },
+	],
+};
+
+describe("withStartSelfHeal", () => {
+	test("appends the single-question check with the field name", () => {
+		const out = withStartSelfHeal(single, { sessionIdEchoed: false });
+		assertInterruptContent(out);
+		expect(out.context).toContain(
+			"BEFORE asking, re-read the user's opening message",
+		);
+		expect(out.context).toContain('stateUpdates: { "color":');
+		expect(out.context).not.toContain("the same sessionId");
+	});
+
+	test("mentions the sessionId only when the response echoes one", () => {
+		const out = withStartSelfHeal(single, { sessionIdEchoed: true });
+		assertInterruptContent(out);
+		expect(out.context).toContain('action "continue", the same sessionId');
+	});
+
+	test("uses the multi-question form when several questions are open", () => {
+		const out = withStartSelfHeal(multi, { sessionIdEchoed: false });
+		assertInterruptContent(out);
+		expect(out.context).toContain("If it answers any of the questions below");
+		expect(out.context).toContain("the engine re-asks the rest");
+	});
+
+	test("appends after author context instead of replacing it", () => {
+		const out = withStartSelfHeal(
+			{ ...single, context: "Only accept a color word." },
+			{ sessionIdEchoed: false },
+		);
+		assertInterruptContent(out);
+		expect(out.context?.startsWith("Only accept a color word.")).toBe(true);
+		expect(out.context).toContain("BEFORE asking");
+	});
+
+	test("leaves validation-error re-parks untouched", () => {
+		const errored = {
+			...single,
+			context: "ERROR: not a color\n\nOnly accept a color word.",
+		};
+		expect(withStartSelfHeal(errored, { sessionIdEchoed: false })).toBe(
+			errored,
+		);
+	});
+
+	test("leaves non-interrupt content untouched", () => {
+		const complete = { status: "complete" as const, state: {} };
+		expect(withStartSelfHeal(complete, { sessionIdEchoed: false })).toBe(
+			complete,
+		);
+	});
+});
+
+function buildTwoStepFlow() {
+	return createFlow({
+		id: "self_heal_probe",
+		title: "p",
+		description: "d",
+		state: { color: z.string().optional(), size: z.string().optional() },
+	})
+		.addNode("ask_color", ({ interrupt }) =>
+			interrupt({
+				color: { question: "Favorite color?", suggestions: ["Red", "Blue"] },
+			}),
+		)
+		.addNode("ask_size", ({ interrupt }) =>
+			interrupt({ size: { question: "Which size?", suggestions: ["S", "M"] } }),
+		)
+		.addEdge(START, "ask_color")
+		.addEdge("ask_color", "ask_size")
+		.addEdge("ask_size", END)
+		.compile({ store: new TestFlowStateStore() });
+}
+
+describe("start-interrupt self-heal wiring", () => {
+	test("a start that parks on an interrupt carries the check in its context", async () => {
+		const h = await createFlowTestHarness(buildTwoStepFlow());
+		const r = await h.start("visitor wants a recommendation");
+		expect(r.status).toBe("interrupt");
+		assertInterruptResult(r);
+		expect(r.context).toContain(
+			"BEFORE asking, re-read the user's opening message",
+		);
+	});
+
+	test("a continue that advances carries no check", async () => {
+		const h = await createFlowTestHarness(buildTwoStepFlow());
+		await h.start("visitor wants a recommendation");
+		const r = await h.continueWith({ color: "Red" });
+		expect(r.status).toBe("interrupt");
+		assertInterruptResult(r);
+		expect(r.field).toBe("size");
+		expect(r.context ?? "").not.toContain("BEFORE asking");
+	});
+
+	test("an empty bounce re-parks without the check (no loop)", async () => {
+		const h = await createFlowTestHarness(buildTwoStepFlow());
+		await h.start("visitor wants a recommendation");
+		const r = await h.continueWith({});
+		expect(r.status).toBe("interrupt");
+		assertInterruptResult(r);
+		expect(r.field).toBe("color");
+		expect(r.context ?? "").not.toContain("BEFORE asking");
+	});
+
+	test("a start that auto-skips to a later step still gets the check on that step", async () => {
+		const h = await createFlowTestHarness(buildTwoStepFlow());
+		const r = await h.start("visitor wants a recommendation", { color: "Red" });
+		expect(r.status).toBe("interrupt");
+		assertInterruptResult(r);
+		expect(r.field).toBe("size");
+		expect(r.context).toContain("BEFORE asking");
+	});
+
+	test("suggestions meta is unaffected by the injection", async () => {
+		const h = await createFlowTestHarness(buildTwoStepFlow());
+		const r = await h.start("visitor wants a recommendation");
+		assertInterruptResult(r);
+		expect(r.suggestions).toEqual(["Red", "Blue"]);
+	});
+});

--- a/src/mcp/server/flows/__tests__/start-self-heal.test.ts
+++ b/src/mcp/server/flows/__tests__/start-self-heal.test.ts
@@ -24,12 +24,6 @@ class TestFlowStateStore {
 	}
 }
 
-/**
- * `withStartSelfHeal` returns the `FlowContent` union, and `createFlowTestHarness`
- * results carry the same union shape. These narrow to the interrupt member so
- * the assertions below can read `context`/`field`/`suggestions`, properties
- * the other members (widget/complete/error) don't declare.
- */
 function assertInterruptContent(
 	content: FlowContent,
 ): asserts content is FlowInterruptContent {

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -31,6 +31,7 @@ import {
 	collectRedactedStateFields,
 	REDACTED_STATE_UPDATE_FIELDS_META_KEY,
 } from "./redacted";
+import { withStartSelfHeal } from "./start-self-heal";
 
 // ============================================================================
 // Input schema
@@ -391,10 +392,20 @@ export function compileFlow<TState extends Record<string, unknown>>(
 		const result = await handleToolCall(args, sessionId, _meta, waniwani);
 
 		// Echo sessionId in response when not sourced from _meta (client must pass it back)
-		const contentObj =
+		let contentObj =
 			!metaSessionId && sessionId
 				? { ...result.content, sessionId }
 				: result.content;
+
+		// A start that parks on a question the visitor's opening message already
+		// answered is the widest desync path: the agent replies past the parked
+		// step and the pill row describes the wrong question. The appended check
+		// tells the agent to advance the flow in the same turn instead.
+		if (args.action === "start") {
+			contentObj = withStartSelfHeal(contentObj, {
+				sessionIdEchoed: !metaSessionId && sessionId !== undefined,
+			});
+		}
 
 		// Authoritative for the turn: an empty array clears pills an earlier flow
 		// call in the same turn set. Only the single-open-question shorthand

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -143,10 +143,15 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				} catch {
 					existing = null;
 				}
-				// A stored step unknown to this graph belongs to a different flow
-				// sharing the store and session id; such a start runs fresh instead
-				// of resuming another flow's state.
-				if (existing?.step && nodes.has(existing.step)) {
+				// A record written by a different flow sharing the store and session
+				// id never redirects, even when its step name happens to also exist
+				// in this flow's graph. Records that predate the flowId field fall
+				// back to the node-name check so they still redirect once.
+				if (
+					existing?.step &&
+					(existing.flowId === config.id ||
+						(existing.flowId === undefined && nodes.has(existing.step)))
+				) {
 					const mergedState = deepMerge(
 						existing.state as Record<string, unknown>,
 						expandDotPaths(args.stateUpdates ?? {}),
@@ -477,7 +482,10 @@ export function compileFlow<TState extends Record<string, unknown>>(
 		// want the prior behavior (drop the session as soon as END is reached).
 		if (sessionId && result.flowTokenContent) {
 			try {
-				await store.set(sessionId, result.flowTokenContent);
+				await store.set(sessionId, {
+					...result.flowTokenContent,
+					flowId: config.id,
+				});
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : String(err);
 				const errorContent = [

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -143,7 +143,10 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				} catch {
 					existing = null;
 				}
-				if (existing?.step) {
+				// A stored step unknown to this graph belongs to a different flow
+				// sharing the store and session id; such a start runs fresh instead
+				// of resuming another flow's state.
+				if (existing?.step && nodes.has(existing.step)) {
 					const mergedState = deepMerge(
 						existing.state as Record<string, unknown>,
 						expandDotPaths(args.stateUpdates ?? {}),

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -62,22 +62,22 @@ function buildInputSchema(config: {
 			.describe(
 				'"start" to begin the flow, "continue" to resume after a pause (interrupt or widget), "reset" to restart from the beginning with a correction to a previously-collected field',
 			),
+		stateUpdates: stateUpdatesSchema
+			.optional()
+			.describe(
+				'REQUIRED on every call ({} is valid). The only channel that fills flow fields. Copy in every field the user\'s latest message answers, keyed by field name (dot-paths like "driver.name" for nested fields). On start, re-read the user\'s opening message first: each answer it contains MUST be extracted here or the flow will re-ask it. Pass {} when it answers none. Copy only what the user\'s own words state; never infer or derive ("I just retired" does not fill an age field).',
+			),
 		intent: z
 			.string()
 			.optional()
 			.describe(
-				`Required when action is "start". Provide a brief summary of the user's goal for this flow. Do not invent missing intent.${piiNote}`,
+				`Required when action is "start". Provide a brief summary of the user's goal for this flow. Do not invent missing intent. The flow engine never reads intent: facts placed here fill NO fields; every concrete answer must also go in stateUpdates.${piiNote}`,
 			),
 		context: z
 			.string()
 			.optional()
 			.describe(
 				`Optional when action is "start". Describe the situation or environment that led the user to start this flow — e.g. what page they are on, what they were doing, or what triggered the request. Do not invent missing context.${piiNote}`,
-			),
-		stateUpdates: stateUpdatesSchema
-			.optional()
-			.describe(
-				'State field values to set before processing the next node. Pass the user\'s answer (keyed by the field name from the response) and any other values the user mentioned. For nested state fields, use dot-paths like "driver.name".',
 			),
 		sessionId: z
 			.string()

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -61,7 +61,7 @@ function buildInputSchema(config: {
 		action: z
 			.enum(["start", "continue", "reset"])
 			.describe(
-				'"start" to begin the flow, "continue" to resume after a pause (interrupt or widget), "reset" to restart from the beginning with a correction to a previously-collected field',
+				'"start" to begin the flow (only if this flow has not already been started in this conversation), "continue" to resume after a pause (interrupt or widget), "reset" to restart from the beginning with a correction to a previously-collected field',
 			),
 		stateUpdates: stateUpdatesSchema
 			.optional()
@@ -129,8 +129,47 @@ export function compileFlow<TState extends Record<string, unknown>>(
 		sessionId: string | undefined,
 		meta?: Record<string, unknown>,
 		waniwani?: ScopedWaniWaniClient,
+		sessionIdWasSupplied = false,
 	) {
 		if (args.action === "start") {
+			// A start on a session parked mid-flow executes as a continue: the
+			// model sometimes issues a spurious start after a continue in the
+			// same turn, and a fresh re-entry would wipe accumulated state and
+			// stamp the wrong step's suggestions onto the turn.
+			if (sessionIdWasSupplied && sessionId) {
+				let existing: Awaited<ReturnType<typeof store.get>> = null;
+				try {
+					existing = await store.get(sessionId);
+				} catch {
+					existing = null;
+				}
+				if (existing?.step) {
+					const mergedState = deepMerge(
+						existing.state as Record<string, unknown>,
+						expandDotPaths(args.stateUpdates ?? {}),
+					) as TState;
+					const redirectedResult = await executeFrom(
+						existing.step,
+						mergedState,
+						nodes,
+						edges,
+						validators,
+						meta,
+						waniwani,
+						input.nodeOptions,
+						config.state,
+					);
+					if (redirectedResult.content.status === "interrupt") {
+						const note =
+							'This flow was already in progress; resumed at the current step. Use action "reset" to correct an earlier answer.';
+						redirectedResult.content.context = redirectedResult.content.context
+							? `${redirectedResult.content.context}\n\n${note}`
+							: note;
+					}
+					return { ...redirectedResult, redirected: true };
+				}
+			}
+
 			const intent =
 				typeof args.intent === "string" ? args.intent.trim() : undefined;
 			if (!intent) {
@@ -373,6 +412,8 @@ export function compileFlow<TState extends Record<string, unknown>>(
 		const _meta: Record<string, unknown> = requestExtra._meta ?? {};
 		const metaSessionId = extractSessionId(_meta);
 		let sessionId = metaSessionId ?? args.sessionId;
+		const sessionIdWasSupplied =
+			metaSessionId !== undefined || args.sessionId !== undefined;
 
 		// Auto-generate session ID for clients that don't provide one (e.g. Claude Code)
 		if (!sessionId && args.action === "start") {
@@ -389,7 +430,13 @@ export function compileFlow<TState extends Record<string, unknown>>(
 
 		const waniwani = extractScopedClient(requestExtra);
 
-		const result = await handleToolCall(args, sessionId, _meta, waniwani);
+		const result = await handleToolCall(
+			args,
+			sessionId,
+			_meta,
+			waniwani,
+			sessionIdWasSupplied,
+		);
 
 		// Echo sessionId in response when not sourced from _meta (client must pass it back)
 		let contentObj =
@@ -400,8 +447,10 @@ export function compileFlow<TState extends Record<string, unknown>>(
 		// A start that parks on a question the visitor's opening message already
 		// answered is the widest desync path: the agent replies past the parked
 		// step and the pill row describes the wrong question. The appended check
-		// tells the agent to advance the flow in the same turn instead.
-		if (args.action === "start") {
+		// tells the agent to advance the flow in the same turn instead. A
+		// redirected start already carries its own resumed-session framing, so
+		// it skips this self-heal check.
+		if (args.action === "start" && !result.redirected) {
 			contentObj = withStartSelfHeal(contentObj, {
 				sessionIdEchoed: !metaSessionId && sessionId !== undefined,
 			});

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -132,10 +132,8 @@ export function compileFlow<TState extends Record<string, unknown>>(
 		sessionIdWasSupplied = false,
 	) {
 		if (args.action === "start") {
-			// A start on a session parked mid-flow executes as a continue: the
-			// model sometimes issues a spurious start after a continue in the
-			// same turn, and a fresh re-entry would wipe accumulated state and
-			// stamp the wrong step's suggestions onto the turn.
+			// A spurious start on a session parked mid-flow executes as a
+			// continue instead of wiping the accumulated state.
 			if (sessionIdWasSupplied && sessionId) {
 				let existing: Awaited<ReturnType<typeof store.get>> = null;
 				try {
@@ -143,15 +141,8 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				} catch {
 					existing = null;
 				}
-				// A record written by a different flow sharing the store and session
-				// id never redirects, even when its step name happens to also exist
-				// in this flow's graph. Records that predate the flowId field fall
-				// back to the node-name check so they still redirect once.
-				if (
-					existing?.step &&
-					(existing.flowId === config.id ||
-						(existing.flowId === undefined && nodes.has(existing.step)))
-				) {
+				// Only a record this flow wrote may redirect; anything else starts fresh.
+				if (existing?.step && existing.flowId === config.id) {
 					const mergedState = deepMerge(
 						existing.state as Record<string, unknown>,
 						expandDotPaths(args.stateUpdates ?? {}),
@@ -169,7 +160,7 @@ export function compileFlow<TState extends Record<string, unknown>>(
 					);
 					if (redirectedResult.content.status === "interrupt") {
 						const note =
-							'This flow was already in progress; resumed at the current step. Use action "reset" to correct an earlier answer.';
+							'This flow was already in progress; resumed at the current step. Use action "reset" to correct an earlier answer. If the user wants to start over, use "reset" with every field to change; answers not corrected are kept.';
 						redirectedResult.content.context = redirectedResult.content.context
 							? `${redirectedResult.content.context}\n\n${note}`
 							: note;
@@ -452,12 +443,8 @@ export function compileFlow<TState extends Record<string, unknown>>(
 				? { ...result.content, sessionId }
 				: result.content;
 
-		// A start that parks on a question the visitor's opening message already
-		// answered is the widest desync path: the agent replies past the parked
-		// step and the pill row describes the wrong question. The appended check
-		// tells the agent to advance the flow in the same turn instead. A
-		// redirected start already carries its own resumed-session framing, so
-		// it skips this self-heal check.
+		// Redirected starts carry their own resumed-session framing, so only
+		// fresh starts get the self-heal check.
 		if (args.action === "start" && !result.redirected) {
 			contentObj = withStartSelfHeal(contentObj, {
 				sessionIdEchoed: !metaSessionId && sessionId !== undefined,

--- a/src/mcp/server/flows/start-self-heal.ts
+++ b/src/mcp/server/flows/start-self-heal.ts
@@ -8,12 +8,9 @@ const MULTI_QUESTION_CHECK =
 	'BEFORE asking, re-read the user\'s opening message. If it answers any of the questions below, do NOT re-ask those: immediately call this tool again with action "continue" and stateUpdates containing those answers; the engine re-asks the rest. Do NOT infer or convert values. Ask only what their message does not answer.';
 
 /**
- * Appends a hidden self-heal instruction to a start-interrupt so an agent
- * that received the visitor's answers in the opening message advances the
- * flow in the same turn instead of re-asking. Validation-error re-parks
- * (context starting with "ERROR:") and non-interrupt content pass through
- * untouched. The instruction is never persisted in flow state, so a bounce
- * that still extracts nothing cannot loop.
+ * Appends a hidden instruction to a start-interrupt telling the agent to
+ * advance with "continue" when the opening message already answers the
+ * parked question. Never persisted, so an empty bounce cannot loop.
  */
 export function withStartSelfHeal(
 	content: FlowContent,

--- a/src/mcp/server/flows/start-self-heal.ts
+++ b/src/mcp/server/flows/start-self-heal.ts
@@ -1,0 +1,37 @@
+import type { FlowContent } from "./@types";
+
+function singleQuestionCheck(field: string, sessionIdPhrase: string): string {
+	return `BEFORE asking, re-read the user's opening message. If it already answers the question below, do NOT ask it: immediately call this tool again with action "continue"${sessionIdPhrase} and stateUpdates: { "${field}": <the answer in the user's own words> }, then follow the new response instead. Do NOT infer or convert values (a life event is not an age); a plain greeting answers nothing. Ask the question below only if their message does not answer it.`;
+}
+
+const MULTI_QUESTION_CHECK =
+	'BEFORE asking, re-read the user\'s opening message. If it answers any of the questions below, do NOT re-ask those: immediately call this tool again with action "continue" and stateUpdates containing those answers; the engine re-asks the rest. Do NOT infer or convert values. Ask only what their message does not answer.';
+
+/**
+ * Appends a hidden self-heal instruction to a start-interrupt so an agent
+ * that received the visitor's answers in the opening message advances the
+ * flow in the same turn instead of re-asking. Validation-error re-parks
+ * (context starting with "ERROR:") and non-interrupt content pass through
+ * untouched. The instruction is never persisted in flow state, so a bounce
+ * that still extracts nothing cannot loop.
+ */
+export function withStartSelfHeal(
+	content: FlowContent,
+	options: { sessionIdEchoed: boolean },
+): FlowContent {
+	if (content.status !== "interrupt") {
+		return content;
+	}
+	if (content.context?.startsWith("ERROR:")) {
+		return content;
+	}
+	const sessionIdPhrase = options.sessionIdEchoed ? ", the same sessionId" : "";
+	const check =
+		typeof content.field === "string"
+			? singleQuestionCheck(content.field, sessionIdPhrase)
+			: MULTI_QUESTION_CHECK;
+	return {
+		...content,
+		context: content.context ? `${content.context}\n\n${check}` : check,
+	};
+}

--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, test } from "bun:test";
+import { z } from "zod";
 import type { TrackInput } from "../../../../tracking/@types.js";
+import type { FlowTokenContent } from "../../flows/@types.js";
+import { END, START } from "../../flows/@types.js";
+import { createFlow } from "../../flows/create-flow.js";
 import { withWaniwani } from "../index.js";
+
+class TestFlowStateStore {
+	private readonly map = new Map<string, FlowTokenContent>();
+	async get(key: string): Promise<FlowTokenContent | null> {
+		return this.map.get(key) ?? null;
+	}
+	async set(key: string, value: FlowTokenContent): Promise<void> {
+		this.map.set(key, value);
+	}
+	async delete(key: string): Promise<void> {
+		this.map.delete(key);
+	}
+}
 
 function mockClient() {
 	const tracked: TrackInput[] = [];
@@ -991,5 +1008,36 @@ describe("withWaniwani", () => {
 		expect(result._meta?.["waniwani/suggestions"]).toEqual({
 			suggestions: ["Bronze", "Gold"],
 		});
+	});
+
+	test("preserves the start-interrupt self-heal instruction on a flow tool result", async () => {
+		const { client } = mockClient();
+		const mock = mockServer();
+
+		withWaniwani(mock.server, { client });
+
+		const flow = createFlow({
+			id: "self_heal_flow",
+			title: "Self heal flow",
+			description: "Asks one question",
+			state: { color: z.string().optional() },
+		})
+			.addNode("ask_color", ({ interrupt }) =>
+				interrupt({ color: { question: "Favorite color?" } }),
+			)
+			.addEdge(START, "ask_color")
+			.addEdge("ask_color", END)
+			.compile({ store: new TestFlowStateStore() });
+
+		await flow.register(mock.server);
+
+		const handler = mock.registered[0]?.[2];
+		const result = (await handler?.(
+			{ action: "start", intent: "visitor wants a recommendation" },
+			{ _meta: { sessionId: "test-session-self-heal" } },
+		)) as Record<string, unknown>;
+
+		const structured = result.structuredContent as Record<string, unknown>;
+		expect(structured.context).toContain("BEFORE asking");
 	});
 });


### PR DESCRIPTION
Closes WAN-734

Three flow-engine changes keeping the conversation and flow state in lockstep on the first turn and after:

- `stateUpdates` ordered before `intent` in the generated tool schema, with a description requiring extraction on every call ({} when nothing to extract). Answers in the opening message reach the flow on `start` and already-answered questions auto-skip.
- Start-interrupts carry an engine-appended hidden instruction: when the opening message already answers the parked question, the agent advances with `continue` in the same turn, so the widget's suggestion pills describe the question actually asked.
- A `start` on a session parked mid-flow executes as a `continue` (state merges, parked widgets re-emit), guarded by a persisted `flowId` identity: only records stamped by the same flow resume. Records from another flow, or written before the field existed, start fresh, so state never bleeds across flows sharing a store and session id. The redirect note tells the agent that `reset` keeps uncorrected answers (stopgap until WAN-743 adds an explicit `restart`).

Also: widget pill-selection regression tests, docs (flows.md, chat-widget.md, upgrading.md, flows-api-reference.md), version 0.19.4 (patch: no public API change, no user code changes, no migration skill). Rebased on main after the 0.19.3 release.

Verification: typecheck clean, 565/567 tests (2 pre-existing failures on main), build success. E2E against a live MCP: served schema, self-heal, redirect, widget re-emission, Zod rejection of invented values all confirmed; playground LLM run shows the turn-1 desync no longer reproducing. Follow-ups: WAN-737 (same identity guard for continue/reset), WAN-743 (explicit restart action).