### PR TITLE
feat(documents): extract a document into typed fields (WAN-953)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       "import": "./dist/kb/index.js",
       "default": "./dist/kb/index.js"
     },
+    "./documents": {
+      "types": "./dist/documents/index.d.ts",
+      "import": "./dist/documents/index.js",
+      "default": "./dist/documents/index.js"
+    },
     "./internal": {
       "types": "./dist/internal/index.d.ts",
       "import": "./dist/internal/index.js",

--- a/src/documents/client.test.ts
+++ b/src/documents/client.test.ts
@@ -1,0 +1,436 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { z } from "zod";
+import { WaniWaniError } from "../error.js";
+import { createDocumentsClient } from "./client.js";
+
+const EXTRACT_URL = "https://example.test/api/mcp/modules/documents/extract";
+
+const invoiceSchema = z.object({
+	invoiceNumber: z.string(),
+	total: z.number(),
+	dueDate: z.string().nullable(),
+});
+
+const wireData = {
+	fields: { invoiceNumber: "INV-1", total: 42.5, dueDate: null },
+	pageCount: 3,
+	pageConfidence: 0.94,
+	documentId: "doc_123",
+};
+
+interface CapturedCall {
+	url: string;
+	method: string | undefined;
+	headers: Record<string, string>;
+	body: Record<string, unknown>;
+}
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+function stubFetch(nextResponse: () => Response): CapturedCall[] {
+	const calls: CapturedCall[] = [];
+	globalThis.fetch = Object.assign(
+		async (input: unknown, init?: RequestInit) => {
+			const headers: Record<string, string> = {};
+			new Headers(init?.headers).forEach((value, key) => {
+				headers[key] = value;
+			});
+			calls.push({
+				url: String(input),
+				method: init?.method,
+				headers,
+				body: typeof init?.body === "string" ? JSON.parse(init.body) : {},
+			});
+			return nextResponse();
+		},
+		{ preconnect: () => {} },
+	);
+	return calls;
+}
+
+function envelope(data: unknown, status = 200): Response {
+	return new Response(JSON.stringify({ success: true, message: "ok", data }), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function client(overrides?: { apiUrl?: string; apiKey?: string | undefined }) {
+	return createDocumentsClient({
+		apiUrl: overrides?.apiUrl ?? "https://example.test",
+		apiKey: "apiKey" in (overrides ?? {}) ? overrides?.apiKey : "wwk_test",
+	});
+}
+
+describe("documents.extract — request", () => {
+	test("POSTs to the platform extract endpoint with the environment key as a bearer token", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe(EXTRACT_URL);
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.headers.authorization).toBe("Bearer wwk_test");
+		expect(calls[0]?.headers["content-type"]).toContain("application/json");
+	});
+
+	test("joins a trailing-slash apiUrl without doubling the separator", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await client({ apiUrl: "https://example.test/" }).extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(calls[0]?.url).toBe(EXTRACT_URL);
+	});
+
+	test("honours a self-hosted apiUrl", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await client({ apiUrl: "https://eu.app.waniwani.ai" }).extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(calls[0]?.url).toBe(
+			"https://eu.app.waniwani.ai/api/mcp/modules/documents/extract",
+		);
+	});
+
+	test("sends the document url and filename verbatim", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await client().extract({
+			url: "https://cdn.test/a%20b/invoice.pdf?sig=abc",
+			filename: "Facture été.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(calls[0]?.body.url).toBe(
+			"https://cdn.test/a%20b/invoice.pdf?sig=abc",
+		);
+		expect(calls[0]?.body.filename).toBe("Facture été.pdf");
+	});
+
+	test("sends the caller's schema as JSON Schema produced by z.toJSONSchema", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(calls[0]?.body.schema).toEqual(z.toJSONSchema(invoiceSchema));
+	});
+
+	test("a nullable field crosses the wire as a null-permitting JSON Schema", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(JSON.stringify(calls[0]?.body.schema)).toContain(
+			'"dueDate":{"anyOf":[{"type":"string"},{"type":"null"}]}',
+		);
+	});
+});
+
+describe("documents.extract — page selection", () => {
+	test("sends zero-based page indexes verbatim, including out-of-range ones", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+			pages: [0, 2, 999],
+		});
+
+		expect(calls[0]?.body.pages).toEqual([0, 2, 999]);
+	});
+
+	test("asking for only the first page sends index 0, not index 1", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+			pages: [0],
+		});
+
+		expect(calls[0]?.body.pages).toEqual([0]);
+	});
+
+	test("omits pages from the body when the caller selects none", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(calls[0]?.body).not.toHaveProperty("pages");
+	});
+});
+
+describe("documents.extract — response", () => {
+	test("returns the envelope's data fields", async () => {
+		stubFetch(() => envelope(wireData));
+
+		const result = await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(result.pageCount).toBe(3);
+		expect(result.pageConfidence).toBe(0.94);
+		expect(result.documentId).toBe("doc_123");
+		expect(result.fields).toEqual({
+			invoiceNumber: "INV-1",
+			total: 42.5,
+			dueDate: null,
+		});
+	});
+
+	test("a nullable field the document did not answer comes back as null", async () => {
+		stubFetch(() =>
+			envelope({ ...wireData, fields: { ...wireData.fields, dueDate: null } }),
+		);
+
+		const result = await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(result.fields.dueDate).toBeNull();
+	});
+
+	test("re-parses fields with the caller's schema, dropping keys it does not declare", async () => {
+		stubFetch(() =>
+			envelope({
+				...wireData,
+				fields: { ...wireData.fields, _internalDebug: "leaked" },
+			}),
+		);
+
+		const result = await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(result.fields).not.toHaveProperty("_internalDebug");
+	});
+
+	test("rejects when the platform's fields do not satisfy the caller's schema", async () => {
+		stubFetch(() =>
+			envelope({
+				...wireData,
+				fields: { invoiceNumber: "INV-1", total: "42.5" },
+			}),
+		);
+
+		await expect(
+			client().extract({
+				url: "https://cdn.test/invoice.pdf",
+				filename: "invoice.pdf",
+				schema: invoiceSchema,
+			}),
+		).rejects.toThrow();
+	});
+
+	test("a null pageConfidence survives as null", async () => {
+		stubFetch(() => envelope({ ...wireData, pageConfidence: null }));
+
+		const result = await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(result.pageConfidence).toBeNull();
+	});
+
+	test("a missing pageConfidence surfaces as null, never undefined", async () => {
+		stubFetch(() =>
+			envelope({
+				fields: wireData.fields,
+				pageCount: 1,
+				documentId: "doc_123",
+			}),
+		);
+
+		const result = await client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		expect(result.pageConfidence).toBeNull();
+	});
+});
+
+describe("documents.extract — failures", () => {
+	test("a non-2xx response surfaces as WaniWaniError carrying the status", async () => {
+		stubFetch(() => new Response("file too large", { status: 413 }));
+
+		const promise = client().extract({
+			url: "https://cdn.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: invoiceSchema,
+		});
+
+		await expect(promise).rejects.toBeInstanceOf(WaniWaniError);
+		await promise.catch((error: unknown) => {
+			expect(error).toBeInstanceOf(WaniWaniError);
+			if (error instanceof WaniWaniError) {
+				expect(error.status).toBe(413);
+				expect(error.message).toContain("file too large");
+			}
+		});
+	});
+
+	test("a non-2xx response with an empty body still carries the status", async () => {
+		stubFetch(() => new Response("", { status: 502 }));
+
+		await client()
+			.extract({
+				url: "https://cdn.test/invoice.pdf",
+				filename: "invoice.pdf",
+				schema: invoiceSchema,
+			})
+			.catch((error: unknown) => {
+				expect(error).toBeInstanceOf(WaniWaniError);
+				if (error instanceof WaniWaniError) {
+					expect(error.status).toBe(502);
+					expect(error.message).toContain("502");
+				}
+			});
+	});
+
+	test("a non-2xx envelope surfaces its message, not the raw JSON body", async () => {
+		stubFetch(
+			() =>
+				new Response(
+					JSON.stringify({
+						success: false,
+						message: "Private and loopback addresses are refused",
+						data: null,
+					}),
+					{ status: 400, headers: { "content-type": "application/json" } },
+				),
+		);
+
+		await client()
+			.extract({
+				url: "http://127.0.0.1/invoice.pdf",
+				filename: "invoice.pdf",
+				schema: invoiceSchema,
+			})
+			.catch((error: unknown) => {
+				expect(error).toBeInstanceOf(WaniWaniError);
+				if (error instanceof WaniWaniError) {
+					expect(error.status).toBe(400);
+					expect(error.message).toBe(
+						"Private and loopback addresses are refused",
+					);
+				}
+			});
+	});
+
+	test("throws before issuing a request when no API key is configured", async () => {
+		const calls = stubFetch(() => envelope(wireData));
+
+		await expect(
+			client({ apiKey: undefined }).extract({
+				url: "https://cdn.test/invoice.pdf",
+				filename: "invoice.pdf",
+				schema: invoiceSchema,
+			}),
+		).rejects.toThrow("WANIWANI_API_KEY is not set");
+		expect(calls).toHaveLength(0);
+	});
+});
+
+// zod is an optional peer dependency (package.json peerDependenciesMeta), so
+// `import "@waniwani/sdk"` must keep working for a consumer who has not
+// installed it.
+describe("core path stays free of the optional zod peer", () => {
+	test("no module reachable from src/index.ts value-imports zod", () => {
+		const entry = resolve(import.meta.dir, "..", "index.ts");
+		const seen = new Set<string>();
+		const offenders: string[] = [];
+
+		const STATEMENT =
+			/^[ \t]*(?:import|export)[ \t]+(type[ \t]+)?([^;]*?)from[ \t]*["']([^"']+)["']/gm;
+
+		const retainedSpecifiers = (source: string): string[] => {
+			const out: string[] = [];
+			for (const match of source.matchAll(STATEMENT)) {
+				if (match[1]) {
+					continue;
+				}
+				const spec = match[3];
+				if (spec) {
+					out.push(spec);
+				}
+			}
+			return out;
+		};
+
+		const walk = (file: string): void => {
+			if (seen.has(file)) {
+				return;
+			}
+			seen.add(file);
+			let source: string;
+			try {
+				source = readFileSync(file, "utf-8");
+			} catch {
+				return;
+			}
+			const specifiers = retainedSpecifiers(source);
+			if (specifiers.includes("zod")) {
+				offenders.push(file.slice(file.indexOf("/src/") + 1));
+			}
+			for (const spec of specifiers) {
+				if (!spec.startsWith(".")) {
+					continue;
+				}
+				const base = resolve(dirname(file), spec.replace(/\.js$/, ""));
+				for (const candidate of [`${base}.ts`, `${base}/index.ts`]) {
+					try {
+						readFileSync(candidate, "utf-8");
+						walk(candidate);
+						break;
+					} catch {}
+				}
+			}
+		};
+
+		walk(entry);
+
+		expect(offenders).toEqual([]);
+	});
+});

