### PR TITLE
feat(tracking)!: capture user intent on every wrapped tool

### DIFF
--- a/skills/migrate-waniwani-sdk-0.19-to-0.20/SKILL.md
+++ b/skills/migrate-waniwani-sdk-0.19-to-0.20/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: migrate-waniwani-sdk-0.19-to-0.20
+description: "Migrate a project from @waniwani/sdk 0.19.x to 0.20.x and auto-apply its breaking changes: withWaniwani now captures the user's intent on every tool it wraps (on by default, opt out with captureIntent: false), createFlow no longer declares its own intent field, createFlowTestHarness().start() lost its leading intent argument, and createFlow's omitIntentPII now governs only context. Trigger when the user is on @waniwani/sdk 0.19.x and wants to move to 0.20, asks to migrate to 0.20, or hits type errors on harness.start(...) or a missing FlowToolInput.intent after bumping @waniwani/sdk."
+metadata:
+  author: Waniwani
+---
+
+# Migrate `@waniwani/sdk` 0.19 → 0.20
+
+A self-contained migration for the single hop from `0.19.x` to `0.20.x`. Apply it when a project on 0.19 is moving to 0.20. It covers only that jump; for other version boundaries use the matching `migrate-waniwani-sdk-<from>-to-<to>` skill, or the general procedure in the SDK's [changelog](https://docs.waniwani.ai/sdk/changelog).
+
+**Precondition:** the project is on `@waniwani/sdk@0.19.x`. If it is on an older version, migrate up to 0.19 first (each jump ships its own migration skill); if it is already on 0.20+, there is nothing to do here.
+
+## What 0.20 changes
+
+An MCP server sees tool calls and their arguments, never the conversation that produced them. `withWaniwani` now closes that gap for **every** tool it wraps, not just flow tools: each tool's input schema gains an optional `intent` argument, the calling model fills it in with the user's goal, the value is stripped before your handler runs, and it is tracked as `properties.input.intent` on `tool.called`.
+
+That single implementation replaces the flow-only copy, which is where the breaks come from:
+
+- **`createFlowTestHarness().start()` lost its leading `intent` argument.** `start(intent, stateUpdates?, context?)` is now `start(stateUpdates?, context?)`. This is the only break `tsc` catches, and it is the whole migration for most projects.
+- **`createFlow` no longer declares `intent`.** `FlowToolInput.intent` is gone and the flow protocol text no longer asks for it. A flow wrapped in `withWaniwani` is unaffected — the field arrives from the capture layer, alongside `action` / `context` / `stateUpdates` / `sessionId`. A flow that is **not** wrapped collects no intent at all.
+- **`createFlow({ omitIntentPII: true })` now governs only the `context` field.** The intent-side instruction moved to `withWaniwani(server, { captureIntent: { omitPII: true } })`.
+- **Every wrapped tool advertises one more property**, so any `tools/list` snapshot or golden file changes. Tools that declared no input schema go from zero properties to one.
+
+**Not affected:** node handlers, flow state, the store, event ingest, and the shape of `tool.called` itself. Nothing in the engine ever read `intent`, so no flow behavior changes. Your tool handlers keep receiving exactly the parameters they declared.
+
+## Procedure
+
+1. **Bump the dependency.**
+   ```bash
+   bun add @waniwani/sdk@^0.20.0
+   ```
+2. **Collect the call sites.**
+   ```bash
+   bun run typecheck
+   rg "createFlowTestHarness|omitIntentPII"
+   ```
+   The type checker lists every `harness.start(...)` that still passes an intent. `omitIntentPII` does not fail to compile, so grep is what finds it.
+3. **Apply rewrite 1** to every `harness.start(...)` call.
+4. **Apply rewrite 2** only if the project sets `omitIntentPII: true` — skipping it silently loses the PII instruction on the captured intent.
+5. **Refresh tool-schema snapshots** if the project has any (`bun test --update-snapshots`, or hand-edit the golden file to include `intent`).
+6. **Verify — this is the completion check.**
+   ```bash
+   bun run typecheck
+   bun test
+   ```
+7. **Report** which rewrites were applied and whether any snapshot changed.
+
+## Rewrite 1 — drop the intent argument from `harness.start(...)`
+
+```ts
+// Before
+const r1 = await harness.start("I want to get pet insurance");
+const r2 = await harness.start("Compare electricity rates", { zipcode: "75001" });
+const r3 = await harness.start("Get a quote", { zipcode: "75001" }, "on the pricing page");
+
+// After
+const r1 = await harness.start();
+const r2 = await harness.start({ zipcode: "75001" });
+const r3 = await harness.start({ zipcode: "75001" }, "on the pricing page");
+```
+
+Mechanical: delete the leading string argument and shift the rest left. The intent string it carried was never read by the engine, so nothing is lost — do not try to preserve it by moving it into `stateUpdates` or `context`.
+
+## Rewrite 2 — keep the PII instruction on the captured intent
+
+Only when a flow sets `omitIntentPII: true`. That option still applies to the flow's `context` field, but the intent field is now the wrapper's, so the wrapper needs telling too:
+
+```ts
+// Before — one setting covered intent and context
+const flow = createFlow({ id: "quote", omitIntentPII: true, /* … */ });
+await withWaniwani(server);
+
+// After — flow keeps context, wrapper takes intent
+const flow = createFlow({ id: "quote", omitIntentPII: true, /* … */ });
+await withWaniwani(server, { captureIntent: { omitPII: true } });
+```
+
+Neither setting redacts server-side; both add a guidance line telling the model to summarize abstractly.
+
+## Opt out — leave tool schemas exactly as declared
+
+Capture is on by default. A server whose published tool contract must not change (an app mid-review in a directory that snapshots tool schemas, or a strict privacy posture) turns it off:
+
+```ts
+await withWaniwani(server, { captureIntent: false });
+```
+
+Or narrows it to specific tools, and renames the argument to reuse a field a tool already collects:
+
+```ts
+await withWaniwani(server, {
+  captureIntent: { tools: ["get_quote"], argumentName: "reason" },
+});
+```
+
+A tool that already declares the argument name is left untouched, and its value reaches its handler as usual.
+
+## Not covered by a shim
+
+`harness.start()` takes the new shape with no deprecated overload. Accepting a string first argument would mean a permanently union-typed parameter (`Record<string, unknown> | string`) on a public signature, degrading editor help for the correct form, to spare test-only code from a one-line edit that the compiler points straight at.
+
+## Common mistakes
+
+- **Preserving the intent string.** It was observational: nothing in the engine read it. Delete it; do not fold it into `stateUpdates` or `context`.
+- **Rewriting node handlers.** They never received `intent` and still do not.
+- **Assuming an unwrapped flow still asks for intent.** Capture lives in `withWaniwani`. A `createFlow` used standalone (OSS path, no wrapper) collects none — wrap the server if you want it.
+- **Leaving `omitIntentPII: true` as the only PII setting.** It now covers `context` only. Without rewrite 2 the captured intent carries no PII instruction.
+- **Chasing a handler that "lost" an argument.** The wrapper strips `intent` before your handler runs, and restores the single-argument call shape for tools that declared no input schema, so handler signatures are unchanged.
+- **Skipping the verify step.** A clean `bun run typecheck` plus green `bun test` is the definition of done.

--- a/skills/waniwani-sdk/SKILL.md
+++ b/skills/waniwani-sdk/SKILL.md
@@ -109,7 +109,7 @@ If no `{ store }` is passed and `WANIWANI_API_KEY` is not set, `.compile()` thro
 Adds hosted features on top of the OSS flow engine.
 
 - **Hosted flow state** — `WaniwaniKvStore` used by default when no `{ store }` is passed.
-- **Event tracking** — a typed, revenue-first funnel taxonomy (`lead_qualified` → `price_shown` / `prices_compared` / `option_selected` → `converted`) via flat `track.*` helpers; `withWaniwani(server)` auto-captures `tool.called`. Off-platform conversions correlate by `externalUserId`. See [events.md](references/events.md).
+- **Event tracking** — a typed, revenue-first funnel taxonomy (`lead_qualified` → `price_shown` / `prices_compared` / `option_selected` → `converted`) via flat `track.*` helpers; `withWaniwani(server)` auto-captures `tool.called`, including the `intent` behind each call. Off-platform conversions correlate by `externalUserId`. See [events.md](references/events.md).
 - **Knowledge base** — `createKbClient()` for ingest/search.
 - **Funnel analytics** — flow graphs auto-sync to the dashboard.
 - **Chat widget** — `ChatEmbed` talks directly to `app.waniwani.ai`.
