### PR TITLE
chore: set version back to 0.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.20.0",
+  "version": "0.19.9",
   "description": "MCP distribution SDK. Build sales funnels, lead generation, booking, and quote apps on top of your MCP server. Event tracking, flows, widgets, knowledge base.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waniwani/sdk",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "MCP distribution SDK. Build sales funnels, lead generation, booking, and quote apps on top of your MCP server. Event tracking, flows, widgets, knowledge base.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
581c839 bumped the version to 0.21.0 by accident. It changed nothing but the number in `package.json`, and the `v0.21.0` tag pushed from it fired the release workflow, so the legacy-tier removal went to npm as 0.21.0 while `main` had never shipped 0.20.0 at all.

This sets `package.json` back to 0.20.0 so the release that was actually prepared (changelog, `migrate-waniwani-sdk-0.19-to-0.20` skill, the removed entry points) publishes under the version it was written for. A revert rather than a force-push, because the bad commit is already on `main`.

Cleanup done outside this PR:

- GitHub release `v0.21.0` and its tag: deleted
- npm `@waniwani/sdk@0.21.0`: still published, needs `npm unpublish @waniwani/sdk@0.21.0` from an authenticated maintainer (zero downloads, 72-hour window open)

npm permanently burns an unpublished version number, so 0.21.0 can never be reused. The next release after 0.20.0 is 0.22.0.

Once this merges, tag `v0.20.0` on main to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
