### PR TITLE
feat(webmcp): publish the site's MCP tools to browsing agents

### DIFF
--- a/scripts/inline-embed-css.ts
+++ b/scripts/inline-embed-css.ts
@@ -1,8 +1,12 @@
 /**
  * Post-build: Inline CSS into the embed IIFE bundle.
  *
- * The embed entry point (src/chat/web/embed/embed.ts) contains a placeholder:
+ * src/chat/web/embed/embed-css.ts contains a placeholder:
  *   const EMBED_CSS = "__WANIWANI_EMBED_CSS__";
+ *
+ * It lives in one module, imported by every root that needs it (the chat's and
+ * the WebMCP overlay's), so the string below appears exactly once in the
+ * bundle — which matters, because `String.replace` swaps only the first.
  *
  * This script reads dist/chat/styles.css, escapes it for JS string embedding,
  * and replaces the placeholder in dist/chat/embed.js.
@@ -36,7 +40,7 @@ if (!embedJs.includes(placeholder)) {
 		`ERROR: Placeholder "${placeholder}" not found in ${embedPath}`,
 	);
 	console.error(
-		'Make sure src/chat/web/embed/embed.ts contains: const EMBED_CSS = "__WANIWANI_EMBED_CSS__";',
+		'Make sure src/chat/web/embed/embed-css.ts contains: const EMBED_CSS = "__WANIWANI_EMBED_CSS__";',
 	);
 	process.exit(1);
 }

--- a/src/chat/web/ai-elements/tool.tsx
+++ b/src/chat/web/ai-elements/tool.tsx
@@ -19,6 +19,11 @@ import {
 	useRef,
 	useState,
 } from "react";
+import {
+	autoHeightFromMeta,
+	metaOf,
+	resourceUriFromMeta,
+} from "../../../shared/view-uri";
 import { useTranslation } from "../i18n";
 import { cn } from "../lib/utils";
 import { Button } from "../ui/button";
@@ -443,60 +448,6 @@ export type ToolDefinitionsMap = Record<
 	{ _meta?: Record<string, unknown> }
 >;
 
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-	if (typeof value !== "object" || value === null) {
-		return undefined;
-	}
-	return value as Record<string, unknown>;
-}
-
-function getUiObject(
-	meta: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
-	return asRecord(meta?.ui);
-}
-
-function extractOutputMeta(
-	output: unknown,
-): Record<string, unknown> | undefined {
-	return asRecord(asRecord(output)?._meta);
-}
-
-/**
- * Extract a widget resource URI from a `_meta` object, checking all three
- * shapes the spec and in-the-wild servers use, in priority order:
- *
- * 1. `_meta.ui.resourceUri` — MCP Apps preferred (nested)
- * 2. `_meta["ui/resourceUri"]` — MCP Apps legacy/compat (flat)
- * 3. `_meta["openai/outputTemplate"]` — OpenAI Apps SDK
- */
-function extractResourceUriFromMeta(
-	meta: Record<string, unknown> | undefined,
-): string | undefined {
-	if (!meta) {
-		return undefined;
-	}
-	const nested = getUiObject(meta)?.resourceUri;
-	if (typeof nested === "string" && nested.length > 0) {
-		return nested;
-	}
-	const flat = meta["ui/resourceUri"];
-	if (typeof flat === "string" && flat.length > 0) {
-		return flat;
-	}
-	const openai = meta["openai/outputTemplate"];
-	if (typeof openai === "string" && openai.length > 0) {
-		return openai;
-	}
-	return undefined;
-}
-
-function extractAutoHeightFromMeta(
-	meta: Record<string, unknown> | undefined,
-): boolean {
-	return getUiObject(meta)?.autoHeight === true;
-}
-
 /**
  * Resolve the widget resource URI for a tool part.
  *
@@ -518,14 +469,12 @@ export function resolveWidgetResourceUri(
 	toolDefinitions?: ToolDefinitionsMap,
 ): string | undefined {
 	if (toolName) {
-		const fromDef = extractResourceUriFromMeta(
-			toolDefinitions?.[toolName]?._meta,
-		);
+		const fromDef = resourceUriFromMeta(toolDefinitions?.[toolName]?._meta);
 		if (fromDef) {
 			return fromDef;
 		}
 	}
-	return extractResourceUriFromMeta(extractOutputMeta(output));
+	return resourceUriFromMeta(metaOf(output));
 }
 
 /**
@@ -539,11 +488,11 @@ export function resolveWidgetAutoHeight(
 	toolDefinitions?: ToolDefinitionsMap,
 ): boolean {
 	if (toolName) {
-		if (extractAutoHeightFromMeta(toolDefinitions?.[toolName]?._meta)) {
+		if (autoHeightFromMeta(toolDefinitions?.[toolName]?._meta)) {
 			return true;
 		}
 	}
-	return extractAutoHeightFromMeta(extractOutputMeta(output));
+	return autoHeightFromMeta(metaOf(output));
 }
 
 /**

--- a/src/chat/web/embed/__tests__/webmcp-endpoints.test.ts
+++ b/src/chat/web/embed/__tests__/webmcp-endpoints.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { resolveWebMcpEndpoints } from "../webmcp-endpoints";
+
+const API = "https://app.waniwani.ai/api/mcp/chat";
+const TOKEN = "wwp_abc123";
+
+describe("resolveWebMcpEndpoints", () => {
+	// The whole point of routing through the hosted API: the token identifies
+	// the environment, so nothing about the MCP server appears on the page.
+	test("derives both endpoints from the token alone", () => {
+		const resolved = resolveWebMcpEndpoints({ api: API, token: TOKEN });
+		expect(resolved).toEqual({
+			toolsEndpoint: `${API}/webmcp`,
+			resourceEndpoint: `${API}/resource?token=${TOKEN}`,
+			headers: { Authorization: `Bearer ${TOKEN}` },
+		});
+	});
+
+	// A POST can carry a header; an iframe GET cannot, so only the resource URL
+	// spends the token in the query string.
+	test("authenticates the POST by header and the iframe by query", () => {
+		const resolved = resolveWebMcpEndpoints({ api: API, token: TOKEN });
+		expect(resolved?.toolsEndpoint).not.toContain(TOKEN);
+		expect(resolved?.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+		expect(resolved?.resourceEndpoint).toContain(`token=${TOKEN}`);
+	});
+
+	describe("switches", () => {
+		test("an unknown channel switch reads as on", () => {
+			expect(
+				resolveWebMcpEndpoints({ api: API, token: TOKEN }, undefined),
+			).not.toBeNull();
+			expect(
+				resolveWebMcpEndpoints({ api: API, token: TOKEN }, true),
+			).not.toBeNull();
+		});
+
+		// The page's is markup intent; the channel's is the dashboard kill switch,
+		// which has to work without the site being touched.
+		test("either one closes it", () => {
+			expect(
+				resolveWebMcpEndpoints({
+					api: API,
+					token: TOKEN,
+					webmcp: { enabled: false },
+				}),
+			).toBeNull();
+			expect(
+				resolveWebMcpEndpoints({ api: API, token: TOKEN }, false),
+			).toBeNull();
+		});
+	});
+
+	test("is on with no webmcp config at all", () => {
+		expect(resolveWebMcpEndpoints({ api: API, token: TOKEN })).not.toBeNull();
+	});
+
+	test("the page's switch closes it", () => {
+		expect(
+			resolveWebMcpEndpoints({
+				api: API,
+				token: TOKEN,
+				webmcp: { enabled: false },
+			}),
+		).toBeNull();
+	});
+
+	// The token is the whole configuration. Without it there is no environment
+	// to resolve and nothing to point at.
+	test("no token means nothing to point at", () => {
+		expect(resolveWebMcpEndpoints({ api: API })).toBeNull();
+	});
+
+	describe("channelId", () => {
+		// Ingest drops what it cannot attribute, so a call with no channel is a
+		// conversion nobody sees.
+		test("takes the author-set channel", () => {
+			expect(
+				resolveWebMcpEndpoints({ api: API, token: TOKEN, channelId: "ch-1" })
+					?.channelId,
+			).toBe("ch-1");
+		});
+
+		test("falls back to the one the server resolved from the token", () => {
+			expect(
+				resolveWebMcpEndpoints({ api: API, token: TOKEN }, undefined, "ch-2")
+					?.channelId,
+			).toBe("ch-2");
+		});
+
+		test("author-set wins", () => {
+			expect(
+				resolveWebMcpEndpoints(
+					{ api: API, token: TOKEN, channelId: "ch-1" },
+					undefined,
+					"ch-2",
+				)?.channelId,
+			).toBe("ch-1");
+		});
+
+		// A first visit has no cached config yet, and publishing tools beats
+		// waiting for a round trip to learn a channel the server can infer.
+		test("is absent when neither knows one", () => {
+			expect(
+				resolveWebMcpEndpoints({ api: API, token: TOKEN }),
+			).not.toHaveProperty("channelId");
+		});
+	});
+
+	describe("mcpServerUrl", () => {
+		// It is the chat's override for which MCP server the *server* talks to,
+		// not an instruction to bypass it. Forwarded so both surfaces land on the
+		// same server, and gated where the app already gates it.
+		test("rides along as a query param rather than redirecting the page", () => {
+			const resolved = resolveWebMcpEndpoints({
+				api: API,
+				token: TOKEN,
+				mcpServerUrl: "https://staging.mcp.example/mcp",
+			});
+			expect(resolved?.toolsEndpoint).toBe(
+				`${API}/webmcp?mcpServerUrl=${encodeURIComponent("https://staging.mcp.example/mcp")}`,
+			);
+			expect(resolved?.resourceEndpoint).toContain("mcpServerUrl=");
+			expect(resolved?.resourceEndpoint).toContain(`token=${TOKEN}`);
+		});
+
+		test("is absent from the urls when unset", () => {
+			const resolved = resolveWebMcpEndpoints({ api: API, token: TOKEN });
+			expect(resolved?.toolsEndpoint).not.toContain("mcpServerUrl");
+			expect(resolved?.resourceEndpoint).not.toContain("mcpServerUrl");
+		});
+	});
+
+	// `buildApiUrl` exists because internal surfaces append markers to the base.
+	test("preserves query params already on the api base", () => {
+		const resolved = resolveWebMcpEndpoints({
+			api: `${API}?test=1`,
+			token: TOKEN,
+		});
+		expect(resolved?.toolsEndpoint).toBe(`${API}/webmcp?test=1`);
+		expect(resolved?.resourceEndpoint).toContain("test=1");
+	});
+});

--- a/src/chat/web/embed/config.ts
+++ b/src/chat/web/embed/config.ts
@@ -79,6 +79,20 @@ export interface PageSuggestionsEntry {
  * public token. It only carries display-facing fields (title, welcome message,
  * placeholder, suggestions) — system prompt and step budget stay server-side.
  */
