### PR TITLE
fix(chat): record suggestion impressions on every surface

### DIFF
--- a/skills/waniwani-sdk/references/chat-widget.md
+++ b/skills/waniwani-sdk/references/chat-widget.md
@@ -813,7 +813,7 @@ Both hosted surfaces accept an `onEvent` callback — `WaniWani.chat.init({ onEv
 | `thread.changed` | Thread created or switched (requires thread history; the top-level `sessionId` is the target thread's session, `undefined` for a fresh thread) | `{ threadId }` |
 | `chat.error` | Chat request failed | `{ message }` (truncated to 200 chars) |
 | `suggestion.clicked` | Suggestion pill or welcome card clicked (dock pills, in-chat pills, welcome cards) | `{ text, index, origin }` (`index` is `-1` when the position is unknown; `origin` is one of `"channel"`, `"page"`, `"flow"`, `"followup"` — see [Where the suggestion pills come from](#where-the-suggestion-pills-come-from)) |
-| `suggestions.shown` | A pill set was rendered — one event per set, not per pill. Fires once per set: re-renders and collapse/expand cycles of the same pills stay silent, a new set (an SPA navigation, a streamed turn) fires again | `{ texts, origin }` (`origin` uses the same taxonomy as `suggestion.clicked`) |
+| `suggestions.shown` | A pill set was rendered and is on screen — one event per set, not per pill (dock pills, in-chat pills, welcome cards). Fires once per set: re-renders and collapse/expand cycles of the same pills stay silent, a new set (an SPA navigation, a streamed turn) fires again. In floating mode the collapsed panel reports nothing, so a set is announced when the visitor can actually see it | `{ texts, origin }` (`origin` uses the same taxonomy as `suggestion.clicked`) |
 | `link.clicked` | Anchor clicked inside the conversation | `{ url }` (absolute URL) |
 
 Do not assume `chat.opened` precedes the first `message.sent`: a send from the docked bar opens the panel and sends in one action, and the open transition is reported after the send.

--- a/src/chat/web/@types.ts
+++ b/src/chat/web/@types.ts
@@ -364,6 +364,14 @@ export interface ChatEmbedProps
 	 * should leave this unset.
 	 */
 	initializing?: boolean;
+	/**
+	 * @internal
+	 * Whether the chat is actually on screen. `false` suppresses
+	 * `suggestions.shown` impressions, so a mount kept hidden behind other
+	 * chrome (the floating dock) never reports pills the visitor cannot see.
+	 * Defaults to `true`; standalone `ChatEmbed` callers should leave it unset.
+	 */
+	onScreen?: boolean;
 }
 
 // `ChatCardProps` moved to `src/legacy/chat/web/chat-card.tsx` alongside the

--- a/src/chat/web/embed/floating-chat.tsx
+++ b/src/chat/web/embed/floating-chat.tsx
@@ -30,16 +30,11 @@ import {
 import type { ChatHandle } from "../@types";
 import BorderGlow from "../components/border-glow";
 import { Suggestions } from "../components/suggestions";
+import { useSuggestionIngest } from "../hooks/use-suggestion-ingest";
 import { useTypingPlaceholder } from "../hooks/use-typing-placeholder";
 import { I18nProvider, useTranslation } from "../i18n";
 import { ChatEmbed } from "../layouts/chat-embed";
 import { resolveSuggestions } from "../lib/resolve-suggestions";
-import {
-	fireSuggestionClick,
-	fireSuggestionShown,
-	resolveShownSuggestions,
-	resolveSuggestionId,
-} from "../lib/suggestion-click";
 import { cn } from "../lib/utils";
 import { themeToCSSProperties } from "../theme";
 import type { EmbedConfig } from "./config";
@@ -189,56 +184,19 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 			[dockRow],
 		);
 
-		// Record every suggestion click and every rendered pill set
-		// server-side, attributed to the authored prompts involved. Rides the
-		// same widget-event stream the host page subscribes to, so there is one
-		// signal per interaction, not two — and it covers both the dock's CTAs
-		// and the panel's own pills.
-		useEffect(() => {
-			return widgetEvents.subscribe((event) => {
-				if (event.name === "suggestion.clicked") {
-					const { text, origin } = event.properties;
-					const promptId = resolveSuggestionId(suggestions.page ?? [], text);
-					void fireSuggestionClick({
-						api: config.api ?? "",
-						token: config.token,
-						channelId: config.channelId,
-						mode: "floating",
-						source: config.source,
-						sessionId: chatRef.current?.sessionId,
-						promptId,
-						origin,
-						text,
-						index: event.properties.index,
-					});
-					return;
-				}
-				if (event.name === "suggestions.shown") {
-					const { texts, origin } = event.properties;
-					const prompts = resolveShownSuggestions(
-						suggestions.page ?? [],
-						texts,
-					);
-					void fireSuggestionShown({
-						api: config.api ?? "",
-						token: config.token,
-						channelId: config.channelId,
-						mode: "floating",
-						source: config.source,
-						sessionId: chatRef.current?.sessionId,
-						prompts,
-						origin,
-					});
-				}
-			});
-		}, [
+		// Record every suggestion click and every rendered pill set server-side,
+		// attributed to the authored prompts involved. Covers both the dock's
+		// CTAs and the panel's own pills.
+		useSuggestionIngest({
 			widgetEvents,
-			suggestions,
-			config.api,
-			config.token,
-			config.channelId,
-			config.source,
-		]);
+			api: config.api,
+			token: config.token,
+			channelId: config.channelId,
+			source: config.source,
+			mode: "floating",
+			pagePrompts: suggestions.page,
+			getSessionId: () => chatRef.current?.sessionId,
+		});
 
 		// One impression per revealed dock row, keyed on the resolved row's
 		// identity — a new fetch (SPA navigation) is a new object and counts
@@ -655,6 +613,11 @@ const FloatingChatInner = forwardRef<FloatingChatHandle, FloatingChatProps>(
 									// leave an opened (full-screen on mobile) panel with no in-UI
 									// way back to the dock. The panel is its own chrome anyway.
 									hideHeader={false}
+									// Mounted eagerly behind the dock, so without this the
+									// panel's own pill row reports impressions for pills no
+									// visitor has seen, and double-counts the pre-chat row
+									// the dock already announced.
+									onScreen={phase === "open"}
 									welcomeMessage={config.welcomeMessage}
 									placeholder={config.placeholder}
 									suggestions={suggestions}

--- a/src/chat/web/embed/inline-chat.tsx
+++ b/src/chat/web/embed/inline-chat.tsx
@@ -14,13 +14,8 @@ import {
 	useRef,
 } from "react";
 import type { ChatHandle } from "../@types";
+import { useSuggestionIngest } from "../hooks/use-suggestion-ingest";
 import { ChatEmbed } from "../layouts/chat-embed";
-import {
-	fireSuggestionClick,
-	fireSuggestionShown,
-	resolveShownSuggestions,
-	resolveSuggestionId,
-} from "../lib/suggestion-click";
 import type { EmbedConfig } from "./config";
 import { useRemoteEmbedConfig } from "./remote-config";
 import { useVisibilityGate } from "./use-pathname";
@@ -121,55 +116,18 @@ export const InlineChat = forwardRef<InlineChatHandle, InlineChatProps>(
 		// on this object's identity.
 		const suggestions = useSuggestions(config);
 
-		// Record every suggestion click and every rendered pill set
-		// server-side, attributed to the authored prompts involved. Rides the
-		// same widget-event stream the host page subscribes to, so there is one
-		// signal per interaction, not two.
-		useEffect(() => {
-			return widgetEvents.subscribe((event) => {
-				if (event.name === "suggestion.clicked") {
-					const { text, origin } = event.properties;
-					const promptId = resolveSuggestionId(suggestions.page ?? [], text);
-					void fireSuggestionClick({
-						api: config.api ?? "",
-						token: config.token,
-						channelId: config.channelId,
-						mode: "inline",
-						source: config.source,
-						sessionId: chatRef.current?.sessionId,
-						promptId,
-						origin,
-						text,
-						index: event.properties.index,
-					});
-					return;
-				}
-				if (event.name === "suggestions.shown") {
-					const { texts, origin } = event.properties;
-					const prompts = resolveShownSuggestions(
-						suggestions.page ?? [],
-						texts,
-					);
-					void fireSuggestionShown({
-						api: config.api ?? "",
-						token: config.token,
-						channelId: config.channelId,
-						mode: "inline",
-						source: config.source,
-						sessionId: chatRef.current?.sessionId,
-						prompts,
-						origin,
-					});
-				}
-			});
-		}, [
+		// Record every suggestion click and every rendered pill set server-side,
+		// attributed to the authored prompts involved.
+		useSuggestionIngest({
 			widgetEvents,
-			suggestions,
-			config.api,
-			config.token,
-			config.channelId,
-			config.source,
-		]);
+			api: config.api,
+			token: config.token,
+			channelId: config.channelId,
+			source: config.source,
+			mode: "inline",
+			pagePrompts: suggestions.page,
+			getSessionId: () => chatRef.current?.sessionId,
+		});
 
 		// `mode` tags every chat request with the embed surface so server-logged
 		// chat events carry it in `properties.mode`, matching `page.viewed`.

--- a/src/chat/web/hooks/__tests__/use-suggestion-ingest.test.tsx
+++ b/src/chat/web/hooks/__tests__/use-suggestion-ingest.test.tsx
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+
+// ---------------------------------------------------------------------------
+// Minimal DOM globals so react-dom/client can mount a hook harness. The hook
+// only subscribes to an emitter and POSTs, so the transport layer and
+// `@ai-sdk/react` never come into it.
+// ---------------------------------------------------------------------------
+
+const win = new Window({ url: "https://shop.example/pricing" });
+for (const key of [
+	"document",
+	"navigator",
+	"HTMLElement",
+	"HTMLDivElement",
+	"MutationObserver",
+	"customElements",
+	"Element",
+	"Node",
+	"Text",
+	"Comment",
+	"DocumentFragment",
+	"Event",
+	"CustomEvent",
+	"localStorage",
+	"requestAnimationFrame",
+	"cancelAnimationFrame",
+	"getComputedStyle",
+] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any)[key] = (win as any)[key];
+}
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).window = win;
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { act, createElement } = await import("react");
+const { createRoot } = await import("react-dom/client");
+type Root = ReturnType<typeof createRoot>;
+
+const { useSuggestionIngest } = await import("../use-suggestion-ingest");
+type Options = Parameters<typeof useSuggestionIngest>[0];
+const { createWidgetEventEmitter } = await import("../../embed/widget-events");
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function Harness({ options }: { options: Options }) {
+	useSuggestionIngest(options);
+	return null;
+}
+
+let root: Root;
+let container: HTMLElement;
+let fetchMock: ReturnType<typeof mock>;
+const originalFetch = globalThis.fetch;
+
+const PAGE_PROMPTS = [{ id: "prompt_1", text: "Do you want a website?" }];
+
+function baseOptions(): Omit<Options, "widgetEvents"> {
+	return {
+		api: "https://app.waniwani.ai/api/mcp/chat",
+		token: "wwp_test",
+		channelId: "chan_1",
+		source: "web",
+		mode: "inline",
+		pagePrompts: PAGE_PROMPTS,
+		getSessionId: () => "sess_1",
+	};
+}
+
+/** Mount the hook against a live emitter and return it. */
+function mount(overrides: Partial<Options> = {}) {
+	const widgetEvents = createWidgetEventEmitter({ mode: "inline" });
+	const options = { ...baseOptions(), widgetEvents, ...overrides } as Options;
+	act(() => {
+		root.render(createElement(Harness, { options }));
+	});
+	return widgetEvents;
+}
+
+/** The single event of the nth POSTed batch. */
+function postedEvent(call: number): Record<string, unknown> {
+	const [, init] = fetchMock.mock.calls[call] as [string, RequestInit];
+	const body = JSON.parse(init.body as string) as {
+		events: Record<string, unknown>[];
+	};
+	return body.events[0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+	container = document.createElement("div");
+	document.body.appendChild(container);
+	root = createRoot(container);
+	fetchMock = mock(async () => new Response("{}", { status: 200 }));
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+	act(() => {
+		root.unmount();
+	});
+	container.remove();
+	globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useSuggestionIngest", () => {
+	test("POSTs suggestion.shown for a rendered set, attributing authored ids", async () => {
+		const events = mount();
+
+		await act(async () => {
+			events.emit({
+				name: "suggestions.shown",
+				properties: {
+					texts: ["Do you want a website?", "Over 65"],
+					origin: "page",
+				},
+			});
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(postedEvent(0)).toMatchObject({
+			name: "suggestion.shown",
+			properties: {
+				origin: "page",
+				count: 2,
+				channelId: "chan_1",
+				mode: "inline",
+				prompts: [
+					{ id: "prompt_1", text: "Do you want a website?" },
+					{ id: null, text: "Over 65" },
+				],
+			},
+		});
+	});
+
+	test("POSTs suggestion.clicked for a flow pill, which carries no authored id", async () => {
+		const events = mount();
+
+		await act(async () => {
+			events.emit({
+				name: "suggestion.clicked",
+				properties: { text: "Over 65", index: 1, origin: "flow" },
+			});
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(postedEvent(0)).toMatchObject({
+			name: "suggestion.clicked",
+			properties: { origin: "flow", text: "Over 65", index: 1, promptId: null },
+		});
+	});
+
+	test("reads the session id at emit time, not at subscribe time", async () => {
+		let sessionId: string | undefined;
+		const events = mount({ getSessionId: () => sessionId });
+
+		await act(async () => {
+			events.emit({
+				name: "suggestions.shown",
+				properties: { texts: ["Over 65"], origin: "flow" },
+			});
+		});
+		// `JSON.stringify` drops an undefined session id, so the first event
+		// carries visitor identity only.
+		expect(postedEvent(0).correlation).not.toHaveProperty("sessionId");
+
+		sessionId = "sess_late";
+		await act(async () => {
+			events.emit({
+				name: "suggestion.clicked",
+				properties: { text: "Over 65", index: 0, origin: "flow" },
+			});
+		});
+		expect(postedEvent(1).correlation).toMatchObject({
+			sessionId: "sess_late",
+		});
+	});
+
+	test("sends nothing without a public token", async () => {
+		const events = mount({ token: undefined });
+
+		await act(async () => {
+			events.emit({
+				name: "suggestions.shown",
+				properties: { texts: ["Over 65"], origin: "flow" },
+			});
+		});
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	test("ignores widget events that are not suggestion events", async () => {
+		const events = mount();
+
+		await act(async () => {
+			events.emit({ name: "chat.opened" });
+		});
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/chat/web/hooks/use-suggestion-ingest.ts
+++ b/src/chat/web/hooks/use-suggestion-ingest.ts
@@ -1,0 +1,90 @@
+"use client";
+
+// ============================================================================
+// Forwards the widget-event suggestion signals to the canonical ingest.
+//
+// Every mount point that owns a `WidgetEventEmitter` mounts this, so a pill
+// impression is recorded the same way on every surface. Riding the widget
+// event stream rather than the render sites keeps one signal per interaction:
+// the host page's `onEvent` subscriber and our own ingest see the same event.
+// ============================================================================
+
+import { useEffect, useRef } from "react";
+import type { WidgetEventEmitter, WidgetMode } from "../embed/widget-events";
+import type { Suggestion } from "../lib/resolve-suggestions";
+import {
+	fireSuggestionClick,
+	fireSuggestionShown,
+	resolveShownSuggestions,
+	resolveSuggestionId,
+} from "../lib/suggestion-click";
+
+export interface UseSuggestionIngestOptions {
+	widgetEvents: WidgetEventEmitter;
+	/** Chat API base, e.g. `https://app.waniwani.ai/api/mcp/chat`. */
+	api: string | undefined;
+	/** Public token (`wwp_...`). Nothing is sent without one. */
+	token: string | undefined;
+	/** Agent channel ID, when known. */
+	channelId?: string;
+	/** Channel-specific event source from the resolved `/config`. */
+	source?: string;
+	/** Embed surface the events happened on. */
+	mode: WidgetMode;
+	/**
+	 * Authored per-page prompts for this URL — the only rung whose pills carry
+	 * a stored id, so it is the only list a text can attribute back to.
+	 */
+	pagePrompts: Suggestion[] | null;
+	/**
+	 * Read at emit time, not at subscribe time: an impression that precedes the
+	 * first exchange has no session id, and the one after it does.
+	 */
+	getSessionId: () => string | undefined;
+}
+
+export function useSuggestionIngest(options: UseSuggestionIngestOptions): void {
+	const { widgetEvents, api, token, channelId, source, mode, pagePrompts } =
+		options;
+
+	// Held in a ref so a fresh closure on every render never resubscribes.
+	const getSessionIdRef = useRef(options.getSessionId);
+	getSessionIdRef.current = options.getSessionId;
+
+	useEffect(() => {
+		if (!api || !token) {
+			return;
+		}
+		return widgetEvents.subscribe((event) => {
+			if (event.name === "suggestion.clicked") {
+				const { text, origin, index } = event.properties;
+				void fireSuggestionClick({
+					api,
+					token,
+					channelId,
+					mode,
+					source,
+					sessionId: getSessionIdRef.current(),
+					promptId: resolveSuggestionId(pagePrompts ?? [], text),
+					origin,
+					text,
+					index,
+				});
+				return;
+			}
+			if (event.name === "suggestions.shown") {
+				const { texts, origin } = event.properties;
+				void fireSuggestionShown({
+					api,
+					token,
+					channelId,
+					mode,
+					source,
+					sessionId: getSessionIdRef.current(),
+					prompts: resolveShownSuggestions(pagePrompts ?? [], texts),
+					origin,
+				});
+			}
+		});
+	}, [widgetEvents, api, token, channelId, source, mode, pagePrompts]);
+}

