### PR TITLE
0.19.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "MCP distribution SDK. Build sales funnels, lead generation, booking, and quote apps on top of your MCP server. Event tracking, flows, widgets, knowledge base.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Version bump to 0.19.7.

Ships the one commit landed since v0.19.6: session error reporting from the SDK's silent failure paths (#116).

The public API change is additive only (new `session.error` event type, `SESSION_ERROR_CODES` / `ERROR_CAUSES` exports, optional `cause` on `ToolCalledProperties`), so per the release rules no changelog migration section or migration skill is required.

Verified locally: `bun run build` (typecheck + lint + bundle) passes. `bun test` has 2 failures in `use-chat-engine.test.tsx` that fail identically on the v0.19.6 tag, so they are pre-existing and unrelated to this release.

After merge, the release needs an admin to tag the merge commit on main (tag creation on `v*` is restricted):

```bash
git checkout main && git pull
git tag v0.19.7 && git push origin v0.19.7
```

The tag push triggers the release workflow, which builds, publishes 0.19.7 to npm, and creates the GitHub release. Do not run `bun run release` for this one, the version is already bumped and it would cut 0.19.8.