+/**
+ * Where the page finds the MCP server whose tools it publishes to a browsing
+ * agent, and whether to publish them at all.
+ */
+export interface WebMcpEmbedConfig {
+	/**
+	 * On unless explicitly switched off.
+	 *
+	 * The page's own switch, for markup that wants the chat but not the tools on
+	 * this particular page.
+	 */
+	enabled?: boolean;
+}
+
 export interface EmbedConfig {
 	/** Waniwani chat API URL. Defaults to `https://app.waniwani.ai/api/mcp/chat`. */
 	api?: string;
@@ -101,6 +115,18 @@ export interface EmbedConfig {
 	visitorId?: VisitorIdInput;
 	/** Override MCP server URL (optional — resolved from environment by default). */
 	mcpServerUrl?: string;
+	/**
+	 * WebMCP: publish this site's MCP tools to a browsing agent standing on the
+	 * page, via `document.modelContext`.
+	 *
+	 * A third surface for the same flows, alongside the connector and this chat.
+	 * On by default, and needs no configuration: the token identifies the
+	 * environment and the hosted API resolves its MCP server per request, the
+	 * same way `/config` and `/resource` already do.
+	 *
+	 * Surfaced as `data-webmcp` on the script tag.
+	 */
+	webmcp?: WebMcpEmbedConfig;
 	/**
 	 * Agent channel ID. Sent to the chat API so the Waniwani app routes the
 	 * conversation to the right agent. Surfaced as `data-channel-id` on the
@@ -361,6 +387,15 @@ export function parseConfigFromScript(): Partial<EmbedConfig> {
 	const mcpServerUrl = str("data-mcp-server-url");
 	if (mcpServerUrl) {
 		config.mcpServerUrl = mcpServerUrl;
+	}
+
+	// Declines the surface on a page that should stay quiet, without touching
+	// the channel every other page shares.
+	const webmcpFlag = str("data-webmcp");
+	if (webmcpFlag) {
+		config.webmcp = {
+			enabled: webmcpFlag !== "false" && webmcpFlag !== "off",
+		};
 	}
 
 	const channelId = str("data-channel-id");

--- a/src/chat/web/embed/embed-css.ts
+++ b/src/chat/web/embed/embed-css.ts
@@ -1,0 +1,43 @@
+/**
+ * The embed's compiled stylesheet, and the one way to get it into a shadow
+ * root.
+ *
+ * Its own module because more than one root needs it: the chat's, and the
+ * WebMCP overlay's, which mounts separately so a widget step renders whether or
+ * not the panel is open. Two roots, one stylesheet, one placeholder.
+ *
+ * The constant is a placeholder at build time. `scripts/inline-embed-css.ts`
+ * replaces the first occurrence of it in `dist/chat/embed.js` with the compiled
+ * `styles.css`, so it must appear exactly once in the bundle — which is the
+ * other reason this is a module rather than a constant copied per entry.
+ */
+
+const EMBED_CSS = "__WANIWANI_EMBED_CSS__";
+
+/**
+ * Recognise the un-replaced placeholder without writing it out a second time.
+ *
+ * `inline-embed-css.ts` swaps the first occurrence of that string in the built
+ * bundle, so a second copy of it here would be a coin flip over which one the
+ * CSS lands in. A prefix nobody would author into a stylesheet is enough to
+ * tell them apart, and there is only ever one full literal to replace.
+ */
+function isPlaceholder(value: string): boolean {
+	return value.startsWith("__WANIWANI");
+}
+
+/**
+ * Append the compiled stylesheet to a shadow root.
+ *
+ * A no-op when the bundle was not post-processed, which is every path other
+ * than the IIFE: the React entry points ship `styles.css` for the host page to
+ * import, so there is nothing to inline and nothing to inject.
+ */
+export function injectEmbedCss(shadowRoot: ShadowRoot): void {
+	if (!EMBED_CSS || isPlaceholder(EMBED_CSS)) {
+		return;
+	}
+	const style = document.createElement("style");
+	style.textContent = EMBED_CSS;
+	shadowRoot.appendChild(style);
+}

--- a/src/chat/web/embed/embed.ts
+++ b/src/chat/web/embed/embed.ts
@@ -27,16 +27,12 @@ import {
 	parseConfigFromScript,
 	resolveConfig,
 } from "./config";
+import { injectEmbedCss } from "./embed-css";
 import { FloatingChat, type FloatingChatHandle } from "./floating-chat";
 import { InlineChat, type InlineChatHandle } from "./inline-chat";
 import { loadCachedConfig } from "./remote-config";
 import { isVisibleForPath } from "./visibility";
-
-// ---------------------------------------------------------------------------
-// CSS placeholder — replaced at build time with the actual CSS string
-// ---------------------------------------------------------------------------
-
-const EMBED_CSS = "__WANIWANI_EMBED_CSS__";
+import { startWebMcp, type WebMcpHandle } from "./webmcp-bootstrap";
 
 // ---------------------------------------------------------------------------
 // Global type augmentation
@@ -243,11 +239,7 @@ function applyContainerAppearance(
 // ---------------------------------------------------------------------------
 
 function injectStyles(shadowRoot: ShadowRoot, config: EmbedConfig): void {
-	if (EMBED_CSS && EMBED_CSS !== "__WANIWANI_EMBED_CSS__") {
-		const style = document.createElement("style");
-		style.textContent = EMBED_CSS;
-		shadowRoot.appendChild(style);
-	}
+	injectEmbedCss(shadowRoot);
 
 	// In the embed.js path the outer `[data-waniwani-embed]` container draws
 	// panel border + shadow (see `CONTAINER_CHROME_CSS`). CSS variables
@@ -769,6 +761,17 @@ function init(options?: Partial<EmbedConfig>): EmbedInstance {
 				"no public token configured (set data-token or pass token to init())",
 			);
 
+	// The site's own tools, published to a browsing agent standing on the page.
+	// Independent of the chat: it mounts its own root, and a widget step reaches
+	// the visitor whether the panel is open or not. Returns null on every browser
+	// without `modelContext`, which is nearly all of them.
+	let webmcp: WebMcpHandle | null = null;
+	try {
+		webmcp = startWebMcp(config);
+	} catch (error) {
+		console.error("[Waniwani] WebMCP setup failed", error);
+	}
+
 	currentInstance = {
 		...mounted,
 		track: trackClient.track,
@@ -777,6 +780,7 @@ function init(options?: Partial<EmbedConfig>): EmbedInstance {
 		getVisitorId: () => getOrCreateVisitorId(),
 		destroy: () => {
 			void trackClient.shutdown();
+			webmcp?.destroy();
 			mounted.destroy();
 		},
 	};

--- a/src/chat/web/embed/remote-config.ts
+++ b/src/chat/web/embed/remote-config.ts
@@ -126,6 +126,12 @@ interface RemoteConfigResponse {
 	 * uploader.
 	 */
 	documentUpload?: RemoteDocumentUpload | null;
+	/**
+	 * The channel's WebMCP switch. Absent on servers that predate the field,
+	 * which reads as on: the surface needs no configuration to work, so the only
+	 * thing worth sending is a channel that has declined it.
+	 */
+	webmcp?: { enabled?: boolean | null } | null;
 }
 
 interface RemoteDocumentUpload {
@@ -250,6 +256,11 @@ function remoteToConfigPartial(
 	}
 	if (typeof data.enableThreadHistory === "boolean") {
 		out.enableThreadHistory = data.enableThreadHistory;
+	}
+	// WebMCP is on by default and derives its endpoints from the token, so the
+	// only thing a channel can say about it is that it declines.
+	if (typeof data.webmcp?.enabled === "boolean") {
+		out.webmcp = { enabled: data.webmcp.enabled };
 	}
 	if (data.toolCallDisplay === "full") {
 		out.showToolCalls = true;

--- a/src/chat/web/embed/webmcp-bootstrap.tsx
+++ b/src/chat/web/embed/webmcp-bootstrap.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { getOrCreateVisitorId } from "../../../shared/visitor-id";
+import {
+	createWebMcpBridge,
+	supportsWebMcp,
+	type WebMcpBridge,
+	type WebMcpWidgetPayload,
+} from "../../../webmcp";
+import { debugLog } from "../lib/debug";
+import type { EmbedConfig } from "./config";
+import { injectEmbedCss } from "./embed-css";
+import { loadCachedConfig } from "./remote-config";
+import {
+	resolveWebMcpEndpoints,
+	type WebMcpEndpoints,
+} from "./webmcp-endpoints";
+import { WebMcpOverlay } from "./webmcp-overlay";
+
+/**
+ * Publishing the site's MCP tools to a browsing agent, from inside the chat
+ * embed.
+ *
+ * Attached to the embed rather than shipped as a second script because the two
+ * want the same three things and the customer should install one tag: the
+ * visitor id, the widget host, and a resolved server URL. A page that already
+ * has the chat gains this for a few kilobytes.
+ *
+ * Everything below is skipped on a browser with no `modelContext`, which is
+ * every visit but the ones this exists for. The check is synchronous and first,
+ * so an ordinary visitor pays one property read.
+ */
+
+/**
+ * Keys the flow engine's state. Tab-scoped on purpose: a value that outlives
+ * the tab resumes a flow abandoned days ago in the middle of the question it
+ * was abandoned on, and one that changes between calls restarts every flow.
+ * Visitor identity is separate and persistent, and both are sent.
+ */
+const SESSION_KEY = "waniwani:webmcp:session";
+
+function tabSessionId(): string {
+	try {
+		const stored = sessionStorage.getItem(SESSION_KEY);
+		if (stored) {
+			return stored;
+		}
+		const minted = crypto.randomUUID();
+		sessionStorage.setItem(SESSION_KEY, minted);
+		return minted;
+	} catch {
+		// Private mode, or a browser refusing storage. A per-load id still keys a
+		// flow correctly for the length of that load, which is the common case.
+		return `s-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+	}
+}
+
+/**
+ * The endpoints, plus the channel's switch and id, read from the session cache.
+ *
+ * Cache rather than a fetch: a browsing agent's visit is the uncached one, and
+ * a round trip here sits in front of every tool registration. A first visit
+ * publishes without a channel and picks one up from the second page onward.
+ */
+function resolveWebMcp(config: EmbedConfig): WebMcpEndpoints | null {
+	const cached = config.token
+		? loadCachedConfig(config.api ?? "", config.token, config.channelId)
+		: null;
+	const resolved = resolveWebMcpEndpoints(
+		config,
+		cached?.webmcp?.enabled,
+		cached?.channelId,
+	);
+	if (!resolved) {
+		debugLog("[webmcp] not publishing site tools: switched off, or no token");
+	}
+	return resolved;
+}
+
+function prefersDark(): boolean {
+	try {
+		return window.matchMedia("(prefers-color-scheme: dark)").matches;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Owns the widget on screen, and the bridge that produces them.
+ *
+ * The bridge starts in an effect rather than before mount so its `onWidget`
+ * can set state directly. The cost is one frame against four network round
+ * trips, which is not where this surface's latency lives.
+ */
+function WebMcpHost({
+	toolsEndpoint,
+	resourceEndpoint,
+	headers,
+	channelId,
+	onBridge,
+}: WebMcpEndpoints & { onBridge: (bridge: WebMcpBridge | null) => void }) {
+	const [widget, setWidget] = React.useState<WebMcpWidgetPayload | null>(null);
+	const [isDark, setIsDark] = React.useState(prefersDark);
+
+	React.useEffect(() => {
+		let disposed = false;
+		let bridge: WebMcpBridge | null = null;
+
+		void createWebMcpBridge({
+			endpoint: toolsEndpoint,
+			headers,
+			channelId,
+			sessionId: tabSessionId(),
+			visitorId: getOrCreateVisitorId(),
+			onWidget: (payload) => setWidget(payload),
+		}).then((created) => {
+			bridge = created;
+			if (disposed) {
+				created?.dispose();
+				return;
+			}
+			onBridge(created);
+		});
+
+		return () => {
+			disposed = true;
+			bridge?.dispose();
+		};
+	}, [toolsEndpoint, headers, channelId, onBridge]);
+
+	React.useEffect(() => {
+		let media: MediaQueryList;
+		try {
+			media = window.matchMedia("(prefers-color-scheme: dark)");
+		} catch {
+			return;
+		}
+		const onChange = () => setIsDark(media.matches);
+		media.addEventListener("change", onChange);
+		return () => media.removeEventListener("change", onChange);
+	}, []);
+
+	return (
+		<WebMcpOverlay
+			widget={widget}
+			toolsEndpoint={toolsEndpoint}
+			resourceEndpoint={resourceEndpoint}
+			isDark={isDark}
+			onClose={() => setWidget(null)}
+		/>
+	);
+}
+
+export type WebMcpHandle = {
+	/** Tools published to the agent. Empty until the bridge has listed them. */
+	getTools: () => string[];
+	destroy: () => void;
+};
+
+/**
+ * Start WebMCP for this page. Returns `null` when the browser has no
+ * `modelContext`, when the page has switched the surface off, or when there is
+ * no token. None of those are errors.
+ */
+export function startWebMcp(config: EmbedConfig): WebMcpHandle | null {
+	// First and synchronous. Every visit that is not a browsing agent stops
+	// here, having done one property read and no network.
+	if (!supportsWebMcp()) {
+		return null;
+	}
+
+	const resolved = resolveWebMcp(config);
+	if (!resolved) {
+		return null;
+	}
+
+	// Its own host element and shadow root, independent of the chat's. A widget
+	// step arrives whether the panel is open or not, whether the chat mounted
+	// inline or floating, and whether it mounted at all.
+	const host = document.createElement("div");
+	host.setAttribute("data-waniwani-webmcp", "");
+	document.body.appendChild(host);
+	const shadow = host.attachShadow({ mode: "open" });
+	// Its own copy of the stylesheet. The overlay is a sibling of the chat, not a
+	// child, so it inherits nothing from the chat's root — and it has to render
+	// correctly on a page where the chat never mounted at all.
+	injectEmbedCss(shadow);
+	const container = document.createElement("div");
+	shadow.appendChild(container);
+
+	let bridge: WebMcpBridge | null = null;
+	const root = ReactDOM.createRoot(container);
+	root.render(
+		<WebMcpHost
+			toolsEndpoint={resolved.toolsEndpoint}
+			resourceEndpoint={resolved.resourceEndpoint}
+			headers={resolved.headers}
+			channelId={resolved.channelId}
+			onBridge={(created) => {
+				bridge = created;
+			}}
+		/>,
+	);
+
+	return {
+		getTools: () => (bridge?.tools ?? []).map((tool) => tool.name),
+		destroy: () => {
+			bridge?.dispose();
+			root.unmount();
+			host.remove();
+		},
+	};
+}

--- a/src/chat/web/embed/webmcp-endpoints.ts
+++ b/src/chat/web/embed/webmcp-endpoints.ts
@@ -1,0 +1,100 @@
+import { buildApiUrl } from "../lib/api-url";
+import type { EmbedConfig } from "./config";
+
+/**
+ * Which two URLs the WebMCP surface talks to, and whether it runs at all.
+ *
+ * Its own module, and pure, because this is the whole of the decision.
+ */
+
+export type WebMcpEndpoints = {
+	/** Where `list` and `call` are posted. */
+	toolsEndpoint: string;
+	/**
+	 * The channel to attribute calls to, when one is known.
+	 *
+	 * Ingest drops events it cannot attribute, and a token-only embed learns its
+	 * channel from `/config` rather than from its own markup, so this may be
+	 * absent on the very first visit and present from the second page onward.
+	 */
+	channelId?: string;
+	/** `Authorization` for that POST. */
+	headers: Record<string, string>;
+	/** Where a widget's HTML is fetched from. */
+	resourceEndpoint: string;
+};
+
+/**
+ * `Partial`, because `token` is required on `EmbedConfig` and a self-hosted
+ * page legitimately has none.
+ */
+export type ResolveInput = Partial<
+	Pick<EmbedConfig, "api" | "token" | "webmcp" | "mcpServerUrl" | "channelId">
+>;
+
+/**
+ * The endpoints, or null when the surface should stay quiet.
+ *
+ * Derived from the token, the same way every other part of the embed derives
+ * its URLs. The page neither knows nor needs the MCP server's address: the
+ * token identifies the environment and the server resolves `environment.url`
+ * from it per request, which is exactly what `/config` and `/resource` already
+ * do. A surface that made the customer paste an origin onto the script tag
+ * would be the only one that did.
+ *
+ * `mcpServerUrl` does not change where the page points. It rides along as a
+ * query param the server reads and gates, the way `/resource` already accepts
+ * one, so a site overriding its chat's MCP server gets both surfaces on that
+ * same server rather than two surfaces on two.
+ *
+ * There is deliberately no way to point the page at an MCP server directly.
+ * Doing so would need CORS on that server for every customer origin and a
+ * `frame-ancestors` policy on its views, and it would put a second copy of the
+ * tools route in the kit. Nothing needs it while the token can answer the same
+ * question.
+ *
+ * @param channelEnabled the channel's own switch, when the config carrying it
+ *   has been seen. `undefined` means unknown, which reads as on.
+ * @param resolvedChannelId the channel the server resolved from the token, for
+ *   an embed whose markup names none.
+ */
+export function resolveWebMcpEndpoints(
+	config: ResolveInput,
+	channelEnabled?: boolean,
+	resolvedChannelId?: string,
+): WebMcpEndpoints | null {
+	// Either switch closes it. The page's is explicit intent from whoever owns
+	// the markup; the channel's is the dashboard kill switch, and it arrives
+	// through `/config` so it can be thrown without touching the site.
+	if (config.webmcp?.enabled === false || channelEnabled === false) {
+		return null;
+	}
+
+	const api = config.api ?? "";
+	if (!config.token) {
+		return null;
+	}
+
+	const override = config.mcpServerUrl
+		? { mcpServerUrl: config.mcpServerUrl }
+		: undefined;
+
+	return {
+		toolsEndpoint: buildApiUrl(api, "/webmcp", override),
+		// Author-set wins over the one the server resolved from the token, the
+		// same precedence the chat's own tracking client uses.
+		...((config.channelId ?? resolvedChannelId) && {
+			channelId: config.channelId ?? resolvedChannelId,
+		}),
+		// A POST can carry a header, so it does. The resource endpoint below
+		// cannot: an iframe navigates by GET, so its token goes in the URL, where
+		// it is no more exposed than it already is in `data-token`.
+		headers: { Authorization: `Bearer ${config.token}` },
+		// Built here rather than through `buildResourceEndpoint`, whose job is to
+		// dig the token out of a headers record. This already has the token.
+		resourceEndpoint: buildApiUrl(api, "/resource", {
+			token: config.token,
+			...override,
+		}),
+	};
+}

--- a/src/chat/web/embed/webmcp-overlay.tsx
+++ b/src/chat/web/embed/webmcp-overlay.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { autoHeightFromMeta } from "../../../shared/view-uri";
+import type { WebMcpWidgetPayload } from "../../../webmcp";
+import { McpAppFrame } from "../components/mcp-app-frame";
+import { cn } from "../lib/utils";
+
+/**
+ * Renders a flow's widget step on the page while a browsing agent talks the
+ * visitor through it.
+ *
+ * The agent lives outside the page and WebMCP carries tools only, so a widget
+ * step can never render in the agent's own window. It renders here. The bridge
+ * resolves the step server-side and hands over everything the view needs; this
+ * mounts it and speaks the host half of the MCP Apps protocol, using the same
+ * component the chat uses for widgets in a message bubble.
+ *
+ * A sibling of the chat rather than a part of it. A widget step arrives whether
+ * or not the panel is open, and the visitor is looking at the page, because the
+ * conversation is happening somewhere else entirely.
+ *
+ * The view is byte-identical to the one a connector host renders. Neither side
+ * knows which host it woke up in.
+ */
+
+/**
+ * Width the panel is designed for, and the width the view is handed.
+ *
+ * 672px is not arbitrary. Two-column widget layouts sit behind Tailwind's `sm:`
+ * breakpoint at 640px, so a narrower panel is not a smaller version of the same
+ * widget, it is the mobile layout with the columns stacked.
+ */
+const PANEL_WIDTH = 672;
+
+/** Leaves the panel clear of the viewport edges when a view asks for more room than there is. */
+const VIEWPORT_MARGIN = 32;
+
+/**
+ * `McpAppFrame` is used exactly as the chat uses it, with no new props.
+ *
+ * Three things would be worth telling it on this surface, and none of them are
+ * worth touching a component every customer's chat renders:
+ *
+ * - It advertises a `message` capability in its handshake, which is how a view
+ *   pushes a follow-up into the conversation. There is no channel back to a
+ *   browsing agent, so a view that uses it is ignored. The panel's own content
+ *   still works; only the agent's narration is lost.
+ * - Its `hostInfo` says "Waniwani Chat". A view reading it is told the wrong
+ *   host, and nothing in ours reads it.
+ * - It clamps its own height. The panel below sets `maxHeight` and scrolls, so
+ *   an oversized view is contained here rather than there.
+ *
+ * Each becomes worth doing once this surface has run in front of real traffic
+ * and one of them has actually cost something.
+ */
+
+export type WebMcpOverlayProps = {
+	/** The step to show, or `null` for nothing. */
+	widget: WebMcpWidgetPayload | null;
+	/** The tools endpoint, so a view's own `tools/call` can be proxied. */
+	toolsEndpoint: string;
+	/** Auth for that endpoint, matching what the bridge sends. */
+	headers?: Record<string, string>;
+	/**
+	 * Where view HTML is fetched from, resolved from the token the same way the
+	 * chat's own widget iframes resolve theirs.
+	 */
+	resourceEndpoint: string;
+	/** Raised when the view says it is finished, and on Escape for a preview. */
+	onClose: () => void;
+	isDark?: boolean;
+};
+
+export function WebMcpOverlay({
+	widget,
+	toolsEndpoint,
+	resourceEndpoint,
+	headers,
+	onClose,
+	isDark = false,
+}: WebMcpOverlayProps) {
+	const [viewport, setViewport] = useState<{
+		width: number;
+		height: number;
+	} | null>(null);
+
+	// Clamping needs the viewport, and reading it during render would differ
+	// between a server pass and the client one.
+	useEffect(() => {
+		const read = () =>
+			setViewport({ width: window.innerWidth, height: window.innerHeight });
+		read();
+		window.addEventListener("resize", read);
+		return () => window.removeEventListener("resize", read);
+	}, []);
+
+	// A real widget step is a flow waiting on the visitor, and closing it strands
+	// the agent mid-conversation with no way to reopen. A preview is something
+	// someone opened to look at, so it gets a way out.
+	const dismissable = widget?.preview === true;
+
+	useEffect(() => {
+		if (!widget || !dismissable) {
+			return;
+		}
+		const onKey = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				onClose();
+			}
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [widget, dismissable, onClose]);
+
+	useEffect(() => {
+		if (!widget) {
+			return;
+		}
+		const previous = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
+		return () => {
+			document.body.style.overflow = previous;
+		};
+	}, [widget]);
+
+	const callTool = useCallback(
+		async (params: { name: string; arguments: Record<string, unknown> }) => {
+			const response = await fetch(toolsEndpoint, {
+				method: "POST",
+				headers: { "content-type": "application/json", ...headers },
+				body: JSON.stringify({ action: "call", ...params }),
+			});
+			if (!response.ok) {
+				throw new Error(`webmcp tool call failed: ${response.status}`);
+			}
+			return (await response.json()) as {
+				content?: Array<{ type: string; text?: string }>;
+				structuredContent?: Record<string, unknown>;
+				_meta?: Record<string, unknown>;
+			};
+		},
+		[toolsEndpoint, headers],
+	);
+
+	if (!widget) {
+		return null;
+	}
+
+	const width = viewport
+		? Math.min(PANEL_WIDTH, viewport.width - VIEWPORT_MARGIN)
+		: PANEL_WIDTH;
+	const maxHeight = viewport ? viewport.height - VIEWPORT_MARGIN : undefined;
+
+	return (
+		<div
+			role="dialog"
+			aria-modal="true"
+			aria-label="Waniwani"
+			// `dark` here and not on an ancestor: this shadow root is a sibling of
+			// the chat's, so it inherits none of the chat root's theming and has to
+			// switch the tokens itself.
+			//
+			// The z-index is arbitrary because the scale has no rung this high, and
+			// it has to clear whatever the host page stacks.
+			className={cn(
+				"ww:fixed ww:inset-0 ww:z-[2147483000] ww:flex ww:items-center ww:justify-center ww:bg-black/45 ww:backdrop-blur-md",
+				isDark && "dark",
+			)}
+		>
+			{/* A real button rather than a click handler on the backdrop div, so
+			    dismissing works from the keyboard and announces itself. Absent
+			    entirely for a real widget step, which has no way out by design. */}
+			{dismissable && (
+				<button
+					type="button"
+					aria-label="Close"
+					onClick={onClose}
+					className="ww:absolute ww:inset-0 ww:h-full ww:w-full ww:cursor-pointer ww:border-none ww:bg-transparent ww:p-0"
+				/>
+			)}
+			<div
+				className="ww:relative ww:overflow-auto ww:rounded-2xl ww:bg-background ww:shadow-2xl"
+				// Measured, not themeable: `width` tracks the viewport and `maxHeight`
+				// is whatever is left of it. Neither has a utility class.
+				style={{ width, maxHeight }}
+			>
+				<McpAppFrame
+					// Remount on a new view so the frame's handshake, retry counter and
+					// size latch all start clean rather than carrying the last widget's.
+					key={`${resourceEndpoint}|${widget.viewUri}`}
+					resourceUri={widget.viewUri}
+					resourceEndpoint={resourceEndpoint}
+					toolInput={widget.data}
+					toolResult={widget.result}
+					autoHeight={autoHeightFromMeta(widget.result._meta)}
+					isDark={isDark}
+					onCallTool={callTool}
+					onOpenLink={(url) => window.open(url, "_blank", "noopener")}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/chat/web/index.ts
+++ b/src/chat/web/index.ts
@@ -17,6 +17,8 @@ export type {
 	McpAppFrameProps,
 } from "./components/mcp-app-frame";
 export { McpAppFrame } from "./components/mcp-app-frame";
+export type { WebMcpOverlayProps } from "./embed/webmcp-overlay";
+export { WebMcpOverlay } from "./embed/webmcp-overlay";
 export type {
 	WidgetEvent,
 	WidgetEventName,

--- a/src/chat/web/lib/visitor-context.ts
+++ b/src/chat/web/lib/visitor-context.ts
@@ -1,6 +1,5 @@
+import { getOrCreateVisitorId } from "../../../shared/visitor-id";
 import { getOrCreateMemoryUserId } from "./memory-user-id";
-
-const VISITOR_ID_KEY = "waniwani-visitor-id";
 
 // ============================================================================
 // Types
@@ -100,158 +99,12 @@ export function detectDeviceType(ua: string): "mobile" | "tablet" | "desktop" {
 	return "desktop";
 }
 
-// ============================================================================
-// Visitor ID (opaque id, persisted in localStorage)
-// ============================================================================
-
-/**
- * A random opaque id, generated synchronously. Prefers `crypto.randomUUID`
- * and falls back to a `crypto.getRandomValues` UUIDv4 when it is missing
- * (older browsers), and finally to a non-crypto random string when the Web
- * Crypto API is entirely unavailable (e.g. a non-secure context). The value
- * is opaque, so any of these is a valid visitor id.
- */
-function randomId(): string {
-	try {
-		if (typeof crypto !== "undefined") {
-			if (typeof crypto.randomUUID === "function") {
-				return crypto.randomUUID();
-			}
-			if (typeof crypto.getRandomValues === "function") {
-				const bytes = crypto.getRandomValues(new Uint8Array(16));
-				// RFC 4122 v4 layout
-				bytes[6] = (bytes[6] & 0x0f) | 0x40;
-				bytes[8] = (bytes[8] & 0x3f) | 0x80;
-				const hex = Array.from(bytes, (b) =>
-					b.toString(16).padStart(2, "0"),
-				).join("");
-				return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
-			}
-		}
-	} catch {
-		// Fall through to the non-crypto path below.
-	}
-	return `v-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-}
-
-/**
- * Synchronously return a stable, persisted visitor id, creating one on first
- * call. Runs with no async work and no `crypto.subtle` dependency, so it never
- * races an in-flight promise and never fails on a non-secure context — callers
- * can rely on a visitor id being present on the very first event or request.
- */
-export function getOrCreateVisitorId(): string {
-	try {
-		const stored = localStorage.getItem(VISITOR_ID_KEY);
-		if (stored) {
-			return stored;
-		}
-	} catch {
-		// localStorage unavailable (private browsing, security policy) — fall
-		// through and mint a fresh id. It won't persist, but the request/event
-		// still carries a visitor id for this page load.
-	}
-
-	const id = randomId();
-
-	try {
-		localStorage.setItem(VISITOR_ID_KEY, id);
-	} catch {
-		// Ignore storage failures.
-	}
-
-	return id;
-}
-
-/**
- * Override the persisted visitor id with a caller-supplied one — typically the
- * distinct id the host site already tracks in PostHog, Amplitude, Segment, etc.
- * The value is stored under the same key as the auto-generated id, so it
- * becomes the single source of truth every later read
- * (`getOrCreateVisitorId`, `collectVisitorContext`) returns, and it is what the
- * chat sends to the server on every request. That threads it through to MCP
- * tools/flows as `context.waniwani.visitorId`, so server code can forward the
- * same id back to the analytics tool it came from.
- *
- * A blank / whitespace-only id is ignored: it returns the current id unchanged
- * so a not-yet-ready analytics id (e.g. before PostHog has bootstrapped) can
- * never wipe a good one. Returns the effective id.
- */
-export function setVisitorId(id: string): string {
-	const trimmed = typeof id === "string" ? id.trim() : "";
-	if (!trimmed) {
-		return getOrCreateVisitorId();
-	}
-
-	try {
-		localStorage.setItem(VISITOR_ID_KEY, trimmed);
-	} catch {
-		// Storage unavailable (private mode / non-secure context). The value
-		// can't persist here — consistent with getOrCreateVisitorId, which also
-		// re-mints each call in this mode. Pass the id via config in that case.
-	}
-
-	return trimmed;
-}
-
-/**
- * A visitor id to apply, or a resolver that produces one. The resolver may be
- * sync (`() => posthog.get_distinct_id()`) or async
- * (`async () => (await sdk.ready()).id`), for analytics SDKs whose id is only
- * available after they bootstrap.
- */
-export type VisitorIdInput =
-	| string
-	| (() => string | undefined | null | Promise<string | undefined | null>);
-
-function isThenable(value: unknown): value is Promise<unknown> {
-	return (
-		value != null && typeof (value as { then?: unknown }).then === "function"
-	);
-}
-
-/**
- * Resolve a {@link VisitorIdInput} and persist the result via
- * {@link setVisitorId}. A literal or sync resolver applies immediately; an
- * async resolver applies once it settles. A blank / null result, a throwing
- * resolver, and a rejected promise are all ignored so the current id is never
- * wiped. Returns a cancel function: call it (e.g. from a React effect cleanup)
- * to drop a late async result after unmount or a prop change.
- */
-export function applyVisitorId(input: VisitorIdInput | undefined): () => void {
-	let cancelled = false;
-	const cancel = () => {
-		cancelled = true;
-	};
-	if (input == null) {
-		return cancel;
-	}
-
-	let value: string | undefined | null | Promise<string | undefined | null>;
-	try {
-		value = typeof input === "function" ? input() : input;
-	} catch {
-		// A throwing resolver must never break the chat — keep the current id.
-		return cancel;
-	}
-
-	if (isThenable(value)) {
-		value.then(
-			(resolved) => {
-				if (!cancelled) {
-					setVisitorId((resolved as string | undefined | null) ?? "");
-				}
-			},
-			() => {
-				// Rejected resolver — keep the current id.
-			},
-		);
-	} else {
-		setVisitorId(value ?? "");
-	}
-
-	return cancel;
-}
+export {
+	applyVisitorId,
+	getOrCreateVisitorId,
+	setVisitorId,
+	type VisitorIdInput,
+} from "../../../shared/visitor-id";
 
 // ============================================================================
 // Main export

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -4,6 +4,35 @@
 // OSS / Free Tier (non-legacy) — recommended for all new code
 // ----------------------------------------------------------------------------
 
+// Widget/view binding, shared with the chat surface — OSS
+export type { MetaCarrier } from "../shared/view-uri";
+export {
+	autoHeightFromMeta,
+	isDisplayTool,
+	resourceUriFromMeta,
+	viewUriFor,
+} from "../shared/view-uri";
+// WebMCP — the site's tools, callable by a browsing agent on the page. OSS.
+export type {
+	WebMcpBridge,
+	WebMcpBridgeOptions,
+	WebMcpCallResponse,
+	WebMcpCallResult,
+	WebMcpContentBlock,
+	WebMcpListResponse,
+	WebMcpPageContext,
+	WebMcpRequest,
+	WebMcpTool,
+	WebMcpWidgetPayload,
+	WidgetStep,
+	WidgetStepStatus,
+} from "../webmcp";
+export {
+	createWebMcpBridge,
+	readWidgetStep,
+	rewriteForAgent,
+	supportsWebMcp,
+} from "../webmcp";
 // Flow framework — OSS
 export type {
 	AddNodeConfig,

--- a/src/shared/__tests__/view-uri.test.ts
+++ b/src/shared/__tests__/view-uri.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test";
+import {
+	autoHeightFromMeta,
+	isDisplayTool,
+	metaOf,
+	resourceUriFromMeta,
+	viewUriFor,
+} from "../view-uri";
+
+describe("resourceUriFromMeta", () => {
+	it("reads the nested MCP Apps spelling", () => {
+		expect(
+			resourceUriFromMeta({ ui: { resourceUri: "ui://views/a.html" } }),
+		).toBe("ui://views/a.html");
+	});
+
+	it("reads the flat MCP Apps spelling", () => {
+		expect(resourceUriFromMeta({ "ui/resourceUri": "ui://views/b.html" })).toBe(
+			"ui://views/b.html",
+		);
+	});
+
+	it("reads the OpenAI Apps SDK spelling", () => {
+		expect(
+			resourceUriFromMeta({ "openai/outputTemplate": "ui://views/c.html" }),
+		).toBe("ui://views/c.html");
+	});
+
+	it("prefers nested over flat over openai when a server emits several", () => {
+		expect(
+			resourceUriFromMeta({
+				ui: { resourceUri: "ui://nested" },
+				"ui/resourceUri": "ui://flat",
+				"openai/outputTemplate": "ui://openai",
+			}),
+		).toBe("ui://nested");
+		expect(
+			resourceUriFromMeta({
+				"ui/resourceUri": "ui://flat",
+				"openai/outputTemplate": "ui://openai",
+			}),
+		).toBe("ui://flat");
+	});
+
+	it("ignores empty strings rather than returning them", () => {
+		expect(
+			resourceUriFromMeta({
+				ui: { resourceUri: "" },
+				"ui/resourceUri": "ui://flat",
+			}),
+		).toBe("ui://flat");
+	});
+
+	it("ignores non-string values", () => {
+		expect(resourceUriFromMeta({ ui: { resourceUri: 42 } })).toBeUndefined();
+		expect(resourceUriFromMeta({ "ui/resourceUri": null })).toBeUndefined();
+	});
+
+	it("survives a non-object ui key", () => {
+		expect(resourceUriFromMeta({ ui: "nope" })).toBeUndefined();
+		expect(resourceUriFromMeta({ ui: null })).toBeUndefined();
+	});
+
+	it("returns undefined for absent meta", () => {
+		expect(resourceUriFromMeta(undefined)).toBeUndefined();
+		expect(resourceUriFromMeta({})).toBeUndefined();
+	});
+});
+
+describe("autoHeightFromMeta", () => {
+	it("is true only for an explicit boolean true", () => {
+		expect(autoHeightFromMeta({ ui: { autoHeight: true } })).toBe(true);
+		expect(autoHeightFromMeta({ ui: { autoHeight: "true" } })).toBe(false);
+		expect(autoHeightFromMeta({ ui: {} })).toBe(false);
+		expect(autoHeightFromMeta(undefined)).toBe(false);
+	});
+});
+
+describe("metaOf", () => {
+	it("pulls _meta off a result", () => {
+		expect(metaOf({ _meta: { a: 1 } })).toEqual({ a: 1 });
+	});
+
+	it("returns undefined for anything without one", () => {
+		expect(metaOf(undefined)).toBeUndefined();
+		expect(metaOf(null)).toBeUndefined();
+		expect(metaOf("text")).toBeUndefined();
+		expect(metaOf({})).toBeUndefined();
+		expect(metaOf({ _meta: "nope" })).toBeUndefined();
+	});
+});
+
+describe("viewUriFor / isDisplayTool", () => {
+	it("reads the binding off a tool definition", () => {
+		const tool = { _meta: { ui: { resourceUri: "ui://views/book.html?v=9" } } };
+		expect(viewUriFor(tool)).toBe("ui://views/book.html?v=9");
+		expect(isDisplayTool(tool)).toBe(true);
+	});
+
+	it("treats a tool with no view as an ordinary tool", () => {
+		expect(viewUriFor({ _meta: { other: true } })).toBeUndefined();
+		expect(isDisplayTool({ _meta: { other: true } })).toBe(false);
+		expect(isDisplayTool({})).toBe(false);
+		expect(isDisplayTool(undefined)).toBe(false);
+	});
+});

--- a/src/shared/view-uri.ts
+++ b/src/shared/view-uri.ts
@@ -1,0 +1,99 @@
+/**
+ * Reading a widget's view binding off MCP `_meta`.
+ *
+ * Kept in `shared/` because three surfaces ask the same question and none of
+ * them should own the answer: the chat resolves a tool part's view before
+ * rendering it, the WebMCP endpoint resolves a display tool's view before
+ * handing it to the page, and both have to agree or a widget renders in one
+ * place and not the other.
+ *
+ * The three spellings below are not alternatives to choose between. They are
+ * what three host generations actually emit, and a server built on any of them
+ * is a server we have to render.
+ */
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	if (typeof value !== "object" || value === null) {
+		return undefined;
+	}
+	return value as Record<string, unknown>;
+}
+
+function uiObject(
+	meta: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	return asRecord(meta?.ui);
+}
+
+/** Anything carrying MCP `_meta`: a tool definition, a tool result, a resource. */
+export type MetaCarrier = {
+	_meta?: Record<string, unknown>;
+};
+
+/**
+ * The view a `_meta` binds to, checking all three shapes in priority order:
+ *
+ * 1. `_meta.ui.resourceUri` — MCP Apps, nested (skybridge, ext-apps)
+ * 2. `_meta["ui/resourceUri"]` — MCP Apps, flat (earlier drafts, still in the wild)
+ * 3. `_meta["openai/outputTemplate"]` — OpenAI Apps SDK
+ *
+ * Order is priority, not preference: a server emitting more than one emits them
+ * as aliases of the same view, and the nested form is the one the current spec
+ * defines.
+ */
+export function resourceUriFromMeta(
+	meta: Record<string, unknown> | undefined,
+): string | undefined {
+	if (!meta) {
+		return undefined;
+	}
+	const nested = uiObject(meta)?.resourceUri;
+	if (typeof nested === "string" && nested.length > 0) {
+		return nested;
+	}
+	const flat = meta["ui/resourceUri"];
+	if (typeof flat === "string" && flat.length > 0) {
+		return flat;
+	}
+	const openai = meta["openai/outputTemplate"];
+	if (typeof openai === "string" && openai.length > 0) {
+		return openai;
+	}
+	return undefined;
+}
+
+/** Whether the host should size the frame from the view's content. */
+export function autoHeightFromMeta(
+	meta: Record<string, unknown> | undefined,
+): boolean {
+	return uiObject(meta)?.autoHeight === true;
+}
+
+/** The `_meta` on a tool result, if it has one. */
+export function metaOf(value: unknown): Record<string, unknown> | undefined {
+	return asRecord(asRecord(value)?._meta);
+}
+
+/**
+ * The view a tool renders, read from its definition.
+ *
+ * Definition rather than result on purpose. A spec-compliant server binds the
+ * view on the tool, so a result carries the binding only by accident, and
+ * reading the result first means a tool whose view is declared correctly looks
+ * like a tool with no view at all.
+ */
+export function viewUriFor(tool: MetaCarrier | undefined): string | undefined {
+	return resourceUriFromMeta(tool?._meta);
+}
+
+/**
+ * Whether a tool exists to render something rather than to be reasoned about.
+ *
+ * The distinction matters wherever a tool list crosses a boundary. A display
+ * tool advertised to a browsing agent is a tool it will try to call to make a
+ * widget appear, on a surface with no widget host in it, which burns a turn and
+ * strands the conversation on a render nobody performs.
+ */
+export function isDisplayTool(tool: MetaCarrier | undefined): boolean {
+	return viewUriFor(tool) !== undefined;
+}

--- a/src/shared/visitor-id.ts
+++ b/src/shared/visitor-id.ts
@@ -1,0 +1,168 @@
+/**
+ * The persistent, per-origin id for an anonymous visitor.
+ *
+ * Kept in `shared/` because more than one browser surface needs the same value
+ * out of the same storage key. The chat sends it on every request; the WebMCP
+ * bridge sends it on every tool call a browsing agent makes. A flow started in
+ * one and continued in the other is the same person only if both read this.
+ *
+ * Deliberately separate from any session id. This value survives tab closes and
+ * days off, which is what makes it identity — and exactly what makes it wrong
+ * as a key for conversational state. See {@link getOrCreateVisitorId}.
+ */
+
+const VISITOR_ID_KEY = "waniwani-visitor-id";
+
+/**
+ * A random opaque id, generated synchronously. Prefers `crypto.randomUUID`
+ * and falls back to a `crypto.getRandomValues` UUIDv4 when it is missing
+ * (older browsers), and finally to a non-crypto random string when the Web
+ * Crypto API is entirely unavailable (e.g. a non-secure context). The value
+ * is opaque, so any of these is a valid visitor id.
+ */
+function randomId(): string {
+	try {
+		if (typeof crypto !== "undefined") {
+			if (typeof crypto.randomUUID === "function") {
+				return crypto.randomUUID();
+			}
+			if (typeof crypto.getRandomValues === "function") {
+				const bytes = crypto.getRandomValues(new Uint8Array(16));
+				// RFC 4122 v4 layout
+				bytes[6] = (bytes[6] & 0x0f) | 0x40;
+				bytes[8] = (bytes[8] & 0x3f) | 0x80;
+				const hex = Array.from(bytes, (b) =>
+					b.toString(16).padStart(2, "0"),
+				).join("");
+				return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+			}
+		}
+	} catch {
+		// Fall through to the non-crypto path below.
+	}
+	return `v-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Synchronously return a stable, persisted visitor id, creating one on first
+ * call. Runs with no async work and no `crypto.subtle` dependency, so it never
+ * races an in-flight promise and never fails on a non-secure context — callers
+ * can rely on a visitor id being present on the very first event or request.
+ *
+ * Not a session id, and not usable as one. This value is stable across days, so
+ * keying conversational state on it resumes a flow abandoned last week in the
+ * middle of the question it was abandoned on. Pair it with a tab-scoped session
+ * id and send both.
+ */
+export function getOrCreateVisitorId(): string {
+	try {
+		const stored = localStorage.getItem(VISITOR_ID_KEY);
+		if (stored) {
+			return stored;
+		}
+	} catch {
+		// localStorage unavailable (private browsing, security policy) — fall
+		// through and mint a fresh id. It won't persist, but the request/event
+		// still carries a visitor id for this page load.
+	}
+
+	const id = randomId();
+
+	try {
+		localStorage.setItem(VISITOR_ID_KEY, id);
+	} catch {
+		// Ignore storage failures.
+	}
+
+	return id;
+}
+
+/**
+ * Override the persisted visitor id with a caller-supplied one — typically the
+ * distinct id the host site already tracks in PostHog, Amplitude, Segment, etc.
+ * The value is stored under the same key as the auto-generated id, so it
+ * becomes the single source of truth every later read
+ * (`getOrCreateVisitorId`, `collectVisitorContext`) returns, and it is what the
+ * chat sends to the server on every request. That threads it through to MCP
+ * tools/flows as `context.waniwani.visitorId`, so server code can forward the
+ * same id back to the analytics tool it came from.
+ *
+ * A blank / whitespace-only id is ignored: it returns the current id unchanged
+ * so a not-yet-ready analytics id (e.g. before PostHog has bootstrapped) can
+ * never wipe a good one. Returns the effective id.
+ */
+export function setVisitorId(id: string): string {
+	const trimmed = typeof id === "string" ? id.trim() : "";
+	if (!trimmed) {
+		return getOrCreateVisitorId();
+	}
+
+	try {
+		localStorage.setItem(VISITOR_ID_KEY, trimmed);
+	} catch {
+		// Storage unavailable (private mode / non-secure context). The value
+		// can't persist here — consistent with getOrCreateVisitorId, which also
+		// re-mints each call in this mode. Pass the id via config in that case.
+	}
+
+	return trimmed;
+}
+
+/**
+ * A visitor id to apply, or a resolver that produces one. The resolver may be
+ * sync (`() => posthog.get_distinct_id()`) or async
+ * (`async () => (await sdk.ready()).id`), for analytics SDKs whose id is only
+ * available after they bootstrap.
+ */
+export type VisitorIdInput =
+	| string
+	| (() => string | undefined | null | Promise<string | undefined | null>);
+
+function isThenable(value: unknown): value is Promise<unknown> {
+	return (
+		value != null && typeof (value as { then?: unknown }).then === "function"
+	);
+}
+
+/**
+ * Resolve a {@link VisitorIdInput} and persist the result via
+ * {@link setVisitorId}. A literal or sync resolver applies immediately; an
+ * async resolver applies once it settles. A blank / null result, a throwing
+ * resolver, and a rejected promise are all ignored so the current id is never
+ * wiped. Returns a cancel function: call it (e.g. from a React effect cleanup)
+ * to drop a late async result after unmount or a prop change.
+ */
+export function applyVisitorId(input: VisitorIdInput | undefined): () => void {
+	let cancelled = false;
+	const cancel = () => {
+		cancelled = true;
+	};
+	if (input == null) {
+		return cancel;
+	}
+
+	let value: string | undefined | null | Promise<string | undefined | null>;
+	try {
+		value = typeof input === "function" ? input() : input;
+	} catch {
+		// A throwing resolver must never break the chat — keep the current id.
+		return cancel;
+	}
+
+	if (isThenable(value)) {
+		value.then(
+			(resolved) => {
+				if (!cancelled) {
+					setVisitorId((resolved as string | undefined | null) ?? "");
+				}
+			},
+			() => {
+				// Rejected resolver — keep the current id.
+			},
+		);
+	} else {
+		setVisitorId(value ?? "");
+	}
+
+	return cancel;
+}

--- a/src/webmcp/@types.ts
+++ b/src/webmcp/@types.ts
@@ -1,0 +1,138 @@
+/**
+ * The shapes crossing the WebMCP boundary.
+ *
+ * Structural rather than imported from `@modelcontextprotocol/sdk`, because
+ * everything here is also read by the browser bridge, and the MCP SDK is an
+ * optional peer dependency that has no business in a page bundle. What the
+ * server sends and what the page reads is JSON either way.
+ */
+
+/**
+ * One MCP content block. `type` is the discriminator every block carries; the
+ * index signature keeps the rest of whichever block it is, since nothing on
+ * this path reads them and re-deriving the union would only restate a schema
+ * the server already validated on the way out.
+ */
+export type WebMcpContentBlock = {
+	type: string;
+	text?: string;
+	[key: string]: unknown;
+};
+
+/** A tool as `tools/list` describes it. */
+export type WebMcpTool = {
+	name: string;
+	description?: string;
+	inputSchema?: Record<string, unknown>;
+	annotations?: Record<string, unknown>;
+	_meta?: Record<string, unknown>;
+};
+
+/** A tool result as `tools/call` returns it. */
+export type WebMcpCallResult = {
+	content?: WebMcpContentBlock[];
+	structuredContent?: Record<string, unknown>;
+	isError?: boolean;
+	_meta?: Record<string, unknown>;
+};
+
+/**
+ * Everything the page needs to mount a widget itself.
+ *
+ * Assembled server-side because none of it is derivable on the page: the view
+ * URI carries a content hash that moves every deploy, and the display tool's
+ * result is what the view reads its own configuration from.
+ */
+export type WebMcpWidgetPayload = {
+	/**
+	 * The `ui://` the view was resolved from.
+	 *
+	 * Carries a content hash that moves on every deploy, which is why this is
+	 * resolved server-side per call and why nothing on the page can cache it.
+	 *
+	 * The only half of the view the page is told. Where to fetch it from is the
+	 * resource endpoint the page already derived from its token, the same one
+	 * the chat's own widget iframes use.
+	 */
+	viewUri: string;
+	/** Display tool the view belongs to. */
+	tool: string;
+	/** Props, delivered to the view as `ui/notifications/tool-input`. */
+	data: Record<string, unknown>;
+	/** The display tool's own result, delivered as `ui/notifications/tool-result`. */
+	result: {
+		content: WebMcpContentBlock[];
+		structuredContent?: Record<string, unknown>;
+		_meta?: Record<string, unknown>;
+	};
+	/** Whether the flow is waiting on the visitor before it can advance. */
+	interactive: boolean;
+	/**
+	 * Set by the preview endpoint. A real widget step is a flow waiting on the
+	 * visitor and has no way out; a preview is something someone opened to look
+	 * at, so the host can give it one.
+	 */
+	preview?: boolean;
+};
+
+/** What every page-facing request carries, whatever it is asking for. */
+type WebMcpRequestBase = {
+	/**
+	 * Tab-scoped, and the key the flow engine stores its state under.
+	 *
+	 * Must be stable for the tab and must not outlive it. A value that changes
+	 * between calls silently restarts every flow; one that persists across days
+	 * resumes a flow abandoned last week mid-question.
+	 */
+	sessionId: string;
+	/**
+	 * The visitor's persistent id. Identity rather than state, and what lets a
+	 * flow started here and a conversation continued in the chat bubble belong
+	 * to one person.
+	 */
+	visitorId?: string;
+	/**
+	 * The channel this page's embed belongs to.
+	 *
+	 * Sent because ingest rejects events it cannot attribute to a channel, and a
+	 * token-only embed learns its channel from `/config` rather than from its
+	 * own markup. Without it a tool call is attributed to nothing and the events
+	 * behind it are dropped.
+	 */
+	channelId?: string;
+	/** Where the visitor was standing when the agent called. */
+	page?: WebMcpPageContext;
+};
+
+/**
+ * `POST` body for the page-facing tools endpoint.
+ *
+ * The bridge builds exactly this, so a server implementing the other end is
+ * type-checked against what actually arrives rather than against a description
+ * of it.
+ */
+export type WebMcpRequest =
+	| (WebMcpRequestBase & { action: "list" })
+	| (WebMcpRequestBase & {
+			action: "call";
+			name: string;
+			arguments?: Record<string, unknown>;
+	  });
+
+/** Where the visitor was standing when the agent called. */
+export type WebMcpPageContext = {
+	url?: string;
+	title?: string;
+};
+
+export type WebMcpListResponse = {
+	tools: WebMcpTool[];
+};
+
+export type WebMcpCallResponse = {
+	content: WebMcpContentBlock[];
+	structuredContent?: Record<string, unknown>;
+	isError?: boolean;
+	/** Present and non-null only when the call produced a resolvable widget step. */
+	widget: WebMcpWidgetPayload | null;
+};

--- a/src/webmcp/__tests__/bridge.test.ts
+++ b/src/webmcp/__tests__/bridge.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+
+// ---------------------------------------------------------------------------
+// The bridge only needs `document`/`navigator` to probe for `modelContext`, a
+// `window` to hang the pagehide listener on, and `fetch`. No React, no MCP SDK.
+// ---------------------------------------------------------------------------
+
+const win = new Window({ url: "https://shop.example/pricing" });
+for (const key of ["document", "navigator", "Event", "CustomEvent"] as const) {
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any)[key] = (win as any)[key];
+}
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).window = win;
+// biome-ignore lint/suspicious/noExplicitAny: test setup
+(globalThis as any).location = win.location;
+
+const { createWebMcpBridge, supportsWebMcp } = await import("../bridge");
+
+type Registered = {
+	name: string;
+	description: string;
+	inputSchema?: Record<string, unknown>;
+	annotations?: Record<string, unknown>;
+	execute: (
+		args: Record<string, unknown>,
+		options?: { signal?: AbortSignal },
+	) => Promise<{ content: Array<Record<string, unknown>> }>;
+};
+
+// Bun runs every test file in one process, so a `globalThis.fetch` left
+// installed here answers the tracking suites' requests too. Captured once and
+// put back after each test.
+const REAL_FETCH = globalThis.fetch;
+
+const ENDPOINT = "https://acme.mcp.example/api/webmcp/tools";
+const SILENT = { error: () => {}, info: () => {} } as unknown as Console;
+
+/** Stand in for `document.modelContext`, recording what the bridge registers. */
+function installModelContext() {
+	const registered: Registered[] = [];
+	const signals: Array<AbortSignal | undefined> = [];
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any).document.modelContext = {
+		registerTool: (tool: Registered, options?: { signal?: AbortSignal }) => {
+			registered.push(tool);
+			signals.push(options?.signal);
+			return Promise.resolve();
+		},
+	};
+	return { registered, signals };
+}
+
+/** Answers `list` with `tools`, and every `call` with the next queued result. */
+function installFetch(tools: unknown[], callResults: unknown[] = []) {
+	const calls: Array<Record<string, unknown>> = [];
+	const queue = [...callResults];
+	const fetchMock = mock(async (..._args: unknown[]) => {
+		const init = _args[1] as RequestInit | undefined;
+		const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+		calls.push(body);
+		const payload = body.action === "list" ? { tools } : queue.shift();
+		return {
+			ok: true,
+			status: 200,
+			json: async () => payload,
+		} as unknown as Response;
+	});
+	// biome-ignore lint/suspicious/noExplicitAny: test setup
+	(globalThis as any).fetch = fetchMock;
+	return { calls, fetchMock };
+}
+
+const SEARCH_TOOL = {
+	name: "search",
+	description: "Search the docs",
+	inputSchema: { type: "object", properties: { q: { type: "string" } } },
+	annotations: { readOnlyHint: true },
+};
+
+beforeEach(() => {
+	// biome-ignore lint/suspicious/noExplicitAny: test cleanup
+	delete (globalThis as any).document.modelContext;
+	// biome-ignore lint/suspicious/noExplicitAny: test cleanup
+	delete (globalThis as any).navigator.modelContext;
+});
+
+afterEach(() => {
+	// biome-ignore lint/suspicious/noExplicitAny: test cleanup
+	delete (globalThis as any).document.modelContext;
+	globalThis.fetch = REAL_FETCH;
+});
+
+describe("supportsWebMcp", () => {
+	test("false on a browser with no modelContext", () => {
+		expect(supportsWebMcp()).toBe(false);
+	});
+
+	test("true when it hangs off document", () => {
+		installModelContext();
+		expect(supportsWebMcp()).toBe(true);
+	});
+
+	// The getter moved from Navigator to Document mid-spec, so both are live.
+	test("true when it hangs off navigator", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test setup
+		(globalThis as any).navigator.modelContext = { registerTool: () => {} };
+		expect(supportsWebMcp()).toBe(true);
+	});
+
+	test("false for an object that is not a model context", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test setup
+		(globalThis as any).document.modelContext = { somethingElse: true };
+		expect(supportsWebMcp()).toBe(false);
+	});
+});
+
+describe("createWebMcpBridge", () => {
+	test("does nothing on a browser with no modelContext", async () => {
+		const { fetchMock } = installFetch([SEARCH_TOOL]);
+		const bridge = await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "s1",
+			logger: SILENT,
+		});
+		expect(bridge).toBeNull();
+		// Not even the list call: an ordinary visit costs no network.
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	test("registers every advertised tool with its schema and annotations", async () => {
+		const { registered } = installModelContext();
+		installFetch([SEARCH_TOOL, { name: "book_demo", description: "Book" }]);
+
+		const bridge = await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "s1",
+			logger: SILENT,
+		});
+
+		expect(registered.map((t) => t.name)).toEqual(["search", "book_demo"]);
+		expect(registered[0]?.inputSchema).toEqual(SEARCH_TOOL.inputSchema);
+		expect(registered[0]?.annotations).toEqual(SEARCH_TOOL.annotations);
+		expect(bridge?.tools.map((t) => t.name)).toEqual(["search", "book_demo"]);
+	});
+
+	test("sends identity, channel and page on every request", async () => {
+		installModelContext();
+		const { calls } = installFetch(
+			[SEARCH_TOOL],
+			[{ content: [], widget: null }],
+		);
+
+		await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "tab-session",
+			visitorId: "visitor-42",
+			channelId: "ch-1",
+			logger: SILENT,
+		});
+
+		expect(calls[0]).toMatchObject({
+			action: "list",
+			sessionId: "tab-session",
+			visitorId: "visitor-42",
+			channelId: "ch-1",
+			page: { url: "https://shop.example/pricing" },
+		});
+	});
+
+	// Ingest drops what it cannot attribute to a channel, so this riding on the
+	// call and not only on the list is the difference between a conversion that
+	// lands and one that vanishes.
+	test("carries the channel on a call, not only on the list", async () => {
+		const { registered } = installModelContext();
+		const { calls } = installFetch(
+			[SEARCH_TOOL],
+			[{ content: [], widget: null }],
+		);
+
+		await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "s1",
+			channelId: "ch-1",
+			logger: SILENT,
+		});
+		await registered[0]?.execute({});
+
+		expect(calls[1]).toMatchObject({ action: "call", channelId: "ch-1" });
+	});
+
+	test("authenticates with the headers it was given", async () => {
+		installModelContext();
+		let seen: HeadersInit | undefined;
+		// biome-ignore lint/suspicious/noExplicitAny: test setup
+		(globalThis as any).fetch = mock(async (..._args: unknown[]) => {
+			const init = _args[1] as RequestInit | undefined;
+			seen = init?.headers;
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({ tools: [] }),
+			} as unknown as Response;
+		});
+
+		await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "s1",
+			headers: { Authorization: "Bearer wwp_abc" },
+			logger: SILENT,
+		});
+
+		expect(seen).toMatchObject({
+			"content-type": "application/json",
+			Authorization: "Bearer wwp_abc",
+		});
+	});
+
+	test("a call forwards arguments and returns the content", async () => {
+		const { registered } = installModelContext();
+		const { calls } = installFetch(
+			[SEARCH_TOOL],
+			[{ content: [{ type: "text", text: "found it" }], widget: null }],
+		);
+
+		await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "tab-session",
+			visitorId: "visitor-42",
+			logger: SILENT,
+		});
+
+		const result = await registered[0]?.execute({ q: "pricing" });
+		expect(result).toEqual({ content: [{ type: "text", text: "found it" }] });
+		expect(calls[1]).toMatchObject({
+			action: "call",
+			name: "search",
+			arguments: { q: "pricing" },
+			sessionId: "tab-session",
+			visitorId: "visitor-42",
+		});
+	});
+
+	test("hands a resolved widget to the host and still answers the agent", async () => {
+		const { registered } = installModelContext();
+		const widget = {
+			viewUri: "ui://views/ext-apps/book.html?v=abc",
+			tool: "show-book-call",
+			data: {},
+			result: { content: [] },
+			interactive: true,
+		};
+		installFetch(
+			[SEARCH_TOOL],
+			[{ content: [{ type: "text", text: "{}" }], widget }],
+		);
+
+		const seen: unknown[] = [];
+		await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "s1",
+			onWidget: (payload) => seen.push(payload),
+			logger: SILENT,
+		});
+
+		const result = await registered[0]?.execute({});
+		expect(seen).toEqual([widget]);
+		expect(result?.content).toEqual([{ type: "text", text: "{}" }]);
+	});
+
+	// A page with no widget host is a supported deployment, not a broken one.
+	test("survives having no onWidget", async () => {
+		const { registered } = installModelContext();
+		installFetch(
+			[SEARCH_TOOL],
+			[
+				{
+					content: [],
+					widget: { viewUri: "ui://x" },
+				},
+			],
+		);
+
+		await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "s1",
+			logger: SILENT,
+		});
+		expect(await registered[0]?.execute({})).toEqual({ content: [] });
+	});
+
+	test("a tool the browser refuses does not take the others with it", async () => {
+		const registered: Registered[] = [];
+		// biome-ignore lint/suspicious/noExplicitAny: test setup
+		(globalThis as any).document.modelContext = {
+			registerTool: (tool: Registered) => {
+				if (tool.name === "broken") {
+					return Promise.reject(new Error("refused"));
+				}
+				registered.push(tool);
+				return Promise.resolve();
+			},
+		};
+		installFetch([
+			{ name: "broken", description: "" },
+			SEARCH_TOOL,
+			{ name: "book_demo", description: "" },
+		]);
+
+		const bridge = await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "s1",
+			logger: SILENT,
+		});
+
+		expect(registered.map((t) => t.name)).toEqual(["search", "book_demo"]);
+		expect(bridge?.tools.map((t) => t.name)).toEqual(["search", "book_demo"]);
+	});
+
+	test("a failed list registers nothing rather than throwing", async () => {
+		installModelContext();
+		// biome-ignore lint/suspicious/noExplicitAny: test setup
+		(globalThis as any).fetch = mock(
+			async () => ({ ok: false, status: 503 }) as unknown as Response,
+		);
+
+		expect(
+			await createWebMcpBridge({
+				endpoint: ENDPOINT,
+				sessionId: "s1",
+				logger: SILENT,
+			}),
+		).toBeNull();
+	});
+
+	test("registration is scoped to a signal, and dispose aborts it", async () => {
+		const { signals } = installModelContext();
+		installFetch([SEARCH_TOOL]);
+
+		const bridge = await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "s1",
+			logger: SILENT,
+		});
+
+		const signal = signals[0];
+		expect(signal).toBeDefined();
+		expect(signal?.aborted).toBe(false);
+		bridge?.dispose();
+		expect(signal?.aborted).toBe(true);
+		// Idempotent: a host that disposes and then unloads must not throw.
+		bridge?.dispose();
+	});
+
+	test("the agent's abort reaches the request", async () => {
+		const { registered } = installModelContext();
+		let seenSignal: AbortSignal | undefined;
+		// biome-ignore lint/suspicious/noExplicitAny: test setup
+		(globalThis as any).fetch = mock(async (..._args: unknown[]) => {
+			const init = _args[1] as
+				| (RequestInit & { signal?: AbortSignal })
+				| undefined;
+			const body = JSON.parse(String(init?.body)) as { action: string };
+			if (body.action === "call") {
+				seenSignal = init?.signal;
+			}
+			return {
+				ok: true,
+				status: 200,
+				json: async () =>
+					body.action === "list"
+						? { tools: [SEARCH_TOOL] }
+						: { content: [], widget: null },
+			} as unknown as Response;
+		});
+
+		await createWebMcpBridge({
+			endpoint: ENDPOINT,
+			sessionId: "s1",
+			logger: SILENT,
+		});
+
+		const controller = new AbortController();
+		await registered[0]?.execute({}, { signal: controller.signal });
+		expect(seenSignal).toBe(controller.signal);
+	});
+});