--- a/src/documents/client.ts
+++ b/src/documents/client.ts
@@ -1,0 +1,71 @@
+import { toJSONSchema } from "zod";
+import { WaniWaniError } from "../error.js";
+import type { InternalConfig } from "../types.js";
+import type {
+	DocumentExtractInput,
+	DocumentExtractResult,
+	DocumentsClient,
+} from "./types.js";
+
+const SDK_NAME = "@waniwani/sdk";
+const EXTRACT_PATH = "/api/mcp/modules/documents/extract";
+
+interface ExtractWireResponse {
+	fields: unknown;
+	pageCount: number;
+	pageConfidence: number | null;
+	documentId: string;
+}
+
+export function createDocumentsClient(
+	config: Pick<InternalConfig, "apiUrl" | "apiKey">,
+): DocumentsClient {
+	const { apiUrl, apiKey } = config;
+
+	return {
+		async extract<T>(
+			input: DocumentExtractInput<T>,
+		): Promise<DocumentExtractResult<T>> {
+			if (!apiKey) {
+				throw new Error("WANIWANI_API_KEY is not set");
+			}
+
+			const response = await fetch(
+				`${apiUrl.replace(/\/$/, "")}${EXTRACT_PATH}`,
+				{
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+						"Content-Type": "application/json",
+						"X-WaniWani-SDK": SDK_NAME,
+					},
+					body: JSON.stringify({
+						url: input.url,
+						filename: input.filename,
+						schema: toJSONSchema(input.schema),
+						sessionId: input.sessionId,
+						correlationId: input.correlationId,
+					}),
+				},
+			);
+
+			if (!response.ok) {
+				const text = await response.text().catch(() => "");
+				throw new WaniWaniError(
+					text || `Documents API error: HTTP ${response.status}`,
+					response.status,
+				);
+			}
+
+			const json = (await response.json()) as { data: ExtractWireResponse };
+			const { fields, pageCount, pageConfidence, documentId } = json.data;
+
+			return {
+				fields: input.schema.parse(fields),
+				pageCount,
+				pageConfidence,
+				documentId,
+			};
+		},
+	};
+}

--- a/src/documents/client.ts
+++ b/src/documents/client.ts
@@ -3,11 +3,17 @@ import type { InternalConfig } from "../types.js";
 import type {
 	DocumentExtractInput,
 	DocumentExtractResult,
+	DocumentSchema,
 	DocumentsClient,
 } from "./types.js";
 
 const SDK_NAME = "@waniwani/sdk";
 const EXTRACT_PATH = "/api/mcp/modules/documents/extract";