@@ -133,6 +133,7 @@ The following are still exported for back-compat with existing customer MCPs but
 | Deploy a pure OSS production MCP server | [self-hosting.md](references/self-hosting.md) |
 | Add a free-tier API key and unlock tracking + dashboard | [setup.md](references/setup.md) |
 | Track events and build a revenue funnel (lead_qualified → price → converted), incl. off-platform conversions | [events.md](references/events.md) |
+| Record why each tool ran, not just that it ran (on by default; `captureIntent`) | [events.md](references/events.md) |
 | Auto-instrument funnel events across existing flows | [instrument-tracking.md](references/instrument-tracking.md) |
 | Audit an existing app's tracking (only defined events, find missing funnel events) | [audit-tracking.md](references/audit-tracking.md) |
 | Use the flow API in detail (nodes, edges, interrupts, widgets) | [flows-api-reference.md](references/flows-api-reference.md) |
@@ -152,7 +153,7 @@ When a playbook exists for the user's task, **follow the playbook step by step**
 
 ## Upgrading the SDK
 
-`@waniwani/sdk` is `0.x`, so **minor version bumps can break the public API**. Whenever you raise the SDK version in a project — editing `package.json`, running `bun add @waniwani/sdk@latest`, or fixing a build that started failing after an upgrade — do not treat it as a drop-in. Read the [changelog](https://docs.waniwani.ai/sdk/changelog) for every breaking change between the old and new version and **auto-apply the documented migration** (each one is a mechanical codemod), then run `bun run typecheck && bun test`. Full procedure in [upgrading.md](references/upgrading.md). Each version hop also has a self-contained, directly invocable migration skill named `migrate-waniwani-sdk-<from>-to-<to>` — for the latest release: `npx skills add Waniwani-AI/sdk -s migrate-waniwani-sdk-0.18-to-0.19`.
+`@waniwani/sdk` is `0.x`, so **minor version bumps can break the public API**. Whenever you raise the SDK version in a project — editing `package.json`, running `bun add @waniwani/sdk@latest`, or fixing a build that started failing after an upgrade — do not treat it as a drop-in. Read the [changelog](https://docs.waniwani.ai/sdk/changelog) for every breaking change between the old and new version and **auto-apply the documented migration** (each one is a mechanical codemod), then run `bun run typecheck && bun test`. Full procedure in [upgrading.md](references/upgrading.md). Each version hop also has a self-contained, directly invocable migration skill named `migrate-waniwani-sdk-<from>-to-<to>` — for the latest release: `npx skills add Waniwani-AI/sdk -s migrate-waniwani-sdk-0.19-to-0.20`.
 
 ## Common mistakes
 

--- a/skills/waniwani-sdk/references/events.md
+++ b/skills/waniwani-sdk/references/events.md
@@ -231,6 +231,49 @@ await client.track({ event: "link.clicked", properties: { url: "https://example.
   identity to the session — useful right before an off-platform conversion so the later
   `converted` can be joined by `externalUserId`.
 
+## Capturing why a tool ran (`captureIntent`)
+
+A tool call tells you *what* happened, never *why*: the MCP server sees the arguments,
+not the conversation that produced them. `withWaniwani` closes that gap by adding an
+optional `intent` argument to each tool's input schema, which the calling model fills in
+with the user's goal.
+
+This is **on by default** — wrapping the server is all it takes:
+
+```ts
+await withWaniwani(server); // every tool now advertises `intent`
+```
+
+The captured value rides on the existing `tool.called` event as
+`properties.input.intent`, so nothing else changes: no extra event, no extra call. Flow
+tools and plain tools go through this one path, so both read back identically.
+
+Narrow it, rename it, or switch it off with `captureIntent`:
+
+```ts
+await withWaniwani(server, {
+  captureIntent: { tools: ["get_quote"], argumentName: "intent", omitPII: true },
+});
+
+await withWaniwani(server, { captureIntent: false }); // leave schemas as declared
+```
+
+- **Your handler never sees it.** The argument is stripped before your tool code runs, so
+  the handler receives exactly the parameters it declared. Argument-less tools stay
+  argument-less from their handler's point of view.
+- **Tools that already declare the argument are left alone**, and the value reaches their
+  handler as usual. Point `argumentName` at a field your tool already collects to reuse it
+  as the intent rather than adding one.
+- **Flows use this too.** `createFlow` does not declare `intent`; its flow tool gets the
+  field here, alongside the flow's own `action` / `context` / `stateUpdates`. An unwrapped
+  flow collects no intent, since there is no tracking for it to feed.
+- **`omitPII: true`** asks the model to summarize abstractly. The flow-side
+  `createFlow({ omitIntentPII: true })` covers that flow's `context` field.
+- **The argument is optional**, so adding it is a backward-compatible schema change: a
+  model that ignores it changes nothing. For an app published in a directory that
+  reviews tool schemas (ChatGPT apps), the field reaches the model once that app's next
+  version is submitted, and what you collect belongs in the app's privacy policy.
+
 ## Off-platform conversions (the case this taxonomy exists for)
 
 The hard problem: a lead chats today, but the sale closes next week on your own website,

--- a/skills/waniwani-sdk/references/flows.md
+++ b/skills/waniwani-sdk/references/flows.md
@@ -115,7 +115,9 @@ Rules for nested state:
 
 ## Pre-filling Answers
 
-When calling `action: "start"`, the AI provides `intent` (required -- the user's goal) and optionally `context` (the situation that led to starting the flow, e.g. what page the user is on or what triggered the request). Both are tool call arguments for the AI -- they are not passed to node handlers or stored in flow state.
+When calling `action: "start"`, the AI optionally provides `context` (the situation that led to starting the flow, e.g. what page the user is on or what triggered the request). It is a tool call argument for the AI -- it is not passed to node handlers or stored in flow state.
+
+The user's goal is captured by `withWaniwani`, which adds an `intent` argument to every tool it wraps and records it on `tool.called` (see [events.md](events.md)). Flows do not declare it themselves.
 
 The AI can also pass known answers via `stateUpdates`. The engine auto-skips nodes whose fields are already filled.
 

--- a/skills/waniwani-sdk/references/upgrading.md
+++ b/skills/waniwani-sdk/references/upgrading.md
@@ -31,6 +31,28 @@ One behavioral note (not a break): `messageBorderRadius` / `--ww-msg-radius` is 
 
 This list mirrors the changelog so you can apply migrations without a network fetch. Always cross-check against the live changelog for anything newer than this file.
 
+### 0.20.0: intent capture moved from `createFlow` into `withWaniwani`
+
+`withWaniwani` now adds an optional `intent` argument to **every** tool it wraps (on by default), strips it before your handler runs, and tracks it as `properties.input.intent` on `tool.called`. `createFlow` no longer declares its own `intent`, so the capture has one implementation instead of two. Consequences:
+
+- `createFlowTestHarness().start()` lost its leading argument: `start(intent, stateUpdates?, context?)` → `start(stateUpdates?, context?)`. The only break `tsc` catches.
+- `FlowToolInput.intent` is gone, and the flow protocol text no longer asks for it. A wrapped flow is unaffected (the field comes from the wrapper); an **unwrapped** flow collects no intent.
+- `createFlow({ omitIntentPII: true })` now governs the `context` field only.
+- Every wrapped tool advertises one more property, so `tools/list` snapshots change. Tools with no declared input schema go from zero properties to one.
+
+Node handlers, flow state, the store, and event ingest are untouched — nothing in the engine ever read `intent`.
+
+Auto-fix:
+
+1. Delete the leading string argument from every `harness.start(...)` call and shift the rest left: `harness.start("Get a quote", { zipcode: "75001" })` → `harness.start({ zipcode: "75001" })`. Do not preserve the string — it was never read.
+2. Where a flow sets `omitIntentPII: true`, also pass `captureIntent: { omitPII: true }` to `withWaniwani`, or the captured intent loses its PII instruction (silent — no compile error).
+3. Refresh any tool-schema snapshot so it includes `intent`.
+4. To keep the published tool contract unchanged instead, pass `captureIntent: false`.
+
+<Tip>
+Run it: `npx skills add Waniwani-AI/sdk -s migrate-waniwani-sdk-0.19-to-0.20`
+</Tip>
+
 ### 0.19.1: `suggestion.clicked` requires a `properties.origin` field
 
 `suggestion.clicked` (part of `WidgetEventDetail` / `WidgetEvent` from `@waniwani/sdk/chat`) gained a required `properties.origin: "channel" | "page" | "flow" | "followup"` field, reporting which provider supplied the clicked pill. On 0.18.x the payload was `{ text, index }`. Consumers who only *read* the event through `onEvent` (the overwhelmingly common case) need no changes: it is a new, always-populated field. Only code that *constructs* a `suggestion.clicked` event literal (test fixtures, a custom adapter) needs updating.

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -38,8 +38,12 @@ export type { TrackingRouteOptions } from "./server/tracking-route";
 export { createTrackingRoute } from "./server/tracking-route";
 // Shared MCP server types (non-legacy)
 export type { McpServer, ZodRawShapeCompat } from "./server/types";
-export type { WithWaniwaniOptions } from "./server/with-waniwani/index";
+export type {
+	InstrumentableMcpServer,
+	WithWaniwaniOptions,
+} from "./server/with-waniwani/index";
 export { withWaniwani } from "./server/with-waniwani/index";
+export type { CaptureIntentOptions } from "./server/with-waniwani/intent-capture";
 
 // ----------------------------------------------------------------------------
 // Legacy — preserved for back-compat. Prefer `@waniwani/sdk/legacy` for new code

--- a/src/mcp/server/flows/@types.ts
+++ b/src/mcp/server/flows/@types.ts
@@ -470,8 +470,12 @@ export type FlowConfig = {
 	state: Record<string, z.ZodType>;
 	/**
 	 * If true, instruct the agent to omit PII (names, emails, phones, addresses,
-	 * IDs, ages, birthdates) from the `intent` and `context` fields. Only adds a
-	 * guidance line to the tool description — does not redact server-side.
+	 * IDs, ages, birthdates) from the `context` field. Only adds a guidance line
+	 * to the tool description — does not redact server-side.
+	 *
+	 * The user's goal is captured by `withWaniwani`, so the PII instruction for
+	 * that field lives there: `withWaniwani(server, { captureIntent: { omitPII:
+	 * true } })`.
 	 */
 	omitIntentPII?: boolean;
 	/**
@@ -554,8 +558,6 @@ export interface CompileInput<TState extends Record<string, unknown>> {
 
 export type FlowToolInput = {
 	action: "start" | "continue" | "reset";
-	/** Required when `action` is `"start"`. */
-	intent?: string;
 	/** Optional when `action` is `"start"`. Describes the situation/environment that led the user to start this flow. */
 	context?: string;
 	stateUpdates?: Record<string, unknown>;

--- a/src/mcp/server/flows/README.md
+++ b/src/mcp/server/flows/README.md
@@ -24,7 +24,7 @@ Flow tools accept:
 type FlowToolInput =
   | {
       action: "start";
-      intent: string;
+      context?: string;
       stateUpdates?: Record<string, unknown>;
     }
   | {
@@ -33,7 +33,9 @@ type FlowToolInput =
     };
 ```
 
-`intent` is required on `start` and should summarize the user's goal for the flow, including relevant prior context that led to triggering it, if available.
+`context` is optional on `start` and describes the situation that led the user here (the page they are on, what triggered the request).
+
+The user's goal is captured separately: `withWaniwani` adds an `intent` argument to every tool it wraps, flows included, and records it on the `tool.called` event. Nothing in the engine reads it, so an unwrapped flow simply does not collect it.
 
 ### Tool output
 

--- a/src/mcp/server/flows/__tests__/compile.test.ts
+++ b/src/mcp/server/flows/__tests__/compile.test.ts
@@ -38,13 +38,9 @@ type RegisterToolArgs = [string, Record<string, unknown>, Handler];
 
 const TEST_SESSION_ID = "test-session-1";
 const TEST_EXTRA = { _meta: { sessionId: TEST_SESSION_ID } };
-const TEST_INTENT =
-	"Qualify the user for this flow based on what they asked for earlier in the conversation.";
-
 function startInput(stateUpdates?: Record<string, unknown>) {
 	return {
 		action: "start" as const,
-		intent: TEST_INTENT,
 		...(stateUpdates ? { stateUpdates } : {}),
 	};
 }
@@ -83,11 +79,11 @@ function expectNodesVisited(
 }
 
 describe("compileFlow response contract", () => {
-	test("starts without intent instead of failing the call", async () => {
+	test("starts with no arguments beyond the action", async () => {
 		const store = new TestFlowStateStore();
 		const flow = createFlow({
-			id: "missing_intent_flow",
-			title: "Missing Intent Flow",
+			id: "bare_start_flow",
+			title: "Bare Start Flow",
 			description: "Collect lead details.",
 			state: {
 				useCase: z.string().describe("Primary use case"),
@@ -148,7 +144,6 @@ describe("compileFlow response contract", () => {
 		const result = (await handler?.(
 			{
 				action: "start",
-				intent: TEST_INTENT,
 				context: "User is on the pricing page and clicked 'Get a quote'.",
 			},
 			TEST_EXTRA,

--- a/src/mcp/server/flows/__tests__/suggestions-meta.test.ts
+++ b/src/mcp/server/flows/__tests__/suggestions-meta.test.ts
@@ -30,12 +30,10 @@ type Handler = (input: unknown, extra: unknown) => Promise<unknown>;
 type RegisterToolArgs = [string, Record<string, unknown>, Handler];
 
 const TEST_SESSION_ID = "test-session-suggestions";
-const TEST_INTENT = "Qualify the user for this flow.";
 
 function startInput(stateUpdates?: Record<string, unknown>) {
 	return {
 		action: "start" as const,
-		intent: TEST_INTENT,
 		...(stateUpdates ? { stateUpdates } : {}),
 	};
 }

--- a/src/mcp/server/flows/compile.ts
+++ b/src/mcp/server/flows/compile.ts
@@ -10,6 +10,7 @@ import { extractScopedClient } from "../scoped-client";
 import {
 	extractSessionId,
 	FLOW_META_KEY,
+	OMIT_PII_NOTE,
 	SUGGESTIONS_META_KEY,
 	type SuggestionsMeta,
 } from "../utils";
@@ -40,9 +41,7 @@ function buildInputSchema(config: {
 	omitIntentPII?: boolean;
 	state?: Record<string, z.ZodType>;
 }) {
-	const piiNote = config.omitIntentPII
-		? " Do not include PII (names, emails, phones, addresses, IDs, ages, birthdates) — summarize abstractly."
-		: "";
+	const piiNote = config.omitIntentPII ? OMIT_PII_NOTE : "";
 
 	// When the flow declares state fields, expose them as typed (optional) keys
 	// on `stateUpdates` so the LLM sees field names, types, and descriptions in
@@ -62,12 +61,9 @@ function buildInputSchema(config: {
 			.describe(
 				'"start" to begin the flow, "continue" to resume after a pause (interrupt or widget), "reset" to restart from the beginning with a correction to a previously-collected field',
 			),
-		intent: z
-			.string()
-			.optional()
-			.describe(
-				`Required when action is "start". Provide a brief summary of the user's goal for this flow. Do not invent missing intent.${piiNote}`,
-			),
+		// `intent` is not declared here: `withWaniwani` adds it to every tool it
+		// wraps, flows included, so the capture lives in one place. A flow that is
+		// never wrapped has no tracking to feed, so it has no use for the field.
 		context: z
 			.string()
 			.optional()
@@ -130,14 +126,6 @@ export function compileFlow<TState extends Record<string, unknown>>(
 		waniwani?: ScopedWaniWaniClient,
 	) {
 		if (args.action === "start") {
-			// `intent` is observational: the schema asks for it on start, but nothing
-			// in the engine reads it (it never reaches a node, the store, or an
-			// event). A missing value therefore costs a conversation turn and buys
-			// nothing, so trim it and carry on instead of failing the call.
-			const intent =
-				typeof args.intent === "string" ? args.intent.trim() : undefined;
-			args.intent = intent || undefined;
-
 			// Trim context if provided (optional field, no error if missing)
 			if (typeof args.context === "string") {
 				const trimmed = args.context.trim();

--- a/src/mcp/server/flows/protocol.ts
+++ b/src/mcp/server/flows/protocol.ts
@@ -7,9 +7,7 @@ export function buildFlowProtocol(config: FlowConfig): string {
 		"",
 		"This tool implements a multi-step conversational flow. Follow this protocol exactly:",
 		"",
-		'1. Call with `action: "start"` to begin and include `intent`.',
-		"   `intent` must be a brief summary of the user's goal for this flow.",
-		"   Do NOT invent missing intent.",
+		'1. Call with `action: "start"` to begin.',
 		"   Optionally include `context` — the situation or environment that led the user to start",
 		"   this flow (e.g. what page they are on, what they were doing, or what triggered the request).",
 		"   Only provide `context` when there is genuinely relevant situational information. Do NOT invent missing context.",
@@ -21,8 +19,8 @@ export function buildFlowProtocol(config: FlowConfig): string {
 
 	if (config.omitIntentPII) {
 		lines.push(
-			"   Do NOT include PII in `intent` or `context` — no names, emails, phones, addresses, IDs, ages, or birthdates.",
-			'   Summarize the goal abstractly (e.g. "user wants a quote", not "Jane Doe wants a quote").',
+			"   Do NOT include PII in `context` — no names, emails, phones, addresses, IDs, ages, or birthdates.",
+			'   Describe the situation abstractly (e.g. "user is on the pricing page", not "Jane Doe is on the pricing page").',
 		);
 	}
 

--- a/src/mcp/server/flows/test-utils.ts
+++ b/src/mcp/server/flows/test-utils.ts
@@ -62,14 +62,12 @@ export async function createFlowTestHarness(
 
 	return {
 		async start(
-			intent: string,
 			stateUpdates?: Record<string, unknown>,
 			context?: string,
 		): Promise<FlowTestResult> {
 			const result = (await handler(
 				{
 					action: "start",
-					intent,
 					...(context ? { context } : {}),
 					...(stateUpdates ? { stateUpdates } : {}),
 				},

--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -60,6 +60,17 @@ const TURN_COUNT_KEYS = ["waniwani/turnCount"] as const;
 /** Meta key for flow execution path (nodesVisited, flowId). */
 export const FLOW_META_KEY = "waniwani/flow" as const;
 
+/**
+ * Instruction appended to an intent/context field description when PII is to be
+ * kept out of the captured value.
+ *
+ * Shared so flow tools (`createFlow({ omitIntentPII })`) and plain tools
+ * (`withWaniwani({ captureIntent: { omitPII } })`) ask the model for the same
+ * thing — a privacy wording change has to land in exactly one place.
+ */
+export const OMIT_PII_NOTE =
+	" Do not include PII (names, emails, phones, addresses, IDs, ages, birthdates) — summarize abstractly." as const;
+
 export type { SuggestionsMeta } from "../../shared/meta-keys";
 export { SUGGESTIONS_META_KEY } from "../../shared/meta-keys";
 

--- a/src/mcp/server/with-waniwani/__test__/intent-capture.integration.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/intent-capture.integration.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { END, START } from "../../flows/@types.js";
+import { createFlow } from "../../flows/create-flow.js";
+import { MemoryKvStore } from "../../kv/index.js";
+import { withWaniwani } from "../index.js";
+import { mockClient } from "./test-helpers.js";
+
+/**
+ * End-to-end coverage against the real MCP SDK, which is where the sharp edges
+ * live: it normalizes input schemas with Zod Mini, and it calls a schemaless
+ * tool as `handler(extra)` but a schema-carrying tool as `handler(args, extra)`.
+ *
+ * A real `McpServer` is passed to `withWaniwani` bare, with no cast — that is
+ * the point of `InstrumentableMcpServer` being structural, so these calls double
+ * as its regression test.
+ */
+
+async function connect(server: McpServer) {
+	const [clientTransport, serverTransport] =
+		InMemoryTransport.createLinkedPair();
+	const client = new Client({ name: "test", version: "1.0.0" });
+	await Promise.all([
+		client.connect(clientTransport),
+		server.connect(serverTransport),
+	]);
+	return client;
+}
+
+function properties(of: unknown): Record<string, unknown> {
+	const schema = of as { properties?: Record<string, unknown> };
+	return schema.properties ?? {};
+}
+
+describe("captureIntent against the real MCP SDK", () => {
+	test("advertises intent, strips it from the handler, tracks it", async () => {
+		const { client: tracker, tracked } = mockClient();
+		const server = new McpServer({ name: "test", version: "1.0.0" });
+
+		await withWaniwani(server, {
+			client: tracker,
+			captureIntent: true,
+		});
+
+		let seen: unknown;
+		server.registerTool(
+			"pricing",
+			{ description: "Get pricing", inputSchema: { plan: z.string() } },
+			async (input) => {
+				seen = input;
+				return { content: [{ type: "text" as const, text: "ok" }] };
+			},
+		);
+
+		const client = await connect(server);
+
+		const listed = await client.listTools();
+		const pricing = listed.tools.find((t) => t.name === "pricing");
+		expect(Object.keys(properties(pricing?.inputSchema)).sort()).toEqual([
+			"intent",
+			"plan",
+		]);
+		expect(
+			(properties(pricing?.inputSchema).intent as { description?: string })
+				?.description,
+		).toContain("user's goal");
+
+		await client.callTool({
+			name: "pricing",
+			arguments: { plan: "pro", intent: "compare plans before upgrading" },
+		});
+
+		expect(seen).toEqual({ plan: "pro" });
+		expect(tracked[0]).toMatchObject({
+			event: "tool.called",
+			properties: {
+				name: "pricing",
+				status: "ok",
+				input: { plan: "pro", intent: "compare plans before upgrading" },
+			},
+		});
+	});
+
+	test("upgrades a tool registered before wrapping", async () => {
+		const { client: tracker, tracked } = mockClient();
+		const server = new McpServer({ name: "test", version: "1.0.0" });
+
+		let seen: unknown;
+		server.registerTool(
+			"pricing",
+			{ inputSchema: { plan: z.string() } },
+			async (input) => {
+				seen = input;
+				return { content: [{ type: "text" as const, text: "ok" }] };
+			},
+		);
+
+		await withWaniwani(server, {
+			client: tracker,
+			captureIntent: true,
+		});
+
+		const client = await connect(server);
+
+		const listed = await client.listTools();
+		expect(
+			Object.keys(
+				properties(listed.tools.find((t) => t.name === "pricing")?.inputSchema),
+			).sort(),
+		).toEqual(["intent", "plan"]);
+
+		await client.callTool({
+			name: "pricing",
+			arguments: { plan: "pro", intent: "renew early" },
+		});
+
+		expect(seen).toEqual({ plan: "pro" });
+		expect(tracked[0]).toMatchObject({
+			properties: { input: { plan: "pro", intent: "renew early" } },
+		});
+	});
+
+	test("keeps an argument-less tool callable", async () => {
+		const { client: tracker, tracked } = mockClient();
+		const server = new McpServer({ name: "test", version: "1.0.0" });
+
+		await withWaniwani(server, {
+			client: tracker,
+			captureIntent: true,
+		});
+
+		// No inputSchema: the SDK calls this handler with `extra` alone, and the
+		// injected schema must not change that.
+		let extraSeen: unknown;
+		server.registerTool("status", { description: "Health" }, async (extra) => {
+			extraSeen = extra;
+			return { content: [{ type: "text" as const, text: "up" }] };
+		});
+
+		const client = await connect(server);
+
+		const listed = await client.listTools();
+		expect(
+			Object.keys(
+				properties(listed.tools.find((t) => t.name === "status")?.inputSchema),
+			),
+		).toEqual(["intent"]);
+
+		const result = await client.callTool({
+			name: "status",
+			arguments: { intent: "check whether the service is up" },
+		});
+
+		expect(result).toMatchObject({ content: [{ type: "text", text: "up" }] });
+		// The handler still receives the request extra, not the arguments object.
+		expect((extraSeen as { requestId?: unknown })?.requestId).toBeDefined();
+		expect(tracked[0]).toMatchObject({
+			properties: {
+				name: "status",
+				status: "ok",
+				input: { intent: "check whether the service is up" },
+			},
+		});
+	});
+
+	test("keeps an argument-less tool registered before wrapping callable", async () => {
+		const { client: tracker, tracked } = mockClient();
+		const server = new McpServer({ name: "test", version: "1.0.0" });
+
+		let extraSeen: unknown;
+		server.registerTool("status", { description: "Health" }, async (extra) => {
+			extraSeen = extra;
+			return { content: [{ type: "text" as const, text: "up" }] };
+		});
+
+		await withWaniwani(server, {
+			client: tracker,
+			captureIntent: true,
+		});
+
+		const client = await connect(server);
+
+		const listed = await client.listTools();
+		expect(
+			Object.keys(
+				properties(listed.tools.find((t) => t.name === "status")?.inputSchema),
+			),
+		).toEqual(["intent"]);
+
+		const result = await client.callTool({
+			name: "status",
+			arguments: { intent: "confirm the service is reachable" },
+		});
+
+		expect(result).toMatchObject({ content: [{ type: "text", text: "up" }] });
+		expect((extraSeen as { requestId?: unknown })?.requestId).toBeDefined();
+		expect(tracked[0]).toMatchObject({
+			properties: {
+				name: "status",
+				input: { intent: "confirm the service is reachable" },
+			},
+		});
+	});
+
+	test("supplies the intent a compiled flow tool no longer declares", async () => {
+		const { client: tracker, tracked } = mockClient();
+		const server = new McpServer({ name: "test", version: "1.0.0" });
+
+		const flow = createFlow({
+			id: "quote",
+			title: "Quote",
+			description: "Collect what we need for a quote.",
+			state: { useCase: z.string().describe("Primary use case") },
+		})
+			.addNode({
+				id: "ask",
+				run: ({ interrupt }) =>
+					interrupt({ useCase: { question: "What is your use case?" } }),
+			})
+			.addEdge(START, "ask")
+			.addEdge("ask", END)
+			.compile({ store: new MemoryKvStore() });
+
+		await withWaniwani(server, { client: tracker });
+		await flow.register(server);
+
+		const client = await connect(server);
+
+		// `intent` arrives from the capture layer, alongside the flow's own fields.
+		const listed = await client.listTools();
+		const schema = properties(
+			listed.tools.find((t) => t.name === "quote")?.inputSchema,
+		);
+		expect(Object.keys(schema).sort()).toEqual([
+			"action",
+			"context",
+			"intent",
+			"sessionId",
+			"stateUpdates",
+		]);
+
+		const result = await client.callTool({
+			name: "quote",
+			arguments: { action: "start", intent: "get a quote for a fleet" },
+		});
+
+		// The flow still runs: the stripped intent does not disturb its own input.
+		expect(JSON.stringify(result)).toContain("What is your use case?");
+		expect(tracked[0]).toMatchObject({
+			properties: {
+				name: "quote",
+				status: "ok",
+				input: { action: "start", intent: "get a quote for a fleet" },
+			},
+		});
+	});
+
+	test("leaves schemas untouched when captureIntent is false", async () => {
+		const { client: tracker } = mockClient();
+		const server = new McpServer({ name: "test", version: "1.0.0" });
+
+		await withWaniwani(server, {
+			client: tracker,
+			captureIntent: false,
+		});
+		server.registerTool(
+			"pricing",
+			{ inputSchema: { plan: z.string() } },
+			async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		);
+
+		const client = await connect(server);
+		const listed = await client.listTools();
+		expect(
+			Object.keys(
+				properties(listed.tools.find((t) => t.name === "pricing")?.inputSchema),
+			),
+		).toEqual(["plan"]);
+	});
+});

--- a/src/mcp/server/with-waniwani/__test__/intent-capture.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/intent-capture.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { withWaniwani } from "../index.js";
+import {
+	buildIntentDescription,
+	createIntentCapture,
+	stripIntentArgument,
+} from "../intent-capture.js";
+import { mockClient, mockServer, shapeOf } from "./test-helpers.js";
+
+/** `createIntentCapture` returns `null` only for `false`; narrow for the tests. */
+function capture(option: true | Parameters<typeof createIntentCapture>[0]) {
+	const created = createIntentCapture(option);
+	if (!created) {
+		throw new Error("expected capture to be enabled");
+	}
+	return created;
+}
+
+describe("intent capture helpers", () => {
+	test("describes the field, and only mentions PII when asked", () => {
+		expect(buildIntentDescription(false)).toContain("user's goal");
+		expect(buildIntentDescription(false)).not.toContain("PII");
+		expect(buildIntentDescription(true)).toContain("PII");
+	});
+
+	test("augments a raw shape, a Zod object, and a missing schema alike", () => {
+		const { augment } = capture(true);
+
+		expect(Object.keys(shapeOf(augment({ city: z.string() }))).sort()).toEqual([
+			"city",
+			"intent",
+		]);
+		expect(
+			Object.keys(shapeOf(augment(z.object({ city: z.string() })))).sort(),
+		).toEqual(["city", "intent"]);
+		expect(Object.keys(shapeOf(augment(undefined)))).toEqual(["intent"]);
+	});
+
+	test("leaves a tool that already declares the argument untouched", () => {
+		const { augment } = capture({ argumentName: "goal" });
+
+		expect(augment({ goal: z.string() })).toBeUndefined();
+		expect(augment(z.object({ goal: z.string() }))).toBeUndefined();
+	});
+
+	test("leaves a schema it cannot extend untouched", () => {
+		const union = z.union([
+			z.object({ a: z.string() }),
+			z.object({ b: z.string() }),
+		]);
+		expect(capture(true).augment(union)).toBeUndefined();
+	});
+
+	test("returns null only when capture is switched off", () => {
+		expect(createIntentCapture(false)).toBeNull();
+		expect(createIntentCapture(undefined)).not.toBeNull();
+		expect(createIntentCapture(true)?.argumentName).toBe("intent");
+		expect(createIntentCapture({ argumentName: "goal" })?.argumentName).toBe(
+			"goal",
+		);
+	});
+
+	test("strips the argument without copying when it is absent", () => {
+		const input = { city: "Paris" };
+		expect(stripIntentArgument(input, "intent")).toBe(input);
+		expect(
+			stripIntentArgument({ city: "Paris", intent: "book" }, "intent"),
+		).toEqual({ city: "Paris" });
+	});
+});
+
+describe("withWaniwani captureIntent", () => {
+	// `captureIntent: true` and an omitted option must behave alike — capture is
+	// on by default.
+	for (const [label, captureIntent] of [
+		["explicitly on", true],
+		["on by default", undefined],
+	] as const) {
+		test(`adds the argument to tools registered after wrapping (${label})`, async () => {
+			const { client } = mockClient();
+			const mock = mockServer();
+
+			await withWaniwani(mock.server, { client, captureIntent });
+
+			mock.registerTool(
+				"pricing",
+				{ description: "Get pricing", inputSchema: { plan: z.string() } },
+				async () => ({ text: "ok" }),
+			);
+
+			const shape = shapeOf(mock.configs.pricing?.inputSchema);
+			expect(Object.keys(shape).sort()).toEqual(["intent", "plan"]);
+		});
+	}
+
+	test("adds the argument to tools registered before wrapping", async () => {
+		const { client } = mockClient();
+		const mock = mockServer();
+
+		mock.registerTool(
+			"pricing",
+			{ description: "Get pricing", inputSchema: { plan: z.string() } },
+			async () => ({ text: "ok" }),
+		);
+
+		await withWaniwani(mock.server, { client, captureIntent: true });
+
+		const shape = shapeOf(mock._registeredTools.pricing?.inputSchema);
+		expect(Object.keys(shape).sort()).toEqual(["intent", "plan"]);
+	});
+
+	test("tracks the intent but keeps it out of the tool's own input", async () => {
+		const { client, tracked } = mockClient();
+		const mock = mockServer();
+
+		await withWaniwani(mock.server, { client, captureIntent: true });
+
+		let seen: unknown;
+		mock.registerTool(
+			"pricing",
+			{ inputSchema: { plan: z.string() } },
+			async (input) => {
+				seen = input;
+				return { text: "ok" };
+			},
+		);
+
+		await mock._registeredTools.pricing?.handler(
+			{ plan: "pro", intent: "compare plans before upgrading" },
+			{ _meta: {} },
+		);
+
+		expect(seen).toEqual({ plan: "pro" });
+		expect(tracked[0]).toMatchObject({
+			event: "tool.called",
+			properties: {
+				name: "pricing",
+				input: { plan: "pro", intent: "compare plans before upgrading" },
+			},
+		});
+	});
+
+	test("does not double-inject on a tool that already declares intent", async () => {
+		const { client } = mockClient();
+		const mock = mockServer();
+
+		await withWaniwani(mock.server, { client, captureIntent: true });
+
+		let seen: unknown;
+		const declared = { action: z.string(), intent: z.string().optional() };
+		mock.registerTool("flow", { inputSchema: declared }, async (input) => {
+			seen = input;
+			return { text: "ok" };
+		});
+
+		// Same object identity: the config was passed through untouched.
+		expect(mock.configs.flow?.inputSchema).toBe(declared);
+
+		// A flow tool reads its own `intent`, so it must still arrive.
+		await mock._registeredTools.flow?.handler(
+			{ action: "start", intent: "get a quote" },
+			{ _meta: {} },
+		);
+		expect(seen).toEqual({ action: "start", intent: "get a quote" });
+	});
+
+	test("honours the tools allow-list and a renamed argument", async () => {
+		const { client } = mockClient();
+		const mock = mockServer();
+
+		await withWaniwani(mock.server, {
+			client,
+			captureIntent: { tools: ["pricing"], argumentName: "goal" },
+		});
+
+		mock.registerTool(
+			"pricing",
+			{ inputSchema: { plan: z.string() } },
+			async () => ({}),
+		);
+		mock.registerTool(
+			"health",
+			{ inputSchema: { deep: z.boolean() } },
+			async () => ({}),
+		);
+
+		expect(
+			Object.keys(shapeOf(mock.configs.pricing?.inputSchema)).sort(),
+		).toEqual(["goal", "plan"]);
+		// Outside the allow-list the raw shape is passed through as declared.
+		expect(
+			Object.keys(mock.configs.health?.inputSchema as Record<string, unknown>),
+		).toEqual(["deep"]);
+	});
+
+	test("leaves every schema alone when captureIntent is false", async () => {
+		const { client } = mockClient();
+		const mock = mockServer();
+
+		await withWaniwani(mock.server, { client, captureIntent: false });
+
+		const declared = { plan: z.string() };
+		mock.registerTool("pricing", { inputSchema: declared }, async () => ({}));
+
+		expect(mock.configs.pricing?.inputSchema).toBe(declared);
+	});
+});

--- a/src/mcp/server/with-waniwani/__test__/test-helpers.ts
+++ b/src/mcp/server/with-waniwani/__test__/test-helpers.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared fakes for the `withWaniwani` tests. Not a `.test.ts` file, so bun does
+ * not collect it as a suite.
+ */
+
+import { z } from "zod";
+import type { TrackInput } from "../../../../tracking/@types.js";
+import type { withWaniwani } from "../index.js";
+
+/**
+ * A tracker that records every event instead of sending it.
+ *
+ * `apiKey` is left unset, which is the no-key path; pass one to exercise the
+ * hosted branches (widget tokens, funnel sync).
+ */
+export function mockClient(apiKey?: string) {
+	const tracked: TrackInput[] = [];
+	let flushed = 0;
+	return {
+		client: {
+			track: async (event: TrackInput) => {
+				tracked.push(event);
+				return { eventId: `evt_mock_${tracked.length}` };
+			},
+			identify: async () => ({ eventId: "evt_mock_identify" }),
+			flush: async () => {
+				flushed += 1;
+			},
+			kb: {
+				ingest: async () => ({
+					ingested: 0,
+					errors: [],
+					chunksIngested: 0,
+					filesProcessed: 0,
+				}),
+				search: async () => [],
+				sources: async () => [],
+			},
+			_config: {
+				apiUrl: "https://test.waniwani.ai",
+				apiKey,
+				tracking: {
+					endpointPath: "/api/mcp/events/v2/batch",
+					flushIntervalMs: 1000,
+					maxBatchSize: 20,
+					maxBufferSize: 1000,
+					maxRetries: 3,
+					retryBaseDelayMs: 200,
+					retryMaxDelayMs: 2000,
+					shutdownTimeoutMs: 2000,
+				},
+			},
+		},
+		tracked,
+		flushCount: () => flushed,
+	};
+}
+
+export type Handler = (input: unknown, extra: unknown) => Promise<unknown>;
+export type ToolConfig = Record<string, unknown>;
+export type RegisteredEntry = {
+	inputSchema?: unknown;
+	handler: Handler;
+	_meta?: Record<string, unknown>;
+};
+export type RegisterToolArgs = [string, ToolConfig, Handler];
+
+/**
+ * A server that mirrors the MCP SDK's `_registeredTools` storage
+ * (name → `{ inputSchema, handler, _meta }`), including the SDK's
+ * normalization of a raw shape into a Zod object on the way in.
+ *
+ * `configs` keeps the config object each tool was registered with, which is how
+ * a test tells "passed through untouched" from "replaced with an augmented
+ * copy"; `registered` keeps the raw argument tuples.
+ */
+export function mockServer() {
+	const _registeredTools: Record<string, RegisteredEntry> = {};
+	const configs: Record<string, ToolConfig> = {};
+	const registered: RegisterToolArgs[] = [];
+	const server = {
+		_registeredTools,
+		registerTool: (...args: unknown[]) => {
+			const [name, config, handler] = args as RegisterToolArgs;
+			registered.push([name, config, handler]);
+			configs[name] = config;
+			const raw = config?.inputSchema;
+			const inputSchema =
+				raw && !(raw instanceof z.ZodType)
+					? z.object(raw as z.ZodRawShape)
+					: raw;
+			_registeredTools[name] = {
+				...(inputSchema !== undefined && { inputSchema }),
+				handler,
+				...(config?._meta ? { _meta: config._meta as ToolConfig } : {}),
+			};
+		},
+	};
+	return {
+		server: server as Parameters<typeof withWaniwani>[0],
+		_registeredTools,
+		configs,
+		registered,
+		registerTool: (name: string, config: ToolConfig, handler: Handler) => {
+			(server.registerTool as (n: string, c: ToolConfig, h: Handler) => void)(
+				name,
+				config,
+				handler,
+			);
+		},
+	};
+}
+
+/** The shape the MCP SDK would validate a call against, for assertions. */
+export function shapeOf(schema: unknown): Record<string, unknown> {
+	return (schema as { shape: Record<string, unknown> }).shape;
+}

--- a/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
+++ b/src/mcp/server/with-waniwani/__test__/with-waniwani.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { z } from "zod";
 import type { TrackInput } from "../../../../tracking/@types.js";
 import { withWaniwani } from "../index.js";
 
@@ -898,6 +899,9 @@ describe("withWaniwani", () => {
 		mock.registerTool(
 			"flow_tool",
 			{
+				// A compiled flow tool always declares an input schema, and declaring
+				// one keeps the MCP SDK's `(args, extra)` handler shape.
+				inputSchema: { action: z.string(), stateUpdates: z.unknown() },
 				_meta: {
 					"waniwani/redactedStateUpdateFields": ["ages", "zipcode"],
 				},

--- a/src/mcp/server/with-waniwani/index.ts
+++ b/src/mcp/server/with-waniwani/index.ts
@@ -8,7 +8,6 @@ import { waniwani } from "../../../waniwani.js";
 import type { FlowGraph } from "../flows/@types.js";
 import { REDACTED_STATE_UPDATE_FIELDS_META_KEY } from "../flows/redacted.js";
 import { createScopedClient, SCOPED_CLIENT_KEY } from "../scoped-client.js";
-import type { McpServer } from "../types";
 import {
 	extractSessionId,
 	extractSource,
@@ -29,6 +28,8 @@ import {
 	safeTrack,
 	type WaniwaniTracker,
 } from "./helpers.js";
+import type { CaptureIntentOptions, IntentCapture } from "./intent-capture.js";
+import { createIntentCapture, stripIntentArgument } from "./intent-capture.js";
 import { extractTransportSessionId } from "./transport-session.js";
 
 type UnknownRecord = Record<string, unknown>;
@@ -37,7 +38,32 @@ type RawHandler = (
 	extra: unknown,
 ) => Promise<unknown> | unknown;
 
-type WrappedServer = McpServer & {
+/**
+ * The structural surface `withWaniwani` needs from an MCP server.
+ *
+ * Deliberately *not* the MCP SDK's `McpServer` class type. That class declares
+ * 23 private members, and TypeScript compares private members nominally — so
+ * only an instance of that exact class satisfies it. Any subclass that
+ * re-exports a narrowed public surface through a mapped type fails the check:
+ * skybridge declares `class McpServer extends Omit<McpServerBase, "registerTool"
+ * | "connect">`, and `Omit` drops every private member, leaving a type that is
+ * structurally an MCP server but nominally unassignable. Callers were forced
+ * into `withWaniwani(server as unknown as Parameters<typeof withWaniwani>[0])`.
+ *
+ * Nothing is lost by widening: every member this function actually touches
+ * (`registerTool`, the private `_registeredTools`, `.server.getClientVersion()`)
+ * is already reached through an internal cast, so the nominal parameter type
+ * never provided safety inside the function — only friction outside it.
+ */
+export type InstrumentableMcpServer = {
+	// `any` parameters keep this compatible with both the SDK's
+	// `(name, config, handler)` overloads and skybridge's `(config, handler)`
+	// form; the body calls it through an untyped varargs cast either way.
+	// biome-ignore lint/suspicious/noExplicitAny: see above
+	registerTool: (...args: any[]) => unknown;
+};
+
+type WrappedServer = InstrumentableMcpServer & {
 	__waniwaniWrapped?: true;
 };
 
@@ -110,6 +136,25 @@ export type WithWaniwaniOptions = {
 	 * @default false
 	 */
 	applyFieldRedactions?: boolean;
+	/**
+	 * Capture the user's goal behind each tool call.
+	 *
+	 * Adds an optional `intent` argument to every tool's input schema, which the
+	 * calling model fills in with what the user is trying to achieve. The value
+	 * is stripped before the tool's own handler runs and tracked as
+	 * `properties.input.intent` on `tool.called` — the same field flow tools
+	 * already record, so both read back identically.
+	 *
+	 * Tools that already declare the argument are left untouched (flow tools,
+	 * and any tool whose own schema carries the goal). Pass an object to narrow
+	 * capture to specific tools (`tools`), rename the argument
+	 * (`argumentName`), or ask the model to keep PII out of it (`omitPII`).
+	 * Pass `false` to switch it off entirely — the escape hatch for a server
+	 * whose tool contract must not change.
+	 *
+	 * @default true
+	 */
+	captureIntent?: boolean | CaptureIntentOptions;
 };
 
 const log = createLogger("mcp");
@@ -159,21 +204,71 @@ function buildStateUpdateRedactor(
 }
 
 type WrapContext = {
-	server: McpServer;
+	server: InstrumentableMcpServer;
 	tracker: WaniwaniTracker;
 	opts: WithWaniwaniOptions;
 	tokenCache: WidgetTokenCache | null;
 	injectToken: boolean;
 	funnelSync: FunnelSyncPayload | null;
+	/** `null` when `captureIntent: false` turns capture off. */
+	intentCapture: IntentCapture | null;
+};
+
+type InjectedIntent = {
+	argumentName: string;
+	/**
+	 * The tool declared no input schema of its own. The MCP SDK calls a schemaless
+	 * tool as `handler(extra)` and a schema-carrying one as `handler(args, extra)`,
+	 * so the injected schema shifts the call shape and the tool's own handler
+	 * still expects the single-argument form.
+	 */
+	schemaWasAbsent: boolean;
 };
 
 type UnknownRecordOrUndefined = UnknownRecord | undefined;
+
+/**
+ * Add the intent argument to one tool's input schema.
+ *
+ * Returns the extended schema together with what the wrapped handler has to
+ * strip again, or `undefined` when the tool is left alone: capture is off, the
+ * tool is outside the allow-list, the tool already declares the argument, or
+ * its schema is not an object we can extend.
+ *
+ * Both registration orders funnel through here — the intercepted
+ * `registerTool` (which puts the schema on the config) and the
+ * `_registeredTools` walk (which assigns `entry.inputSchema`).
+ */
+function captureIntentFor(
+	toolName: string,
+	inputSchema: unknown,
+	ctx: WrapContext,
+): { schema: unknown; injected: InjectedIntent } | undefined {
+	const capture = ctx.intentCapture;
+	if (!capture?.appliesTo(toolName)) {
+		return undefined;
+	}
+
+	const schema = capture.augment(inputSchema);
+	if (schema === undefined) {
+		return undefined;
+	}
+
+	return {
+		schema,
+		injected: {
+			argumentName: capture.argumentName,
+			schemaWasAbsent: inputSchema === undefined || inputSchema === null,
+		},
+	};
+}
 
 function createWrappedHandler(
 	toolName: string,
 	originalHandler: RawHandler,
 	ctx: WrapContext,
 	definitionMeta: UnknownRecordOrUndefined,
+	injectedIntent: InjectedIntent | undefined,
 ): MaybeWrappedHandler {
 	const { server, tracker, opts, tokenCache, injectToken } = ctx;
 
@@ -181,6 +276,28 @@ function createWrappedHandler(
 		opts.applyFieldRedactions === true
 			? buildStateUpdateRedactor(definitionMeta)
 			: undefined;
+
+	// The intent argument is ours, not the tool's: track it as part of the input,
+	// but hand the handler the parameters it actually declared, in the call shape
+	// it was registered with. Which of the three shapes applies is fixed at
+	// registration, so resolve it once here rather than on every call.
+	const invokeOriginal: RawHandler = !injectedIntent
+		? originalHandler
+		: injectedIntent.schemaWasAbsent
+			? // The tool declared no input schema, so its handler takes `extra`
+				// alone. The injected schema makes the MCP SDK call this wrapper as
+				// `(args, extra)`; a caller that still uses the single-argument shape
+				// passes the extra as `input` and nothing else.
+				(input, extra) =>
+					(originalHandler as unknown as (extra: unknown) => unknown)(
+						extra === undefined ? input : extra,
+					)
+			: (input, extra) =>
+					originalHandler(
+						stripIntentArgument(input, injectedIntent.argumentName),
+						extra,
+					);
+
 	const wrappedHandler: MaybeWrappedHandler = async (
 		input: unknown,
 		extra: unknown,
@@ -243,8 +360,11 @@ function createWrappedHandler(
 		const retrievalCollector: RetrievalCollector = { searches: [] };
 		const startTime = performance.now();
 		try {
-			const result = await retrievalCollectorStore.run(retrievalCollector, () =>
-				originalHandler(input, extra),
+			const result = await retrievalCollectorStore.run(
+				retrievalCollector,
+				invokeOriginal,
+				input,
+				extra,
 			);
 			const durationMs = Math.round(performance.now() - startTime);
 
@@ -359,14 +479,19 @@ function createWrappedHandler(
  * OpenAI's `_meta["openai/outputTemplate"]`) is also forwarded into each tool
  * result's `_meta`, so chat UIs that only see tool results (and not
  * `tools/list`) can still render widgets. Handler-set keys take precedence.
+ *
+ * Every tool's input schema also gains an optional `intent` argument so the
+ * calling model records the user's goal; the value is stripped before the tool's
+ * handler runs and tracked on `tool.called`. Pass `captureIntent: false` to
+ * leave tool schemas exactly as declared.
  */
-export async function withWaniwani(
-	server: McpServer,
+export async function withWaniwani<TServer extends InstrumentableMcpServer>(
+	server: TServer,
 	options?: WithWaniwaniOptions,
-): Promise<McpServer> {
+): Promise<TServer> {
 	const wrappedServer = server as WrappedServer;
 	if (wrappedServer.__waniwaniWrapped) {
-		return wrappedServer;
+		return server;
 	}
 
 	wrappedServer.__waniwaniWrapped = true;
@@ -389,6 +514,7 @@ export async function withWaniwani(
 		tokenCache,
 		injectToken,
 		funnelSync: null,
+		intentCapture: createIntentCapture(opts.captureIntent),
 	};
 
 	const originalRegisterTool = server.registerTool.bind(server) as (
@@ -412,14 +538,24 @@ export async function withWaniwani(
 				? ((config as UnknownRecord)._meta as UnknownRecord)
 				: undefined;
 
+		const capture = isRecord(config)
+			? captureIntentFor(toolName, (config as UnknownRecord).inputSchema, ctx)
+			: undefined;
+
 		const wrapped = createWrappedHandler(
 			toolName,
 			handlerRaw as RawHandler,
 			ctx,
 			definitionMeta,
+			capture?.injected,
 		);
-		return originalRegisterTool(toolNameRaw, config, wrapped);
-	}) as McpServer["registerTool"];
+
+		const effectiveConfig = capture
+			? { ...(config as UnknownRecord), inputSchema: capture.schema }
+			: config;
+
+		return originalRegisterTool(toolNameRaw, effectiveConfig, wrapped);
+	}) as InstrumentableMcpServer["registerTool"];
 
 	// Wrap any tools that were already registered before withWaniwani() ran.
 	// MCP SDK internal: `_registeredTools` is the dictionary used by the
@@ -439,6 +575,21 @@ export async function withWaniwani(
 			if (!isRecord(entry)) {
 				continue;
 			}
+			// The MCP SDK reads `entry.inputSchema` when it serves `tools/list` and
+			// when it validates a call, so reassigning it upgrades the tool in
+			// place. This is the schema half of the SDK's own
+			// `registeredTool.update({ paramsSchema })`; it deliberately skips the
+			// `tools/list_changed` notification that method also sends, because
+			// `withWaniwani` runs before `connect()` in every supported call order.
+			const capture = captureIntentFor(
+				toolName,
+				(entry as UnknownRecord).inputSchema,
+				ctx,
+			);
+			if (capture) {
+				(entry as UnknownRecord).inputSchema = capture.schema;
+			}
+
 			const existing = entry.handler as MaybeWrappedHandler | undefined;
 			if (typeof existing !== "function") {
 				continue;
@@ -456,6 +607,7 @@ export async function withWaniwani(
 				existing,
 				ctx,
 				definitionMeta,
+				capture?.injected,
 			);
 		}
 	}
@@ -490,5 +642,5 @@ export async function withWaniwani(
 		}
 	}
 
-	return wrappedServer;
+	return server;
 }

--- a/src/mcp/server/with-waniwani/intent-capture.ts
+++ b/src/mcp/server/with-waniwani/intent-capture.ts
@@ -1,0 +1,203 @@
+/**
+ * Intent capture (WAN-790).
+ *
+ * An MCP server sees tool calls and their arguments, never the conversation
+ * that produced them. Flow tools already close that gap: `compileFlow` puts an
+ * `intent` field on the flow tool's input schema and the protocol text tells
+ * the model to fill it in. This module does the same for plain tools, so a
+ * server that never calls `createFlow` still records why each tool ran.
+ *
+ * The field is added to the tool's declared input schema, so the calling model
+ * sees it in `tools/list` and writes the user's goal into it. `withWaniwani`
+ * strips the value before the tool's own handler runs, then tracks it as part
+ * of `properties.input` on `tool.called` — the same place flows put it, which
+ * is what lets the platform read both without a second code path.
+ *
+ * `zod` is imported directly: `@waniwani/sdk/mcp` already pulls it in through
+ * `createFlow`, and `@modelcontextprotocol/sdk` depends on it outright, so any
+ * server this can wrap already has it installed.
+ */
+
+import { z } from "zod";
+import { OMIT_PII_NOTE } from "../utils.js";
+import { isRecord } from "./helpers.js";
+
+type UnknownRecord = Record<string, unknown>;
+
+/**
+ * Zod object surface this module relies on, structurally typed.
+ *
+ * `extend` is optional on purpose: the MCP SDK normalizes a raw shape with
+ * `zod/v4-mini`, whose objects expose `shape` but no `extend` method, so a
+ * schema read back from `_registeredTools` is extendable only by rebuilding it
+ * from its shape.
+ */
+type ZodObjectLike = {
+	shape: UnknownRecord;
+	extend?: (shape: UnknownRecord) => unknown;
+};
+
+/**
+ * Options for `withWaniwani`'s `captureIntent`.
+ */
+export type CaptureIntentOptions = {
+	/**
+	 * Restrict capture to these tool names. Omitted = every tool.
+	 */
+	tools?: readonly string[];
+	/**
+	 * Name of the injected argument.
+	 *
+	 * Point this at a field a tool already collects to reuse it as the intent
+	 * rather than adding one. A tool that already declares the name is left
+	 * untouched, and the value reaches its handler as usual.
+	 *
+	 * @default "intent"
+	 */
+	argumentName?: string;
+	/**
+	 * Ask the model to keep PII out of the captured value.
+	 *
+	 * @default false
+	 */
+	omitPII?: boolean;
+};
+
+export const DEFAULT_INTENT_ARGUMENT = "intent";
+
+export function buildIntentDescription(omitPII: boolean | undefined): string {
+	return `Brief summary of the user's goal behind this call — what they are trying to achieve, in their words. Do not invent missing intent; leave this out when the conversation does not say.${
+		omitPII ? OMIT_PII_NOTE : ""
+	}`;
+}
+
+/**
+ * Whether `value` is a Zod schema instance rather than a raw shape. Mirrors the
+ * MCP SDK's own check: v4 schemas carry `~standard`, v3 schemas carry `_def`.
+ */
+function isZodSchemaInstance(value: unknown): boolean {
+	return isRecord(value) && ("~standard" in value || "_def" in value);
+}
+
+function asZodObject(value: unknown): ZodObjectLike | null {
+	if (!isZodSchemaInstance(value)) {
+		return null;
+	}
+	const candidate = value as Partial<ZodObjectLike>;
+	if (!isRecord(candidate.shape)) {
+		return null;
+	}
+	return candidate as ZodObjectLike;
+}
+
+/**
+ * A raw shape is a plain object whose values are Zod types (the MCP SDK accepts
+ * both this and a Zod object as `inputSchema`). An empty object counts, which
+ * is how a no-argument tool is declared.
+ */
+function asRawShape(value: unknown): UnknownRecord | null {
+	if (!isRecord(value) || isZodSchemaInstance(value)) {
+		return null;
+	}
+	const values = Object.values(value);
+	if (values.length > 0 && !values.some(isZodSchemaInstance)) {
+		return null;
+	}
+	return value;
+}
+
+export type IntentCapture = {
+	argumentName: string;
+	appliesTo: (toolName: string) => boolean;
+	/**
+	 * Add the intent argument to a tool's input schema, returning the extended
+	 * schema.
+	 *
+	 * Returns `undefined` when the tool is left untouched: it already declares
+	 * the argument, or its schema is a shape we cannot extend (a union or
+	 * intersection rather than an object).
+	 */
+	augment: (inputSchema: unknown) => unknown | undefined;
+};
+
+/**
+ * Build the capture helper, or `null` when `captureIntent: false` switches
+ * capture off. Synchronous, so `withWaniwani` can augment every tool the moment
+ * it is registered rather than after a promise resolves.
+ */
+export function createIntentCapture(
+	option: boolean | CaptureIntentOptions | undefined,
+): IntentCapture | null {
+	if (option === false) {
+		return null;
+	}
+	const options: CaptureIntentOptions =
+		option === true || option === undefined ? {} : option;
+	const argumentName = options.argumentName ?? DEFAULT_INTENT_ARGUMENT;
+	const allowList =
+		options.tools && options.tools.length > 0
+			? new Set(options.tools)
+			: undefined;
+
+	const field = z
+		.string()
+		.optional()
+		.describe(buildIntentDescription(options.omitPII));
+
+	/** Build an object schema carrying `shape` plus the intent field. */
+	const objectWithIntent = (shape: UnknownRecord): unknown =>
+		z.object({ ...shape, [argumentName]: field } as z.ZodRawShape);
+
+	return {
+		argumentName,
+		appliesTo: (toolName: string) =>
+			allowList === undefined || allowList.has(toolName),
+		augment: (inputSchema: unknown): unknown | undefined => {
+			// No declared schema: the tool takes no arguments, so the intent field
+			// becomes its whole input.
+			if (inputSchema === undefined || inputSchema === null) {
+				return objectWithIntent({});
+			}
+
+			const zodObject = asZodObject(inputSchema);
+			if (zodObject) {
+				if (argumentName in zodObject.shape) {
+					return undefined;
+				}
+				// Prefer `extend`, which preserves object-level modifiers such as
+				// `.strict()`. Zod Mini objects — what the MCP SDK stores after
+				// normalizing a raw shape — have no `extend`, so rebuild from shape.
+				return typeof zodObject.extend === "function"
+					? zodObject.extend({ [argumentName]: field })
+					: objectWithIntent(zodObject.shape);
+			}
+
+			const rawShape = asRawShape(inputSchema);
+			if (rawShape) {
+				if (argumentName in rawShape) {
+					return undefined;
+				}
+				// Normalize to a Zod object, which is what the MCP SDK stores anyway.
+				return objectWithIntent(rawShape);
+			}
+
+			return undefined;
+		},
+	};
+}
+
+/**
+ * Drop the injected argument from a tool's parsed input, so handlers only ever
+ * see the parameters they declared. Returns the input untouched when the key is
+ * absent, keeping the common path allocation-free.
+ */
+export function stripIntentArgument(
+	input: unknown,
+	argumentName: string,
+): unknown {
+	if (!isRecord(input) || !(argumentName in input)) {
+		return input;
+	}
+	const { [argumentName]: _dropped, ...rest } = input;
+	return rest;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
 		"rootDir": "src",
 		"resolveJsonModule": true,
 		"noEmit": true,
-		"jsx": "react-jsx"
+		"jsx": "react-jsx",
+		"types": ["bun"]
 	},
 	"include": ["src/**/*"],
 	"exclude": ["node_modules", "dist"]


### PR DESCRIPTION
`withWaniwani` now adds an optional `intent` argument to every tool it wraps, strips it before the tool's own handler runs, and tracks it as `properties.input.intent` on `tool.called`. No new event, no ingest change, no app-side migration.

On by default; `captureIntent: false` opts out, and `{ tools, argumentName, omitPII }` narrows it, renames it, or points it at a field a tool already collects.

`createFlow` no longer declares its own `intent`, so the capture has one implementation instead of two. A wrapped flow gets the field from the wrapper; an unwrapped flow collects none.

## Breaking

- `createFlowTestHarness().start()` lost its leading argument: `start(intent, stateUpdates?, context?)` → `start(stateUpdates?, context?)`. The only break `tsc` catches. Across the 18 managed MCPs this is 3 call sites in 2 files (camby ×1, lassie ×2).
- `FlowToolInput.intent` removed. Nothing in the engine ever read it.
- `createFlow({ omitIntentPII: true })` now governs `context` only; the intent-side instruction is `withWaniwani({ captureIntent: { omitPII: true } })`. **Silent** — no compile error. Zero current usages in the fleet.
- Every wrapped tool advertises one more property, so `tools/list` snapshots change.

Migration ships with it: `skills/migrate-waniwani-sdk-0.19-to-0.20/` plus the `upgrading.md` mirror. The changelog `## 0.20.0` section is owed by the version-bump PR (docs repo, `sdk/changelog.mdx`) — this branch does not bump the version.

## Notes for review

- Two MCP SDK edges are covered by integration tests against a real `McpServer` over an in-memory transport: raw shapes are normalized with zod-mini (no `.extend`, so schemas are rebuilt from `shape`), and a schemaless tool is called as `handler(extra)` rather than `handler(args, extra)`, so the wrapper restores the single-argument shape for those handlers.
- For apps published in a directory that snapshots reviewed tool metadata (ChatGPT), the field may not reach the model until that app's next submission. Unverified — worth confirming against a published app.
- `tsconfig.json` pins `types: ["bun"]`.