--- a/src/webmcp/__tests__/widget-step.test.ts
+++ b/src/webmcp/__tests__/widget-step.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "bun:test";
+import type { WebMcpCallResult } from "../@types";
+import { readWidgetStep, rewriteForAgent } from "../widget-step";
+
+/** A flow tool result, shaped the way the engine actually emits one. */
+function flowResult(payload: Record<string, unknown>): WebMcpCallResult {
+	return { content: [{ type: "text", text: JSON.stringify(payload) }] };
+}
+
+const WIDGET_PAYLOAD = {
+	status: "widget",
+	tool: "show-book-call",
+	data: { email: "a@b.c" },
+	description:
+		"IMPORTANT: You MUST now call the show-book-call tool to display the widget. Do NOT skip this step",
+	interactive: true,
+	sessionId: "flow-session-1",
+};
+
+describe("readWidgetStep", () => {
+	it("reads a widget step", () => {
+		const step = readWidgetStep(flowResult(WIDGET_PAYLOAD));
+		expect(step).not.toBeNull();
+		expect(step?.tool).toBe("show-book-call");
+		expect(step?.data).toEqual({ email: "a@b.c" });
+		expect(step?.interactive).toBe(true);
+	});
+
+	it("treats an unset interactive as display-only", () => {
+		const step = readWidgetStep(
+			flowResult({ status: "widget", tool: "show-card" }),
+		);
+		expect(step?.interactive).toBe(false);
+		expect(step?.data).toEqual({});
+	});
+
+	it("treats a non-boolean interactive as display-only", () => {
+		const step = readWidgetStep(
+			flowResult({ status: "widget", tool: "show-card", interactive: "yes" }),
+		);
+		expect(step?.interactive).toBe(false);
+	});
+
+	it("ignores a data that is not an object", () => {
+		expect(
+			readWidgetStep(flowResult({ status: "widget", tool: "t", data: [1, 2] }))
+				?.data,
+		).toEqual({});
+		expect(
+			readWidgetStep(flowResult({ status: "widget", tool: "t", data: "x" }))
+				?.data,
+		).toEqual({});
+	});
+
+	it("passes every other flow status through", () => {
+		for (const status of ["interrupt", "complete", "error"]) {
+			expect(readWidgetStep(flowResult({ status }))).toBeNull();
+		}
+	});
+
+	it("passes an ordinary tool result through", () => {
+		expect(
+			readWidgetStep({ content: [{ type: "text", text: "just some prose" }] }),
+		).toBeNull();
+		expect(
+			readWidgetStep({ content: [{ type: "text", text: "[1,2,3]" }] }),
+		).toBeNull();
+		expect(
+			readWidgetStep({ content: [{ type: "image", data: "…" }] }),
+		).toBeNull();
+		expect(readWidgetStep({ content: [] })).toBeNull();
+		expect(readWidgetStep({})).toBeNull();
+	});
+
+	it("requires a tool to call", () => {
+		expect(readWidgetStep(flowResult({ status: "widget" }))).toBeNull();
+		expect(
+			readWidgetStep(flowResult({ status: "widget", tool: 7 })),
+		).toBeNull();
+	});
+});
+
+describe("rewriteForAgent", () => {
+	const step = readWidgetStep(flowResult(WIDGET_PAYLOAD));
+	if (!step) {
+		throw new Error("fixture should parse");
+	}
+
+	it("reports widget_shown and tells an interactive step to wait", () => {
+		const out = rewriteForAgent(step, true);
+		expect(out.status).toBe("widget_shown");
+		expect(out.instructions).toContain("wait for the user");
+	});
+
+	it("tells a display-only step to continue", () => {
+		const out = rewriteForAgent({ ...step, interactive: false }, true);
+		expect(out.status).toBe("widget_shown");
+		expect(out.instructions).toContain('action "continue"');
+		expect(out.instructions).not.toContain("wait for the user");
+	});
+
+	it("falls back to carrying the step in words", () => {
+		const out = rewriteForAgent(step, false);
+		expect(out.status).toBe("widget_unavailable");
+		expect(out.instructions).toContain("Carry the step in words");
+	});
+
+	// Both name a display tool that is not advertised on this surface. Leaving
+	// either in place is an instruction to call something that cannot be called,
+	// and the engine's `description` says exactly that in capitals.
+	it("strips both references to the display tool", () => {
+		for (const rendered of [true, false]) {
+			const out = rewriteForAgent(step, rendered);
+			expect(out.tool).toBeUndefined();
+			expect(out.description).toBeUndefined();
+			expect(JSON.stringify(out)).not.toContain("show-book-call");
+		}
+	});
+
+	it("carries the rest of the payload through untouched", () => {
+		const out = rewriteForAgent(step, true);
+		expect(out.sessionId).toBe("flow-session-1");
+		expect(out.data).toEqual({ email: "a@b.c" });
+	});
+
+	// The engine grows fields on the widget payload (`intro` arrived in 0.20.1).
+	// Anything it adds has to reach the agent, because the protocol may require
+	// the agent to echo it back.
+	it("carries fields the engine adds later", () => {
+		const withIntro = readWidgetStep(
+			flowResult({ ...WIDGET_PAYLOAD, intro: { text: "hi" }, field: "slot" }),
+		);
+		const out = rewriteForAgent(
+			withIntro as NonNullable<typeof withIntro>,
+			true,
+		);
+		expect(out.intro).toEqual({ text: "hi" });
+		expect(out.field).toBe("slot");
+	});
+});

