### PR TITLE
feat(flows)!: require stateUpdates on every flow tool call

### DIFF
--- a/src/mcp/server/flows/__tests__/required-state-updates.test.ts
+++ b/src/mcp/server/flows/__tests__/required-state-updates.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { FlowTokenContent, McpServer } from "../@types";
+import { END, START } from "../@types";
+import { createFlow } from "../create-flow";
+
+class TestFlowStateStore {
+	private readonly map = new Map<string, FlowTokenContent>();
+	async get(key: string): Promise<FlowTokenContent | null> {
+		return this.map.get(key) ?? null;
+	}
+	async set(key: string, value: FlowTokenContent): Promise<void> {
+		this.map.set(key, value);
+	}
+	async delete(key: string): Promise<void> {
+		this.map.delete(key);
+	}
+}
+
+type RegisterToolArgs = [
+	string,
+	{ inputSchema: Record<string, z.ZodTypeAny> },
+	unknown,
+];
+
+function registeredSchema(): Record<string, z.ZodTypeAny> {
+	const registered: RegisterToolArgs[] = [];
+	const server = {
+		registerTool: (...args: unknown[]) => {
+			registered.push(args as RegisterToolArgs);
+		},
+	};
+	const flow = createFlow({
+		id: "required_probe",
+		title: "Required probe",
+		description: "d",
+		state: { color: z.string().optional() },
+	})
+		.addNode("ask_color", ({ interrupt }) =>
+			interrupt({ color: { question: "Favorite color?" } }),
+		)
+		.addEdge(START, "ask_color")
+		.addEdge("ask_color", END)
+		.compile({ store: new TestFlowStateStore() });
+	void flow.register(server as unknown as McpServer);
+	const schema = registered[0]?.[1]?.inputSchema;
+	if (!schema) {
+		throw new Error("flow did not register an input schema");
+	}
+	return schema;
+}
+
+describe("stateUpdates is required in the generated input schema", () => {
+	test("the schema key is not optional", () => {
+		expect(registeredSchema().stateUpdates?.isOptional()).toBe(false);
+	});
+
+	test("a call omitting stateUpdates fails schema validation", () => {
+		const parsed = z
+			.object(registeredSchema())
+			.safeParse({ action: "start", intent: "wants a recommendation" });
+		expect(parsed.success).toBe(false);
+	});
+
+	test("an empty object satisfies the requirement", () => {
+		const parsed = z.object(registeredSchema()).safeParse({
+			action: "start",
+			intent: "wants a recommendation",
+			stateUpdates: {},
+		});
+		expect(parsed.success).toBe(true);
+	});
+
+	test("declared state fields still pass through", () => {
+		const parsed = z.object(registeredSchema()).safeParse({
+			action: "continue",
+			stateUpdates: { color: "Red" },
+		});
+		expect(parsed.success).toBe(true);
+	});
+
+	test("the description names the {} escape hatch", () => {
+		const description = registeredSchema().stateUpdates?.description ?? "";
+		expect(description).toContain("{}");
+	});
+});

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -74,11 +74,9 @@ function buildInputSchema(config: {
 			.describe(
 				`Optional when action is "start". Describe the situation or environment that led the user to start this flow — e.g. what page they are on, what they were doing, or what triggered the request. Do not invent missing context.${piiNote}`,
 			),
-		stateUpdates: stateUpdatesSchema
-			.optional()
-			.describe(
-				'State field values to set before processing the next node. Pass the user\'s answer (keyed by the field name from the response) and any other values the user mentioned. For nested state fields, use dot-paths like "driver.name".',
-			),
+		stateUpdates: stateUpdatesSchema.describe(
+			'State field values to set before processing the next node, required on every call. Pass the user\'s answer (keyed by the field name from the response) and any other values the user mentioned; pass {} when the message provides no field values. For nested state fields, use dot-paths like "driver.name".',
+		),
 		sessionId: z
 			.string()
 			.optional()


### PR DESCRIPTION
Part of WAN-734 (deterministic hardening of the flow-start desync fix, proposed as an alternative/complement to the prompt-level parts of #112).

The generated flow tool schema declares `stateUpdates` as a required parameter, with `{}` as the explicit "nothing to extract" value. Hosts that validate tool calls against the schema reject any call omitting it, so the model is structurally forced through the extraction step on every call instead of being able to skip the only channel that fills flow fields.

- Container required, fields stay optional: `{}` is always valid, so no legitimate call shape becomes impossible.
- Enforcement comes from schema validation (MCP SDK / host side); the handler keeps its `args.stateUpdates ?? {}` fallback, so callers that bypass validation degrade to the previous behavior instead of erroring.
- Flow-author code is unaffected. The break is wire-level only: direct tool-callers that omit the parameter today.
- No version bump in this branch per repo policy; targets the next minor, where the release PR carries the changelog and upgrading.md entries.

Verification: 5 new schema tests (required, omission rejected, `{}` accepted, typed fields pass through, description names the escape hatch), full suite 540 passing with only the 2 pre-existing chat-engine failures, typecheck and lint clean. All 222 mcp tests pass unmodified, showing the engine never depended on the parameter being omittable.