--- a/src/chat/web/layouts/__tests__/chat-embed-widget-events.test.tsx
+++ b/src/chat/web/layouts/__tests__/chat-embed-widget-events.test.tsx
@@ -114,7 +114,9 @@ afterEach(() => {
 	container = null;
 });
 
-async function renderEmbed() {
+type EmbedProps = Parameters<typeof ChatEmbed>[0];
+
+async function renderEmbed(overrides: Partial<EmbedProps> = {}) {
 	const emitter = createWidgetEventEmitter({ mode: "inline" });
 	const events: WidgetEventType[] = [];
 	emitter.subscribe((event) => events.push(event));
@@ -123,20 +125,31 @@ async function renderEmbed() {
 	document.body.appendChild(container);
 	root = createRoot(container);
 
-	await act(async () => {
-		root?.render(
-			createElement(
-				WidgetEventsProvider,
-				{ value: emitter },
-				createElement(ChatEmbed, {
-					api: "https://example.com/api/chat",
-					suggestions: { initial: ["First suggestion", "Second suggestion"] },
-				}),
-			),
-		);
-	});
+	const props: EmbedProps = {
+		api: "https://example.com/api/chat",
+		suggestions: { initial: ["First suggestion", "Second suggestion"] },
+		...overrides,
+	};
 
-	return { events };
+	const render = async (next: Partial<EmbedProps> = {}) => {
+		await act(async () => {
+			root?.render(
+				createElement(
+					WidgetEventsProvider,
+					{ value: emitter },
+					createElement(ChatEmbed, { ...props, ...next }),
+				),
+			);
+		});
+	};
+
+	await render();
+
+	return { events, render };
+}
+
+function shownSets(events: WidgetEventType[]) {
+	return events.filter((e) => e.name === "suggestions.shown");
 }
 
 function clickElement(el: Element) {
@@ -173,6 +186,45 @@ describe("ChatEmbed widget events", () => {
 				origin: "channel",
 			},
 		});
+	});
+
+	test("the pre-chat pill row announces one impression", async () => {
+		const { events } = await renderEmbed();
+
+		expect(shownSets(events)).toHaveLength(1);
+		expect(shownSets(events)[0]).toMatchObject({
+			name: "suggestions.shown",
+			properties: {
+				texts: ["First suggestion", "Second suggestion"],
+				origin: "channel",
+			},
+		});
+	});
+
+	test("welcome-screen cards announce their own impression", async () => {
+		const { events } = await renderEmbed({
+			suggestions: false,
+			welcome: { title: "Hi", suggestions: ["Over 65", "Under 65"] },
+		});
+
+		expect(shownSets(events)).toHaveLength(1);
+		expect(shownSets(events)[0]).toMatchObject({
+			name: "suggestions.shown",
+			properties: { texts: ["Over 65", "Under 65"], origin: "channel" },
+		});
+	});
+
+	test("an off-screen mount holds its impression until it is shown", async () => {
+		const { events, render } = await renderEmbed({ onScreen: false });
+		expect(shownSets(events)).toHaveLength(0);
+
+		await render({ onScreen: true });
+		expect(shownSets(events)).toHaveLength(1);
+
+		// Still one set, so a hide/show cycle doesn't re-count the same pills.
+		await render({ onScreen: false });
+		await render({ onScreen: true });
+		expect(shownSets(events)).toHaveLength(1);
 	});
 
 	test("clicking an anchor inside the messages scroller emits link.clicked", async () => {

--- a/src/chat/web/layouts/chat-embed.tsx
+++ b/src/chat/web/layouts/chat-embed.tsx
@@ -83,6 +83,7 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 			enableThreadHistory = false,
 			showToolCalls = true,
 			initializing = false,
+			onScreen = true,
 			disclaimer,
 		} = props;
 
@@ -310,10 +311,18 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 		// on the array identity `useSuggestionRow` returns (a new array per
 		// config load / streamed turn), so re-renders of the same set stay
 		// silent. The embed hosts subscribe and log one impression per set.
+		//
+		// `onScreen` holds the announcement rather than dropping it: a hidden
+		// mount that becomes visible with the same row still owes its
+		// impression, so the effect re-runs and reports it then.
 		const announcedSuggestionsRef = useRef<string[] | null>(null);
 		useEffect(() => {
 			const current = suggestionsState.suggestions;
-			if (current.length === 0 || announcedSuggestionsRef.current === current) {
+			if (
+				!onScreen ||
+				current.length === 0 ||
+				announcedSuggestionsRef.current === current
+			) {
 				return;
 			}
 			announcedSuggestionsRef.current = current;
@@ -321,7 +330,37 @@ const ChatEmbedInner = forwardRef<ChatHandle, ChatEmbedProps>(
 				name: "suggestions.shown",
 				properties: { texts: current, origin: suggestionsState.source },
 			});
-		}, [suggestionsState.suggestions, suggestionsState.source, widgetEvents]);
+		}, [
+			suggestionsState.suggestions,
+			suggestionsState.source,
+			widgetEvents,
+			onScreen,
+		]);
+
+		// Welcome-screen cards are a second, separately-rendered set of pills:
+		// they live in the message area rather than the row above the input, and
+		// `MessageList` shows them while the conversation is empty. Announced
+		// here so a card that earns a click has a matching impression — the
+		// click already reports itself through `handleSuggestionSelect`.
+		const welcomeSuggestions = welcome?.suggestions;
+		const announcedWelcomeRef = useRef<string[] | null>(null);
+		useEffect(() => {
+			if (
+				!onScreen ||
+				engine.messages.length > 0 ||
+				!welcomeSuggestions?.length ||
+				announcedWelcomeRef.current === welcomeSuggestions
+			) {
+				return;
+			}
+			announcedWelcomeRef.current = welcomeSuggestions;
+			widgetEvents.emit({
+				name: "suggestions.shown",
+				// Welcome cards are always operator-authored channel prompts, the
+				// same origin `handleSuggestionSelect` reports for their clicks.
+				properties: { texts: welcomeSuggestions, origin: "channel" },
+			});
+		}, [welcomeSuggestions, engine.messages.length, widgetEvents, onScreen]);
 
 		const handleWidgetMessage = useCallback(
 			(message: {

--- a/src/chat/web/layouts/waniwani-chat.tsx
+++ b/src/chat/web/layouts/waniwani-chat.tsx
@@ -29,6 +29,7 @@ import { useSuggestions } from "../embed/use-suggestions";
 import type { WidgetEvent } from "../embed/widget-events";
 import { createWidgetEventEmitter } from "../embed/widget-events";
 import { WidgetEventsProvider } from "../embed/widget-events-context";
+import { useSuggestionIngest } from "../hooks/use-suggestion-ingest";
 import type { Locale, MessageOverrides } from "../i18n";
 import {
 	createChatTrackClient,
@@ -350,6 +351,20 @@ export const WaniwaniChat = forwardRef<ChatHandle, WaniwaniChatProps>(
 		// attribution. Memoized inside the hook — the pill row keys an effect
 		// on this object's identity.
 		const suggestions = useSuggestions(config);
+
+		// Record every suggestion click and every rendered pill set server-side,
+		// attributed to the authored prompts involved. Same signal the script
+		// embeds record, so a React host is not a blind spot in the funnel.
+		useSuggestionIngest({
+			widgetEvents,
+			api: config.api ?? resolvedApi,
+			token: config.token ?? token,
+			channelId: config.channelId ?? channelId,
+			source: config.source,
+			mode: "inline",
+			pagePrompts: suggestions.page,
+			getSessionId: () => innerRef.current?.sessionId,
+		});
 
 		// Host-page tracking client: same public token and channel as the chat,
 		// session id attached live once the first exchange assigns one.


### PR DESCRIPTION
Closes WAN-829

## Why

Chip data is incomplete: we can see taps but not what was offered, so "27% answered with a tap" cannot distinguish "no options shown" from "options shown and ignored".

The reported symptom (hardcoded `interrupt({ suggestions })` pills tracked nowhere, dynamic ones tracked fine) is a default that already changed: flow-driven pills were opt-in and off by default up to and including 0.19.3, so a flow interrupt rendered nothing and announced nothing while channel / page / followup pills reported normally. `suggestion.shown` ingest shipped in 0.19.3 (#107), flow became unconditional in 0.19.4 (#115). Customers pinned at 0.19.3 or below are fixed by upgrading.

This PR fixes the gaps that survive on 0.19.5.

## What

- **`WaniwaniChat` posted nothing.** It fired `page.viewed` and emitted widget events to `onEvent`, but never forwarded `suggestion.shown` / `suggestion.clicked` to ingest. Only the two script embeds did, so every React host was a blind spot. The forwarding they duplicated now lives in `useSuggestionIngest`, mounted by all three surfaces.
- **Welcome-screen cards had clicks with no impressions.** `handleSuggestionSelect` covered them; the announce effect watched only the pill row. They now announce their own set with the `channel` origin their clicks already report.
- **Floating mode inflated page/channel impressions.** The panel is mounted eagerly behind the dock, so its pre-chat row announced a set nobody had seen, on top of the dock announcing the same set. A new internal `onScreen` prop holds the panel's announcement until it opens, so a set still earns its impression when it becomes visible.

## Not in scope

A multi-field `interrupt({ a: {...suggestions}, b: {...} })` ships `{ suggestions: [] }` to the widget, because only the single-question shorthand carries a top-level `suggestions`. The empty array is authoritative, so it also suppresses that turn's followups. Left alone here since it is not the reported case, and flipping it changes a tested contract.

## Testing

- New `use-suggestion-ingest` suite: ingest payload for both events, authored-id attribution, session id read at emit time, no-token bail.
- New `ChatEmbed` cases: pre-chat row announces once, welcome cards announce their own set, an off-screen mount holds its impression until shown and does not re-count across a hide/show cycle.
- `bun run typecheck` and `bun biome check` clean. 526 pass; the 2 `useChatEngine – thread history` failures pre-date this branch on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)