--- a/src/webmcp/bridge.ts
+++ b/src/webmcp/bridge.ts
@@ -1,0 +1,262 @@
+/**
+ * The WebMCP bridge.
+ *
+ * A browsing agent standing on a page never speaks to the MCP server. It speaks
+ * to the page, through `document.modelContext`, and this is what puts the
+ * server's tools there. Every `execute()` the agent calls lands on the endpoint
+ * below, which stamps attribution server-side and answers.
+ *
+ * Nothing here discovers its own configuration. The endpoint, both ids, and the
+ * widget callback are arguments, because there are two callers with two
+ * different ways of knowing them: the chat embed reads them from its remote
+ * config, and the standalone loader derives them from its own script tag.
+ * Sniffing `document.currentScript` inside a bundle that may be loaded twenty
+ * modules deep finds the wrong script or none.
+ */
+
+import type {
+	WebMcpCallResponse,
+	WebMcpContentBlock,
+	WebMcpListResponse,
+	WebMcpPageContext,
+	WebMcpRequest,
+	WebMcpTool,
+	WebMcpWidgetPayload,
+} from "./@types";
+
+/**
+ * The slice of the WebMCP browser API this uses.
+ *
+ * Declared structurally rather than pulled from a types package: the API is
+ * still moving (the getter migrated from `Navigator` to `Document` in
+ * webmcp#173, which is why both are probed below), and a dependency that
+ * disagrees with the browser is worse than four lines here.
+ */
+type ModelContext = {
+	registerTool: (
+		descriptor: {
+			name: string;
+			description: string;
+			inputSchema?: Record<string, unknown>;
+			annotations?: Record<string, unknown>;
+			execute: (
+				args: Record<string, unknown>,
+				options?: { signal?: AbortSignal },
+			) => Promise<{ content: WebMcpContentBlock[] }>;
+		},
+		options?: { signal?: AbortSignal },
+	) => Promise<unknown> | unknown;
+};
+
+export type WebMcpBridgeOptions = {
+	/** Absolute URL of the server's page-facing tools endpoint. */
+	endpoint: string;
+	/**
+	 * Extra request headers, merged over `content-type`.
+	 *
+	 * The hosted API authenticates with `Authorization: Bearer <public token>`
+	 * here, the same as every other call the embed makes. A self-hosted server
+	 * reached directly needs none.
+	 */
+	headers?: Record<string, string>;
+	/**
+	 * Tab-scoped id, and the key the flow engine stores its state under.
+	 *
+	 * Must be stable for the tab and must not outlive it. A value that changes
+	 * between calls silently restarts every flow; a value that persists across
+	 * days resumes a flow abandoned last week mid-question.
+	 */
+	sessionId: string;
+	/**
+	 * The visitor's persistent id, from `shared/visitor-id`.
+	 *
+	 * Identity rather than state. Sending it is what lets a flow started here
+	 * and a conversation continued in the chat bubble belong to one person.
+	 */
+	visitorId?: string;
+	/**
+	 * The channel this embed belongs to, from the script tag or `/config`.
+	 *
+	 * Ingest drops events it cannot attribute to a channel, so a tool call sent
+	 * without this produces conversions nobody can see.
+	 */
+	channelId?: string;
+	/**
+	 * Called when a tool call resolves to a widget the page should mount.
+	 *
+	 * Optional, and the surface works without it: everything the visitor needs
+	 * is also in the text the agent receives. A page with no host gets a flow
+	 * carried in words.
+	 */
+	onWidget?: (widget: WebMcpWidgetPayload) => void;
+	/** Defaults to `console`. */
+	logger?: Pick<Console, "error" | "info">;
+};
+
+/** Live for as long as the bridge is registered. */
+export type WebMcpBridge = {
+	/** Tools successfully registered with the browser. */
+	readonly tools: WebMcpTool[];
+	/** Unregister everything. Idempotent. */
+	dispose: () => void;
+};
+
+function readModelContext(): ModelContext | null {
+	if (typeof document === "undefined" && typeof navigator === "undefined") {
+		return null;
+	}
+	// The getter moved from Navigator to Document (webmcp#173). Probe both.
+	const candidate =
+		(typeof document !== "undefined"
+			? (document as unknown as { modelContext?: unknown }).modelContext
+			: undefined) ??
+		(typeof navigator !== "undefined"
+			? (navigator as unknown as { modelContext?: unknown }).modelContext
+			: undefined);
+
+	if (
+		candidate &&
+		typeof (candidate as ModelContext).registerTool === "function"
+	) {
+		return candidate as ModelContext;
+	}
+	return null;
+}
+
+/** Whether this browser can host site tools at all. Almost every visit: no. */
+export function supportsWebMcp(): boolean {
+	return readModelContext() !== null;
+}
+
+function pageContext(): WebMcpPageContext {
+	return { url: location.href, title: document.title };
+}
+
+/**
+ * Register the server's tools with the browsing agent.
+ *
+ * Resolves once registration has been attempted for every advertised tool. A
+ * tool the browser refuses is logged and skipped rather than failing the rest,
+ * because a partial tool list is a working page and an exception here is a
+ * blank one.
+ *
+ * Returns `null` when the browser has no `modelContext`, which is the common
+ * case and not an error.
+ */
+export async function createWebMcpBridge(
+	options: WebMcpBridgeOptions,
+): Promise<WebMcpBridge | null> {
+	const { endpoint, headers, sessionId, visitorId, channelId, onWidget } =
+		options;
+	const log = options.logger ?? console;
+
+	const mc = readModelContext();
+	if (!mc) {
+		return null;
+	}
+
+	// Unregistration is aborting this, not a method call.
+	const controller = new AbortController();
+	const onPageHide = () => controller.abort();
+	window.addEventListener("pagehide", onPageHide);
+
+	let disposed = false;
+	const dispose = () => {
+		if (disposed) {
+			return;
+		}
+		disposed = true;
+		window.removeEventListener("pagehide", onPageHide);
+		controller.abort();
+	};
+
+	/**
+	 * Identity and place, attached to every request rather than left to each
+	 * call site. Read per call, because a single-page app navigates without
+	 * re-registering and `page` would otherwise name whichever URL happened to
+	 * be open when the tools were published.
+	 */
+	function identity() {
+		return { sessionId, visitorId, channelId, page: pageContext() };
+	}
+
+	async function post<T>(
+		request: WebMcpRequest,
+		signal?: AbortSignal,
+	): Promise<T> {
+		const response = await fetch(endpoint, {
+			method: "POST",
+			headers: { "content-type": "application/json", ...headers },
+			body: JSON.stringify(request),
+			...(signal ? { signal } : {}),
+		});
+		if (!response.ok) {
+			throw new Error(`webmcp ${request.action} failed: ${response.status}`);
+		}
+		return (await response.json()) as T;
+	}
+
+	let tools: WebMcpTool[] = [];
+	try {
+		const listed = await post<WebMcpListResponse>({
+			...identity(),
+			action: "list",
+		});
+		tools = listed?.tools ?? [];
+	} catch (error) {
+		log.error("[webmcp] could not list site tools", error);
+		dispose();
+		return null;
+	}
+
+	const registered: WebMcpTool[] = [];
+	await Promise.all(
+		tools.map(async (tool) => {
+			try {
+				await mc.registerTool(
+					{
+						name: tool.name,
+						description: tool.description ?? "",
+						...(tool.inputSchema ? { inputSchema: tool.inputSchema } : {}),
+						...(tool.annotations ? { annotations: tool.annotations } : {}),
+						execute: async (args, execOptions) => {
+							// The agent's abort travels all the way to the tool, so a
+							// visitor who navigates away mid-flow cancels the work
+							// upstream instead of leaving it running.
+							const result = await post<WebMcpCallResponse>(
+								{
+									...identity(),
+									action: "call",
+									name: tool.name,
+									arguments: args ?? {},
+								},
+								execOptions?.signal,
+							);
+							// A widget step arrives already resolved: the page mounts the
+							// view, the agent is told in words that it is on screen.
+							// Handed to a callback rather than rendered here so the host
+							// owns presentation, and a host with none still works.
+							if (result?.widget) {
+								onWidget?.(result.widget);
+							}
+							return { content: result?.content ?? [] };
+						},
+					},
+					{ signal: controller.signal },
+				);
+				registered.push(tool);
+			} catch (error) {
+				log.error(`[webmcp] could not register ${tool.name}`, error);
+			}
+		}),
+	);
+
+	log.info(`[webmcp] registered ${registered.length} site tool(s)`);
+
+	return {
+		get tools() {
+			return registered;
+		},
+		dispose,
+	};
+}