+
+/** Method syntax makes the parameter bivariant, so a structural schema is accepted without an assertion. */
+interface ZodModule {
+	toJSONSchema(schema: DocumentSchema<unknown>): Record<string, unknown>;
+}
 
 interface ExtractWireResponse {
 	fields: unknown;
@@ -65,7 +71,7 @@ export function createDocumentsClient(
 			// zod is an optional peer dependency and this module is reachable from the
 			// package root, so a top-level import would break every consumer that only
 			// uses tracking.
-			const { toJSONSchema } = await import("zod");
+			const { toJSONSchema }: ZodModule = await import("zod");
 
 			const response = await fetch(
 				`${apiUrl.replace(/\/$/, "")}${EXTRACT_PATH}`,

--- a/src/documents/client.ts
+++ b/src/documents/client.ts
@@ -16,14 +16,31 @@ interface ExtractWireResponse {
 	documentId: string;
 }
 
-/** The platform names what it refused in the envelope's `message`; the raw body is the fallback. */
+/**
+ * The platform puts the machine-readable code on `message` and the human reason
+ * on `detail`, so a refusal reads as "UNSUPPORTED_DOCUMENT_TYPE: photo.heic is
+ * not one of ...". The raw body is the fallback.
+ */
 function refusalMessage(body: string, status: number): string {
 	try {
 		const parsed: unknown = JSON.parse(body);
-		if (parsed !== null && typeof parsed === "object" && "message" in parsed) {
-			const { message } = parsed;
-			if (typeof message === "string" && message.length > 0) {
-				return message;
+		if (parsed !== null && typeof parsed === "object") {
+			const code =
+				"message" in parsed && typeof parsed.message === "string"
+					? parsed.message
+					: "";
+			const detail =
+				"detail" in parsed && typeof parsed.detail === "string"
+					? parsed.detail
+					: "";
+			if (code && detail) {
+				return `${code}: ${detail}`;
+			}
+			if (code) {
+				return code;
+			}
+			if (detail) {
+				return detail;
 			}
 		}
 	} catch {

--- a/src/documents/client.ts
+++ b/src/documents/client.ts
@@ -1,4 +1,3 @@
-import { toJSONSchema } from "zod";
 import { WaniWaniError } from "../error.js";
 import type { InternalConfig } from "../types.js";
 import type {
@@ -17,6 +16,22 @@ interface ExtractWireResponse {
 	documentId: string;
 }
 
+/** The platform names what it refused in the envelope's `message`; the raw body is the fallback. */
+function refusalMessage(body: string, status: number): string {
+	try {
+		const parsed: unknown = JSON.parse(body);
+		if (parsed !== null && typeof parsed === "object" && "message" in parsed) {
+			const { message } = parsed;
+			if (typeof message === "string" && message.length > 0) {
+				return message;
+			}
+		}
+	} catch {
+		// A non-JSON body is surfaced as-is below.
+	}
+	return body || `Documents API error: HTTP ${status}`;
+}
+
 export function createDocumentsClient(
 	config: Pick<InternalConfig, "apiUrl" | "apiKey">,
 ): DocumentsClient {
@@ -29,6 +44,11 @@ export function createDocumentsClient(
 			if (!apiKey) {
 				throw new Error("WANIWANI_API_KEY is not set");
 			}
+
+			// zod is an optional peer dependency and this module is reachable from the
+			// package root, so a top-level import would break every consumer that only
+			// uses tracking.
+			const { toJSONSchema } = await import("zod");
 
 			const response = await fetch(
 				`${apiUrl.replace(/\/$/, "")}${EXTRACT_PATH}`,
@@ -53,7 +73,7 @@ export function createDocumentsClient(
 			if (!response.ok) {
 				const text = await response.text().catch(() => "");
 				throw new WaniWaniError(
-					text || `Documents API error: HTTP ${response.status}`,
+					refusalMessage(text, response.status),
 					response.status,
 				);
 			}
@@ -64,7 +84,7 @@ export function createDocumentsClient(
 			return {
 				fields: input.schema.parse(fields),
 				pageCount,
-				pageConfidence,
+				pageConfidence: pageConfidence ?? null,
 				documentId,
 			};
 		},

--- a/src/documents/client.ts
+++ b/src/documents/client.ts
@@ -43,6 +43,7 @@ export function createDocumentsClient(
 						url: input.url,
 						filename: input.filename,
 						schema: toJSONSchema(input.schema),
+						pages: input.pages,
 						sessionId: input.sessionId,
 						correlationId: input.correlationId,
 					}),

--- a/src/documents/index.ts
+++ b/src/documents/index.ts
@@ -3,5 +3,6 @@ export { createDocumentsClient } from "./client";
 export type {
 	DocumentExtractInput,
 	DocumentExtractResult,
+	DocumentSchema,
 	DocumentsClient,
 } from "./types";

--- a/src/documents/index.ts
+++ b/src/documents/index.ts
@@ -1,0 +1,7 @@
+export { createDocumentsClient } from "./client";
+
+export type {
+	DocumentExtractInput,
+	DocumentExtractResult,
+	DocumentsClient,
+} from "./types";

--- a/src/documents/types.ts
+++ b/src/documents/types.ts
@@ -18,6 +18,8 @@ export interface DocumentExtractInput<T> {
 	filename: string;
 	/** The shape to return. Extraction runs in strict mode, so mark anything a document may not answer `.nullable()`. */
 	schema: ZodType<T>;
+	/** Zero-based page indexes to read: `[0]` is the first page. Omit to read every page. Ignored for images. Billing is per page processed, so a narrower selection costs less. */
+	pages?: number[];
 	/** Conversation this document arrived in */
 	sessionId?: string;
 	/** Ties the extraction to one tool call */

--- a/src/documents/types.ts
+++ b/src/documents/types.ts
@@ -1,4 +1,12 @@
-import type { ZodType } from "zod";
+/**
+ * Structural stand-in for a Zod schema. Declared structurally so the package
+ * root's type graph does not reference `zod`, which is an optional peer: a
+ * consumer using only tracking would otherwise get TS2307 without skipLibCheck.
+ * Any Zod schema satisfies it.
+ */
+export interface DocumentSchema<T> {
+	parse(value: unknown): T;
+}
 
 export interface DocumentExtractResult<T> {
 	/** The document's contents, parsed with the schema you passed. A null field is one the document did not legibly answer. */
@@ -17,7 +25,7 @@ export interface DocumentExtractInput<T> {
 	/** Name of the file, used to refuse an unsupported type before fetching it */
 	filename: string;
 	/** The shape to return. Extraction runs in strict mode, so mark anything a document may not answer `.nullable()`. */
-	schema: ZodType<T>;
+	schema: DocumentSchema<T>;
 	/** Zero-based page indexes to read: `[0]` is the first page. Omit to read every page. Ignored for images. Billing is per page processed, so a narrower selection costs less. */
 	pages?: number[];
 	/** Conversation this document arrived in */

--- a/src/documents/types.ts
+++ b/src/documents/types.ts
@@ -1,0 +1,30 @@
+import type { ZodType } from "zod";
+
+export interface DocumentExtractResult<T> {
+	/** The document's contents, parsed with the schema you passed. A null field is one the document did not legibly answer. */
+	fields: T;
+	/** Pages the vendor processed and billed */
+	pageCount: number;
+	/** Mean per-page OCR confidence, null when none was reported */
+	pageConfidence: number | null;
+	/** Handle for this extraction, valid for the 7-day retention window */
+	documentId: string;
+}
+
+export interface DocumentExtractInput<T> {
+	/** A publicly fetchable URL; private and loopback addresses are refused */
+	url: string;
+	/** Name of the file, used to refuse an unsupported type before fetching it */
+	filename: string;
+	/** The shape to return. Extraction runs in strict mode, so mark anything a document may not answer `.nullable()`. */
+	schema: ZodType<T>;
+	/** Conversation this document arrived in */
+	sessionId?: string;
+	/** Ties the extraction to one tool call */
+	correlationId?: string;
+}
+
+export interface DocumentsClient {
+	/** Read one document and get its contents shaped by `schema`. Accepts PDF, PNG, JPEG, TIFF, BMP, GIF and WEBP up to 50 MB. */
+	extract<T>(input: DocumentExtractInput<T>): Promise<DocumentExtractResult<T>>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 export type {
 	DocumentExtractInput,
 	DocumentExtractResult,
+	DocumentSchema,
 	DocumentsClient,
 } from "./documents/types.js";
 export { WaniWaniError } from "./error.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 // Waniwani SDK
 
 // Error
+export type {
+	DocumentExtractInput,
+	DocumentExtractResult,
+	DocumentsClient,
+} from "./documents/types.js";
 export { WaniWaniError } from "./error.js";
 
 // Types - KB Client

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -31,7 +31,6 @@ export {
 // Generic key-value store — OSS interface, free-tier hosted impl
 export type { KvStore, KvStoreSetOptions } from "./server/kv";
 export { MemoryKvStore, WaniwaniKvStore } from "./server/kv";
-// Scoped client — free tier (used inside withWaniwani-wrapped tools)
 export type { ScopedWaniWaniClient } from "./server/scoped-client";
 export { extractScopedClient, SCOPED_CLIENT_KEY } from "./server/scoped-client";
 // Tracking helpers — free tier
@@ -39,5 +38,7 @@ export type { TrackingRouteOptions } from "./server/tracking-route";
 export { createTrackingRoute } from "./server/tracking-route";
 // Shared MCP server types (non-legacy)
 export type { McpServer, ZodRawShapeCompat } from "./server/types";
+// Scoped client — free tier (used inside withWaniwani-wrapped tools)
+export type { AttachedFile } from "./server/utils";
 export type { WithWaniwaniOptions } from "./server/with-waniwani/index";
 export { withWaniwani } from "./server/with-waniwani/index";

--- a/src/mcp/server/__tests__/attached-files.test.ts
+++ b/src/mcp/server/__tests__/attached-files.test.ts
@@ -1,0 +1,446 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { KbClient } from "../../../kb/types.js";
+import type { TrackInput } from "../../../tracking/@types.js";
+import { createScopedClient } from "../scoped-client.js";
+import { extractAttachedFiles } from "../utils.js";
+
+describe("extractAttachedFiles", () => {
+	test("returns an empty list when the host attached nothing", () => {
+		expect(extractAttachedFiles(undefined)).toEqual([]);
+		expect(extractAttachedFiles({})).toEqual([]);
+		expect(extractAttachedFiles({ "waniwani/sessionId": "sess-1" })).toEqual(
+			[],
+		);
+	});
+
+	test("resolves a ChatGPT attachment keyed by tool parameter name", () => {
+		expect(
+			extractAttachedFiles({
+				"openai/fileParams": {
+					document: {
+						url: "https://files.test/invoice.pdf",
+						name: "invoice.pdf",
+						mime_type: "application/pdf",
+					},
+				},
+			}),
+		).toEqual([
+			{ url: "https://files.test/invoice.pdf", filename: "invoice.pdf" },
+		]);
+	});
+
+	test("resolves a list container in host order", () => {
+		expect(
+			extractAttachedFiles({
+				"openai/fileParams": [
+					{ url: "https://files.test/a.pdf", filename: "a.pdf" },
+					{ url: "https://files.test/b.png", filename: "b.png" },
+				],
+			}),
+		).toEqual([
+			{ url: "https://files.test/a.pdf", filename: "a.pdf" },
+			{ url: "https://files.test/b.png", filename: "b.png" },
+		]);
+	});
+
+	test("reads the snake_case spellings a host may use", () => {
+		expect(
+			extractAttachedFiles({
+				"openai/fileParams": {
+					attachment: {
+						download_url: "https://files.test/scan.tiff",
+						file_name: "scan.tiff",
+					},
+				},
+			}),
+		).toEqual([{ url: "https://files.test/scan.tiff", filename: "scan.tiff" }]);
+	});
+
+	test("derives a filename from the url when the host names none", () => {
+		expect(
+			extractAttachedFiles({
+				"waniwani/fileParams": [{ url: "https://files.test/x/policy.pdf" }],
+			}),
+		).toEqual([
+			{ url: "https://files.test/x/policy.pdf", filename: "policy.pdf" },
+		]);
+	});
+
+	test("prefers the host's filename over one derived from the url", () => {
+		expect(
+			extractAttachedFiles({
+				"waniwani/fileParams": [
+					{ url: "https://files.test/x/opaque-id", filename: "policy.pdf" },
+				],
+			}),
+		).toEqual([
+			{ url: "https://files.test/x/opaque-id", filename: "policy.pdf" },
+		]);
+	});
+
+	test("ignores a non-string filename and falls back to the url", () => {
+		expect(
+			extractAttachedFiles({
+				"waniwani/fileParams": [
+					{ url: "https://files.test/policy.pdf", filename: 42 },
+				],
+			}),
+		).toEqual([
+			{ url: "https://files.test/policy.pdf", filename: "policy.pdf" },
+		]);
+	});
+
+	test("percent-escapes in the path decode into the filename, url untouched", () => {
+		expect(
+			extractAttachedFiles({
+				"waniwani/fileParams": [
+					{ url: "https://files.test/a%20b/rapport%20final.pdf?sig=x" },
+				],
+			}),
+		).toEqual([
+			{
+				url: "https://files.test/a%20b/rapport%20final.pdf?sig=x",
+				filename: "rapport final.pdf",
+			},
+		]);
+	});
+
+	test("skips entries with nothing fetchable", () => {
+		expect(
+			extractAttachedFiles({
+				"openai/fileParams": [
+					{},
+					{ id: "file-abc123", name: "invoice.pdf" },
+					{ url: "file-abc123" },
+					{ url: "" },
+					{ url: 42 },
+					{ url: null },
+				],
+			}),
+		).toEqual([]);
+	});
+
+	test("skips urls the platform cannot fetch over http", () => {
+		expect(
+			extractAttachedFiles({
+				"openai/fileParams": [
+					{ url: "data:application/pdf;base64,JVBERi0=", name: "a.pdf" },
+					{ url: "file:///etc/passwd", name: "passwd" },
+					{ url: "ftp://files.test/a.pdf", name: "a.pdf" },
+					{ url: "blob:https://files.test/abc", name: "a.pdf" },
+				],
+			}),
+		).toEqual([]);
+	});
+
+	test("every resolved file carries a non-empty filename", () => {
+		const files = extractAttachedFiles({
+			"waniwani/fileParams": [
+				{ url: "https://files.test" },
+				{ url: "https://files.test/" },
+				{ url: "https://files.test/?download=1" },
+			],
+		});
+
+		expect(files.length).toBeGreaterThan(0);
+		for (const file of files) {
+			expect(file.filename.length).toBeGreaterThan(0);
+		}
+	});
+
+	test("a ChatGPT signed url keeps the query that makes it fetchable", () => {
+		const signed =
+			"https://files.oaiusercontent.com/file-abc123?se=2026-01-01&sig=xyz%2Fabc";
+		const files = extractAttachedFiles({
+			"openai/fileParams": {
+				document: { url: signed, mime_type: "application/pdf" },
+			},
+		});
+
+		expect(files).toHaveLength(1);
+		expect(files[0]?.url).toBe(signed);
+	});
+
+	test("resolves an MCP resource link, whose url lives under uri", () => {
+		expect(
+			extractAttachedFiles({
+				"waniwani/fileParams": [
+					{
+						type: "resource_link",
+						uri: "https://files.test/invoice.pdf",
+						name: "invoice.pdf",
+						mimeType: "application/pdf",
+					},
+				],
+			}),
+		).toEqual([
+			{ url: "https://files.test/invoice.pdf", filename: "invoice.pdf" },
+		]);
+	});
+
+	test("waniwani/fileParams wins over openai/fileParams, like every sibling key list", () => {
+		expect(
+			extractAttachedFiles({
+				"waniwani/fileParams": [
+					{ url: "https://cdn.waniwani.test/rehosted.pdf", filename: "a.pdf" },
+				],
+				"openai/fileParams": {
+					document: { url: "https://files.test/original.pdf", name: "a.pdf" },
+				},
+			}),
+		).toEqual([
+			{ url: "https://cdn.waniwani.test/rehosted.pdf", filename: "a.pdf" },
+		]);
+	});
+
+	test("falls back to openai/fileParams when the waniwani key is empty", () => {
+		expect(
+			extractAttachedFiles({
+				"waniwani/fileParams": [],
+				"openai/fileParams": {
+					document: { url: "https://files.test/original.pdf", name: "a.pdf" },
+				},
+			}),
+		).toEqual([{ url: "https://files.test/original.pdf", filename: "a.pdf" }]);
+	});
+});
+
+interface CapturedCall {
+	url: string;
+	body: Record<string, unknown>;
+}
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+function stubFetch(): CapturedCall[] {
+	const calls: CapturedCall[] = [];
+	globalThis.fetch = Object.assign(
+		async (input: unknown, init?: RequestInit) => {
+			calls.push({
+				url: String(input),
+				body: typeof init?.body === "string" ? JSON.parse(init.body) : {},
+			});
+			return new Response(
+				JSON.stringify({
+					success: true,
+					message: "ok",
+					data: {
+						fields: { total: 1 },
+						pageCount: 1,
+						pageConfidence: 0.9,
+						documentId: "doc_1",
+					},
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		},
+		{ preconnect: () => {} },
+	);
+	return calls;
+}
+
+const unusedKb: KbClient = {
+	ingest: () => Promise.reject(new Error("kb is unused here")),
+	search: () => Promise.reject(new Error("kb is unused here")),
+	sources: () => Promise.reject(new Error("kb is unused here")),
+};
+
+function makeBase() {
+	return {
+		track: async (_event: TrackInput) => ({ eventId: "evt_test" }),
+		identify: async () => ({ eventId: "evt_id" }),
+		kb: unusedKb,
+	};
+}
+
+const totalSchema = z.object({ total: z.number() });
+
+describe("scoped client documents wiring", () => {
+	test("attachedFiles exposes the attachments on this tool call", () => {
+		const scoped = createScopedClient(
+			makeBase(),
+			{
+				"waniwani/sessionId": "sess-9",
+				"openai/fileParams": {
+					document: {
+						url: "https://files.test/invoice.pdf",
+						name: "invoice.pdf",
+					},
+				},
+			},
+			{ apiUrl: "https://example.test", apiKey: "wwk_test" },
+		);
+
+		expect(scoped.attachedFiles).toEqual([
+			{ url: "https://files.test/invoice.pdf", filename: "invoice.pdf" },
+		]);
+	});
+
+	test("attachedFiles is empty on a host that attaches nothing", () => {
+		const scoped = createScopedClient(
+			makeBase(),
+			{ "waniwani/sessionId": "sess-9" },
+			{ apiUrl: "https://example.test", apiKey: "wwk_test" },
+		);
+
+		expect(scoped.attachedFiles).toEqual([]);
+	});
+
+	test("an attached file spreads straight into documents.extract", async () => {
+		const calls = stubFetch();
+		const scoped = createScopedClient(
+			makeBase(),
+			{
+				"openai/fileParams": {
+					document: {
+						url: "https://files.test/invoice.pdf",
+						name: "invoice.pdf",
+					},
+				},
+			},
+			{ apiUrl: "https://example.test", apiKey: "wwk_test" },
+		);
+		const attached = scoped.attachedFiles[0];
+		if (!attached) {
+			throw new Error("no attached file resolved");
+		}
+
+		await scoped.documents.extract({ ...attached, schema: totalSchema });
+
+		expect(calls[0]?.body.url).toBe("https://files.test/invoice.pdf");
+		expect(calls[0]?.body.filename).toBe("invoice.pdf");
+	});
+
+	test("documents.extract carries the request's sessionId and correlationId", async () => {
+		const calls = stubFetch();
+		const scoped = createScopedClient(
+			makeBase(),
+			{ "waniwani/sessionId": "sess-9", "openai/requestId": "req-7" },
+			{ apiUrl: "https://example.test", apiKey: "wwk_test" },
+		);
+
+		await scoped.documents.extract({
+			url: "https://files.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: totalSchema,
+		});
+
+		expect(calls[0]?.body.sessionId).toBe("sess-9");
+		expect(calls[0]?.body.correlationId).toBe("req-7");
+	});
+
+	test("an explicit sessionId on the call wins over the request's", async () => {
+		const calls = stubFetch();
+		const scoped = createScopedClient(
+			makeBase(),
+			{ "waniwani/sessionId": "sess-9" },
+			{ apiUrl: "https://example.test", apiKey: "wwk_test" },
+		);
+
+		await scoped.documents.extract({
+			url: "https://files.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: totalSchema,
+			sessionId: "sess-explicit",
+		});
+
+		expect(calls[0]?.body.sessionId).toBe("sess-explicit");
+	});
+
+	test("documents.extract targets the resolved api url", async () => {
+		const calls = stubFetch();
+		const scoped = createScopedClient(
+			makeBase(),
+			{},
+			{ apiUrl: "https://eu.app.waniwani.ai", apiKey: "wwk_test" },
+		);
+
+		await scoped.documents.extract({
+			url: "https://files.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: totalSchema,
+		});
+
+		expect(calls[0]?.url).toBe(
+			"https://eu.app.waniwani.ai/api/mcp/modules/documents/extract",
+		);
+	});
+
+	test("documents.extract keeps the caller's page selection", async () => {
+		const calls = stubFetch();
+		const scoped = createScopedClient(
+			makeBase(),
+			{ "waniwani/sessionId": "sess-9" },
+			{ apiUrl: "https://example.test", apiKey: "wwk_test" },
+		);
+
+		await scoped.documents.extract({
+			url: "https://files.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: totalSchema,
+			pages: [0],
+		});
+
+		expect(calls[0]?.body.pages).toEqual([0]);
+	});
+});
+
+describe("scoped client apiUrl resolution", () => {
+	const previous = process.env.WANIWANI_API_URL;
+
+	beforeEach(() => {
+		delete process.env.WANIWANI_API_URL;
+	});
+
+	afterEach(() => {
+		if (previous === undefined) {
+			delete process.env.WANIWANI_API_URL;
+		} else {
+			process.env.WANIWANI_API_URL = previous;
+		}
+	});
+
+	test("an explicit config apiUrl wins over WANIWANI_API_URL", async () => {
+		process.env.WANIWANI_API_URL = "https://eu.app.waniwani.ai";
+		const calls = stubFetch();
+		const scoped = createScopedClient(
+			makeBase(),
+			{ "waniwani/sessionId": "sess-9" },
+			{ apiUrl: "https://self.hosted.test", apiKey: "wwk_test" },
+		);
+
+		await scoped.documents.extract({
+			url: "https://files.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: totalSchema,
+		});
+
+		expect(calls[0]?.url).toBe(
+			"https://self.hosted.test/api/mcp/modules/documents/extract",
+		);
+	});
+
+	test("falls back to WANIWANI_API_URL when the config carries no apiUrl", async () => {
+		process.env.WANIWANI_API_URL = "https://eu.app.waniwani.ai";
+		const calls = stubFetch();
+		const scoped = createScopedClient(
+			makeBase(),
+			{ "waniwani/sessionId": "sess-9" },
+			{ apiKey: "wwk_test" },
+		);
+
+		await scoped.documents.extract({
+			url: "https://files.test/invoice.pdf",
+			filename: "invoice.pdf",
+			schema: totalSchema,
+		});
+
+		expect(calls[0]?.url).toBe(
+			"https://eu.app.waniwani.ai/api/mcp/modules/documents/extract",
+		);
+	});
+});

--- a/src/mcp/server/scoped-client.ts
+++ b/src/mcp/server/scoped-client.ts
@@ -1,3 +1,9 @@
+import { createDocumentsClient } from "../../documents/client.js";
+import type {
+	DocumentExtractInput,
+	DocumentExtractResult,
+	DocumentsClient,
+} from "../../documents/types.js";
 import type { KbClient } from "../../kb/types.js";
 import type {
 	CallableTrack,
@@ -6,7 +12,11 @@ import type {
 	TrackingClient,
 } from "../../tracking/@types.js";
 import { createRevenueApi } from "../../tracking/revenue.js";
+import { DEFAULT_API_URL } from "../../types.js";
 import {
+	type AttachedFile,
+	extractAttachedFiles,
+	extractCorrelationId,
 	extractExternalUserId,
 	extractSessionId,
 	extractVisitorId,
@@ -60,6 +70,14 @@ export interface ScopedWaniWaniClient {
 	): Promise<{ eventId: string }>;
 	/** Knowledge base client (no meta needed). */
 	readonly kb: KbClient;
+	/**
+	 * Files the host attached to this tool call, each with a fetchable `url` and
+	 * a `filename` — spread one straight into `documents.extract()`. Empty on
+	 * hosts that attach nothing.
+	 */
+	readonly attachedFiles: AttachedFile[];
+	/** Documents client; `sessionId` and `correlationId` are carried from the request. */
+	readonly documents: DocumentsClient;
 	/** @internal Resolved API config from withWaniwani(). */
 	readonly _config?: { apiUrl?: string; apiKey?: string };
 }
@@ -89,8 +107,15 @@ export function createScopedClient(
 	const trackOnce = (event: TrackInput): Promise<{ eventId: string }> =>
 		base.track({ ...event, meta: { ...meta, ...event.meta } });
 
+	const sessionId = extractSessionId(meta);
+	const correlationId = extractCorrelationId(meta);
+	const documents = createDocumentsClient({
+		apiUrl: config?.apiUrl ?? DEFAULT_API_URL,
+		apiKey: config?.apiKey,
+	});
+
 	return {
-		sessionId: extractSessionId(meta),
+		sessionId,
 		visitorId: extractVisitorId(meta),
 		externalUserId: extractExternalUserId(meta),
 		track: Object.assign(trackOnce, createRevenueApi(trackOnce)),
@@ -98,6 +123,18 @@ export function createScopedClient(
 			return base.identify(userId, properties, meta);
 		},
 		kb: base.kb,
+		attachedFiles: extractAttachedFiles(meta),
+		documents: {
+			extract<T>(
+				input: DocumentExtractInput<T>,
+			): Promise<DocumentExtractResult<T>> {
+				return documents.extract({
+					...input,
+					sessionId: input.sessionId ?? sessionId,
+					correlationId: input.correlationId ?? correlationId,
+				});
+			},
+		},
 		_config: config,
 	};
 }

--- a/src/mcp/server/scoped-client.ts
+++ b/src/mcp/server/scoped-client.ts
@@ -110,7 +110,7 @@ export function createScopedClient(
 	const sessionId = extractSessionId(meta);
 	const correlationId = extractCorrelationId(meta);
 	const documents = createDocumentsClient({
-		apiUrl: config?.apiUrl ?? DEFAULT_API_URL,
+		apiUrl: config?.apiUrl ?? process.env.WANIWANI_API_URL ?? DEFAULT_API_URL,
 		apiKey: config?.apiKey,
 	});
 

--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -57,6 +57,20 @@ const CORRELATION_ID_KEYS = ["correlationId", "openai/requestId"] as const;
 
 const TURN_COUNT_KEYS = ["waniwani/turnCount"] as const;
 
+const FILE_PARAMS_KEYS = ["waniwani/fileParams", "openai/fileParams"] as const;
+
+const FILE_URL_KEYS = [
+	"url",
+	"download_url",
+	"downloadUrl",
+	"file_url",
+	"fileUrl",
+	"signed_url",
+	"signedUrl",
+] as const;
+
+const FILE_NAME_KEYS = ["filename", "file_name", "fileName", "name"] as const;
+
 /** Meta key for flow execution path (nodesVisited, flowId). */
 export const FLOW_META_KEY = "waniwani/flow" as const;
 
@@ -130,6 +144,97 @@ export function extractTurnCount(
 		}
 	}
 	return undefined;
+}
+
+/** A file the host bound to this tool call, resolved to something fetchable. */
+export interface AttachedFile {
+	url: string;
+	filename: string;
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fetchableUrl(value: unknown): string | undefined {
+	if (typeof value !== "string" || value.length === 0) {
+		return undefined;
+	}
+	try {
+		const url = new URL(value);
+		return url.protocol === "https:" || url.protocol === "http:"
+			? value
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function filenameFromUrl(url: string): string {
+	try {
+		const segments = new URL(url).pathname.split("/").filter(Boolean);
+		const last = segments[segments.length - 1];
+		return last ? decodeURIComponent(last) : "document";
+	} catch {
+		return "document";
+	}
+}
+
+function toAttachedFile(entry: unknown): AttachedFile | undefined {
+	if (!isRecordValue(entry)) {
+		return undefined;
+	}
+
+	const url = fetchableUrl(pickFirst(entry, FILE_URL_KEYS));
+	if (!url) {
+		return undefined;
+	}
+
+	const filename = pickFirst(entry, FILE_NAME_KEYS);
+	return { url, filename: filename ?? filenameFromUrl(url) };
+}
+
+/**
+ * Files the host attached to this tool call, from `openai/fileParams` (ChatGPT)
+ * or `waniwani/fileParams`. The container may be a list or an object keyed by
+ * parameter name, and entries name their URL differently per host, so every
+ * plausible spelling is read and anything without a fetchable URL is skipped.
+ */
+export function extractAttachedFiles(
+	meta: Record<string, unknown> | undefined,
+): AttachedFile[] {
+	if (!meta) {
+		return [];
+	}
+
+	const files: AttachedFile[] = [];
+	const seen = new Set<string>();
+
+	const collect = (candidate: unknown): void => {
+		if (Array.isArray(candidate)) {
+			for (const entry of candidate) {
+				collect(entry);
+			}
+			return;
+		}
+		const file = toAttachedFile(candidate);
+		if (file && !seen.has(file.url)) {
+			seen.add(file.url);
+			files.push(file);
+			return;
+		}
+		if (!file && isRecordValue(candidate)) {
+			for (const entry of Object.values(candidate)) {
+				collect(entry);
+			}
+		}
+	};
+
+	for (const key of FILE_PARAMS_KEYS) {
+		collect(meta[key]);
+	}
+
+	return files;
 }
 
 const SOURCE_SESSION_KEYS = [

--- a/src/mcp/server/utils.ts
+++ b/src/mcp/server/utils.ts
@@ -61,6 +61,7 @@ const FILE_PARAMS_KEYS = ["waniwani/fileParams", "openai/fileParams"] as const;
 
 const FILE_URL_KEYS = [
 	"url",
+	"uri",
 	"download_url",
 	"downloadUrl",
 	"file_url",
@@ -195,10 +196,11 @@ function toAttachedFile(entry: unknown): AttachedFile | undefined {
 }
 
 /**
- * Files the host attached to this tool call, from `openai/fileParams` (ChatGPT)
- * or `waniwani/fileParams`. The container may be a list or an object keyed by
- * parameter name, and entries name their URL differently per host, so every
- * plausible spelling is read and anything without a fetchable URL is skipped.
+ * Files the host attached to this tool call, from the first of
+ * `waniwani/fileParams` or `openai/fileParams` (ChatGPT) that carries any. The
+ * container may be a list or an object keyed by parameter name, and entries name
+ * their URL differently per host, so every plausible spelling is read and
+ * anything without a fetchable URL is skipped.
  */
 export function extractAttachedFiles(
 	meta: Record<string, unknown> | undefined,
@@ -207,33 +209,43 @@ export function extractAttachedFiles(
 		return [];
 	}
 
+	for (const key of FILE_PARAMS_KEYS) {
+		const files = filesUnder(meta[key]);
+		if (files.length > 0) {
+			return files;
+		}
+	}
+
+	return [];
+}
+
+function filesUnder(candidate: unknown): AttachedFile[] {
 	const files: AttachedFile[] = [];
 	const seen = new Set<string>();
 
-	const collect = (candidate: unknown): void => {
-		if (Array.isArray(candidate)) {
-			for (const entry of candidate) {
+	const collect = (value: unknown): void => {
+		if (Array.isArray(value)) {
+			for (const entry of value) {
 				collect(entry);
 			}
 			return;
 		}
-		const file = toAttachedFile(candidate);
-		if (file && !seen.has(file.url)) {
-			seen.add(file.url);
-			files.push(file);
+		const file = toAttachedFile(value);
+		if (file) {
+			if (!seen.has(file.url)) {
+				seen.add(file.url);
+				files.push(file);
+			}
 			return;
 		}
-		if (!file && isRecordValue(candidate)) {
-			for (const entry of Object.values(candidate)) {
+		if (isRecordValue(value)) {
+			for (const entry of Object.values(value)) {
 				collect(entry);
 			}
 		}
 	};
 
-	for (const key of FILE_PARAMS_KEYS) {
-		collect(meta[key]);
-	}
-
+	collect(candidate);
 	return files;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 // Waniwani SDK - Core Types
 
+import type { DocumentsClient } from "./documents/types.js";
 import type { KbClient } from "./kb/types.js";
 import type { TrackingClient, TrackingConfig } from "./tracking/@types.js";
 
@@ -50,11 +51,15 @@ export interface WaniWaniClient extends TrackingClient {
 	readonly _config: InternalConfig;
 	/** Knowledge base client for ingestion, search, and source listing */
 	readonly kb: KbClient;
+	/** Documents client for reading a file into typed fields */
+	readonly documents: DocumentsClient;
 }
 
 // ============================================================================
 // Internal
 // ============================================================================
+
+export const DEFAULT_API_URL = "https://app.waniwani.ai";
 
 export interface InternalConfig {
 	apiUrl: string;

--- a/src/waniwani.ts
+++ b/src/waniwani.ts
@@ -1,5 +1,6 @@
 // Waniwani SDK - Main Entry
 
+import { createDocumentsClient } from "./documents/client.js";
 import { createKbClient } from "./kb/client.js";
 import {
 	getGlobalConfig,
@@ -7,7 +8,11 @@ import {
 	type WaniWaniProjectConfig,
 } from "./project-config.js";
 import { createTrackingClient } from "./tracking/index.js";
-import type { WaniWaniClient, WaniWaniConfig } from "./types.js";
+import {
+	DEFAULT_API_URL,
+	type WaniWaniClient,
+	type WaniWaniConfig,
+} from "./types.js";
 
 /**
  * Create a Waniwani SDK client
@@ -38,9 +43,7 @@ export function waniwani(
 		| undefined;
 
 	const apiUrl =
-		effective?.apiUrl ??
-		process.env.WANIWANI_API_URL ??
-		"https://app.waniwani.ai";
+		effective?.apiUrl ?? process.env.WANIWANI_API_URL ?? DEFAULT_API_URL;
 	const apiKey = effective?.apiKey ?? process.env.WANIWANI_API_KEY;
 	const trackingConfig = {
 		endpointPath:
@@ -59,10 +62,12 @@ export function waniwani(
 	// Compose client from modules
 	const trackingClient = createTrackingClient(internalConfig);
 	const kbClient = createKbClient(internalConfig);
+	const documentsClient = createDocumentsClient(internalConfig);
 
 	return {
 		...trackingClient,
 		kb: kbClient,
+		documents: documentsClient,
 		_config: internalConfig,
 	};
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -127,6 +127,21 @@ export default defineConfig([
 		outDir: "dist",
 		external: ["ai"],
 	},
+	// Documents (Node.js, server-side). `zod` stays external: a caller reaches
+	// this entry by passing a Zod schema, so it is always present.
+	{
+		entry: { "documents/index": "src/documents/index.ts" },
+		format: ["esm"],
+		target: "node20",
+		dts: true,
+		clean: false,
+		shims: true,
+		splitting: true,
+		sourcemap: true,
+		minify: true,
+		outDir: "dist",
+		external: ["zod"],
+	},
 	// Chat embed (self-contained IIFE for any website)
 	{
 		entry: { "chat/embed": "src/chat/web/embed/embed.ts" },


### PR DESCRIPTION
Closes WAN-961

The SDK half of T1 of [WAN-953](https://linear.app/waniwani/issue/WAN-953/plan-documents-module). The platform half is [WaniWani-AI/app#1105](https://github.com/WaniWani-AI/app/pull/1105) and **the two must land together**: this client calls a route that does not exist until that PR merges.

## Summary

`wani.documents.extract({ url, filename, schema })` at a new `@waniwani/sdk/documents` entry. The caller's Zod schema crosses HTTP as JSON Schema, and the response's `fields` are re-parsed with that same schema, so the developer gets a typed object rather than a bag of unknowns. Nulls mark what the document did not legibly answer.

The scoped client exposes it alongside `attachedFiles`, which reads a host's attached files off `_meta` (`openai/fileParams` for ChatGPT). A tool handler spreads one straight into `extract()`, and `sessionId` and `correlationId` come from the request without being passed:

```ts
const { attachedFiles, documents } = context.waniwani;
const { fields } = await documents.extract({ ...attachedFiles[0], schema });
```

`pages` takes zero-based indexes, the same shape the platform and Mistral use, so nothing is translated at the boundary. Billing is per page processed, so narrowing the selection lowers the bill.

`WaniwaniTracker` is deliberately left alone. A custom tracker injected through `withWaniwani` would otherwise have to grow a documents client, so the scoped client builds its own from the resolved config.

## How to see it working

Against a platform running app#1105, with `WANIWANI_API_KEY` set:

```ts
import { waniwani } from "@waniwani/sdk";
import { z } from "zod";

const wani = waniwani();
const { fields, pageCount } = await wani.documents.extract({
  url: "https://example.com/invoice.pdf",
  filename: "invoice.pdf",
  schema: z.object({ provider: z.string().nullable(), totalAmount: z.number().nullable() }),
  pages: [0],
});
```

Measured end to end against the live EU endpoint on a real 4-page electricity invoice: `{ provider: "Iberdrola Clientes, S.A.U.", totalAmount: 424.46 }`, and `pages: [0]` bills 1 page instead of 4 for the same result. A refusal surfaces as `WaniWaniError` reading `UNSUPPORTED_DOCUMENT_TYPE: scan.heic is not one of PDF, PNG, JPEG, TIFF, BMP, GIF or WEBP`.

To see the zod fix specifically: build, then confirm `dist/index.js` contains no `from"zod"`. Before this branch it did.

## Review focus

`extractAttachedFiles` in `src/mcp/server/utils.ts` was written against no vendor documentation for `openai/fileParams`, so its tolerance rules are the softest part of this PR. It reads several spellings of the URL and filename keys, takes the first meta key that yields any files rather than concatenating (concatenating handed a caller the same document twice, and billing is per page), and skips anything without an http(s) URL. The shape has not been checked against a real ChatGPT attachment.

`src/mcp/server/utils.ts` and `scoped-client.ts` are pre-existing files. Everything there is additive.

Version deliberately not bumped, per the repo rule that a feature branch never bumps.

## Not done

The docs page for the documents module is not written. CLAUDE.md requires a public API change to update `docs/docs/sdk/`, which lives in a separate repo not checked out here. `@waniwani/sdk/documents` needs an entry there and a row in the entry-points reference before this is released.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New paid API surface and SSRF-adjacent URL fetching on the platform; `extractAttachedFiles` heuristics for ChatGPT attachments are untested against real host payloads.
> 
> **Overview**
> Adds a **documents** module (`@waniwani/sdk/documents` and `wani.documents`) with `extract({ url, filename, schema, pages?, … })`, which POSTs to `/api/mcp/modules/documents/extract`, sends the caller’s schema as JSON Schema via a **dynamic** `zod` import, and re-parses returned `fields` for typed results plus `pageCount`, `pageConfidence`, and `documentId`.
> 
> **MCP tool handlers** get `context.waniwani.attachedFiles` (from `waniwani/fileParams` or `openai/fileParams`) and a scoped `documents.extract` that auto-fills `sessionId` and `correlationId` from request meta. `AttachedFile` is exported from `@waniwani/sdk/mcp`.
> 
> The package root exports documents **types only** (no static `zod` on the main entry); build adds a dedicated `documents` tsup bundle with `zod` external. **`DEFAULT_API_URL`** is shared for API URL resolution. This client depends on the matching platform route landing with app#1105.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4662a881fa2a73d27c6792aa4ae0bd6009d57b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->