### PR TITLE
docs(kb): ingest lands in the agent's draft and replaces only the sources it names (WAN-1028)

### DIFF
--- a/.claude/skills/knowledge-base/SKILL.md
+++ b/.claude/skills/knowledge-base/SKILL.md
@@ -65,7 +65,7 @@ const files = await Promise.all(
 const client = waniwani();
 
 console.log("Ingesting files into knowledge base...");
-console.log("⚠️  This will replace all existing KB chunks for this environment.");
+console.log("Files land in the agent's draft. Publish it in the WaniWani app to make them live.");
 
 const result = await client.kb.ingest(files);
 console.log(`Done: ${result.chunksIngested} chunks from ${result.filesProcessed} files`);
@@ -177,4 +177,4 @@ Tell the user:
 - Run `bun run kb:ingest` after adding or updating .md files
 - `WANIWANI_API_KEY` must be set in the environment
 - Markdown files should use `# Title` (H1) and `## Section` (H2) structure
-- Ingestion is destructive — it replaces all existing chunks for the environment
+- A push replaces only the sources it names and lands in the agent's draft. Publish in the app to make it live.

--- a/src/kb/types.ts
+++ b/src/kb/types.ts
@@ -55,10 +55,12 @@ export interface KbSource {
 /** KB client for server-side knowledge base operations */
 export interface KbClient {
 	/**
-	 * Ingest files into the knowledge base.
+	 * Push markdown files into the agent's knowledge base.
 	 *
-	 * **Warning**: This is destructive — it deletes ALL existing chunks
-	 * for the environment before ingesting the new files.
+	 * The push replaces only the sources named in the payload and lands in the
+	 * agent's draft. Nothing goes live until someone publishes the draft in the
+	 * WaniWani app. A production key reads live knowledge; any other key reads
+	 * the draft while one is open.
 	 */
 	ingest(files: KbIngestFile[]): Promise<KbIngestResult>;
 


### PR DESCRIPTION
Closes WAN-1028

## Summary

The `ingest()` JSDoc and the knowledge-base skill said a push was destructive and wiped every chunk of the environment. Since app PR #1128 (WAN-1023) a push replaces only the sources it names, lands in the agent's draft, and nothing goes live until someone publishes in the app. A production key reads live knowledge; any other key reads the draft while one is open.

No API change, no version bump: the public shape is the same, only its documented behaviour.

Left for other repos: the workspace `CLAUDE.md` sentence, the `managed/lassie` and `managed/sidecare-mcp` embed scripts, and the `sdk/knowledge-base/overview.mdx` docs page.

## How to see it working

Hover `client.kb.ingest` in an editor, or read the ingest script the `knowledge-base` skill generates: both now say where a push lands and what makes it live.