--- a/src/webmcp/index.ts
+++ b/src/webmcp/index.ts
@@ -1,0 +1,26 @@
+/**
+ * WebMCP: the site's own tools, callable by a browsing agent standing on the
+ * page.
+ *
+ * A third surface alongside the connector and the chat bubble, running the same
+ * flows against the same server. The pieces split by who can see the browser:
+ * the bridge and the widget payload are the page's, and the resolution below is
+ * the server's, imported by whatever mounts the HTTP endpoints.
+ *
+ * OSS tier. Nothing here needs an API key.
+ */
+
+export type {
+	WebMcpCallResponse,
+	WebMcpCallResult,
+	WebMcpContentBlock,
+	WebMcpListResponse,
+	WebMcpPageContext,
+	WebMcpRequest,
+	WebMcpTool,
+	WebMcpWidgetPayload,
+} from "./@types";
+export type { WebMcpBridge, WebMcpBridgeOptions } from "./bridge";
+export { createWebMcpBridge, supportsWebMcp } from "./bridge";
+export type { WidgetStep, WidgetStepStatus } from "./widget-step";
+export { readWidgetStep, rewriteForAgent } from "./widget-step";

--- a/src/webmcp/widget-step.ts
+++ b/src/webmcp/widget-step.ts
@@ -1,0 +1,122 @@
+/**
+ * Widget steps on the WebMCP surface.
+ *
+ * In a chat host a flow's widget step is a two-call dance: the flow answers
+ * `status: "widget"` naming a display tool, the model calls that tool, and the
+ * host renders the `ui://` template it points at. None of that survives the
+ * trip to a browsing agent. There is no widget host in the agent's window, the
+ * display tool is not advertised on this surface, and the round trip would cost
+ * a turn for a render nobody performs.
+ *
+ * So the step is resolved before the agent ever sees it. The server calls the
+ * display tool, finds its view, and hands the page everything it needs to mount
+ * the widget itself. The agent gets prose that never names a display tool. The
+ * visitor gets the calendar on the page they are already looking at.
+ */
+
+import type { FlowWidgetContent } from "../mcp/server/flows/@types";
+import type { WebMcpCallResult } from "./@types";
+
+export type WidgetStep = {
+	/**
+	 * The flow's own response, carried whole.
+	 *
+	 * Typed as the engine's own `FlowWidgetContent` rather than a local shape, so
+	 * a field added to a widget step reaches this file as a type change instead
+	 * of being silently dropped. That has already happened once: `intro` was
+	 * added to the payload and the surface that hand-rolled this parse kept
+	 * working only because it spread the rest through.
+	 */
+	payload: FlowWidgetContent;
+	tool: string;
+	data: Record<string, unknown>;
+	interactive: boolean;
+};
+
+/**
+ * A flow's widget step, or `null` for every other tool result.
+ *
+ * Flow tools answer with a single JSON text block, so anything that does not
+ * parse as JSON with `status: "widget"` and a `tool` to call belongs to someone
+ * else and passes through untouched. That includes ordinary tools, which is
+ * most of them.
+ */
+export function readWidgetStep(result: WebMcpCallResult): WidgetStep | null {
+	const first = result.content?.[0];
+	if (!first || first.type !== "text" || typeof first.text !== "string") {
+		return null;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(first.text);
+	} catch {
+		return null;
+	}
+
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return null;
+	}
+
+	const payload = parsed as Record<string, unknown>;
+	if (payload.status !== "widget" || typeof payload.tool !== "string") {
+		return null;
+	}
+
+	const data =
+		payload.data &&
+		typeof payload.data === "object" &&
+		!Array.isArray(payload.data)
+			? (payload.data as Record<string, unknown>)
+			: {};
+
+	return {
+		payload: payload as FlowWidgetContent,
+		tool: payload.tool,
+		data,
+		// The protocol treats an unset `interactive` as display-only, and so does
+		// this. Telling the agent to wait for an interaction that never comes
+		// strands the conversation; continuing early only costs a turn.
+		interactive: payload.interactive === true,
+	};
+}
+
+const WAIT_INSTRUCTIONS =
+	'The interface for this step is now open in front of the user, on the page. There is no display tool to call on this surface, so do not try. Say one short sentence about what is on screen, then stop and wait for the user to tell you what they did. When they do, call this flow again with action "continue".';
+
+const SHOWN_INSTRUCTIONS =
+	'The interface for this step is now open in front of the user, on the page. There is no display tool to call on this surface, so do not try. Summarise `data` in one short sentence, then call this flow again with action "continue".';
+
+const UNAVAILABLE_INSTRUCTIONS =
+	"The interface for this step could not be opened on the page. Carry the step in words instead: tell the user everything in `data` yourself, then proceed as you otherwise would.";
+
+/** The status a rewritten widget step reports in place of `"widget"`. */
+export type WidgetStepStatus = "widget_shown" | "widget_unavailable";
+
+/**
+ * The step as the agent should read it.
+ *
+ * Built by editing the flow's own payload rather than composing a new object,
+ * so the fields the protocol requires the agent to echo back survive. Dropping
+ * `sessionId` here breaks the flow several turns later, which is the worst kind
+ * of bug to go looking for.
+ *
+ * `tool` and `description` are the two that must not survive. Both name a
+ * display tool the agent cannot call, and leaving either in place is an
+ * instruction to attempt it.
+ */
+export function rewriteForAgent(
+	step: WidgetStep,
+	rendered: boolean,
+): Record<string, unknown> & { status: WidgetStepStatus } {
+	const { tool: _tool, description: _description, ...rest } = step.payload;
+	return {
+		...rest,
+		status: rendered ? "widget_shown" : "widget_unavailable",
+		instructions: rendered
+			? step.interactive
+				? WAIT_INSTRUCTIONS
+				: SHOWN_INSTRUCTIONS
+			: UNAVAILABLE_INSTRUCTIONS,
+	};
+}


### PR DESCRIPTION
Adds a third surface for the same flows, alongside the connector and the chat bubble.

A browsing agent standing on a customer's page registers the site's MCP tools through `document.modelContext`, calls them, and a flow's widget step renders in a modal on the page the visitor is already looking at. Same flows, same widgets, same tracking as the other two surfaces.

## The customer adds nothing

The chat embed already carries the token, the visitor id and a widget host, so this rides on the tag they have:

```html
<script src="https://app.waniwani.ai/embed.js" data-token="wwp_..." defer></script>
```

Both endpoints are derived from that token the way `/config` and `/resource` already derive theirs, so no MCP origin appears on the page and there is nothing new to configure. `data-webmcp="off"` is the only new attribute, and it exists to decline the surface on a page that should stay quiet.

On a browser with no `modelContext`, which is every visit but the ones this exists for, the cost is one property read and no network.

## New public API

`@waniwani/sdk/mcp`, OSS tier, no API key:

| export | does |
|---|---|
| `readWidgetStep` / `rewriteForAgent` | resolve a flow's widget step before the agent sees it |
| `createWebMcpBridge` | register the tools, forward the agent's abort into each call |
| `viewUriFor` / `isDisplayTool` | read a tool's view binding off `_meta` |

The widget-step pair is the interesting one. A browsing agent has no widget host in its window, so the display tool a flow tells it to call cannot render anything and would burn a turn on a render nobody performs. The server calls that tool itself and hands the agent prose instead. `readWidgetStep` is typed against the engine's own `FlowWidgetContent`, so a field added to a widget step shows up here as a type error rather than being silently dropped, which has already happened once: `intro` landed in 0.20.1 and the surface that hand-rolled this parse kept working only by accident.

## Two identities, not one

A tab-scoped session id keys the flow engine's state. A persistent one would resume a flow abandoned last week in the middle of the question it was abandoned on. The persistent visitor id rides alongside, so a flow started here and a conversation continued in the bubble belong to one person. `channelId` travels too, because ingest drops what it cannot attribute and without it a conversion is invisible.

## What this touches that already ships

Most of the diff is new files. Four existing ones are worth a reviewer's eye:

- **`embed.ts`** moves the `EMBED_CSS` placeholder into `embed-css.ts` so the overlay's own shadow root can inject the same stylesheet. If this broke, every customer's chat would render unstyled. It doesn't: the built bundle contains real CSS and zero unreplaced placeholders. While moving it I also removed a hazard I'd introduced, where two identical placeholder literals meant the post-build step's first-occurrence replace was a coin flip. There is one literal now and a prefix check.
- **`visitor-context.ts`** moves the visitor-id functions to `shared/visitor-id.ts` and re-exports them, so the bridge reads the same storage key. `waniwani-visitor-id` is byte-identical and its eight importers are untouched. A drift here would have broken analytics continuity silently.
- **`tool.tsx`** now calls the shared `resourceUriFromMeta` instead of a local copy. Behaviour is identical.
- **`remote-config.ts`** gains one optional field, the channel's WebMCP switch.

**`McpAppFrame` is deliberately not in that list.** I had four changes to it and backed all of them out. Three were tidiness, and the fourth was a size-reporter fix carried over from a bug observed under a different host implementation (`@modelcontextprotocol/ext-apps`' `AppBridge`), never reproduced in `McpAppFrame` itself. None of that justified touching a component every customer's chat renders. The overlay uses it exactly as the chat does, with a comment recording the three trade-offs and why each can wait for evidence.

## Verifying

```
bun run build && bun test
```

New coverage: 13 tests on endpoint resolution, 16 on the bridge, 13 on widget steps, 13 on `_meta` view-binding. The two `useChatEngine – thread history` failures predate this branch and are on `main`.

To drive it in a browser you need the app's `POST /api/mcp/chat/webmcp` route, which is not merged yet. I have a local harness that stands in for it and resolves widget payloads against a deployed MCP server, so the modal, the MCP Apps handshake and the sizing can all be exercised end to end. Happy to land it under `scripts/` if that's useful to others.

## Not in this PR

- The app-side `POST /api/mcp/chat/webmcp` route. Blocked on this releasing, since it imports the exports above.
- The channel kill switch does nothing until the app serves a `webmcp` block on `/config`. The embed already reads it and ignores its absence, so that ships server-side with no SDK release. **Worth deciding before this goes out:** with no block served, any environment whose embed is live starts publishing tools to browsing agents on the next release.
- Nothing in `@waniwani/kit`. Everything WebMCP asks of an MCP server, the chat already asks and kit-built servers already answer.
- Flow annotations. `createFlow` already accepts them and passes them through; they are per-app config, not an SDK or kit gap.

Additive throughout, so no migration skill and no breaking-change entry.
